### PR TITLE
Prepare deployment: Cloud Run Dockerfile, hosting rewrite, locked DB rules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Version control / CI
+.git
+.github
+
+# Dependencies and build output (rebuilt inside the image)
+node_modules
+**/node_modules
+**/dist
+
+# Env files - never bake secrets into the image
+.env
+.env.*
+!.env.example
+!**/.env.example
+
+# apps/web is not needed to build or run the API image; workspace installs
+# only need its package.json (copied explicitly in the Dockerfile), not its
+# sources.
+apps/web/src
+apps/web/public
+apps/web/index.html
+apps/web/dist
+
+# Editor/OS cruft
+.DS_Store
+*.log
+.vscode
+.idea
+
+# Docs (not needed at build/runtime)
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+
+# Builds and runs apps/api (Fastify) for Cloud Run.
+#
+# Workspace-aware multi-stage build:
+#   1. `deps`    - installs the full pnpm workspace (needs every member's
+#                  package.json to resolve the lockfile, even though only
+#                  apps/api and packages/shared are built/run afterward).
+#   2. `build`   - builds packages/shared, then apps/api, then uses
+#                  `pnpm deploy` to assemble a self-contained, production-only
+#                  copy of apps/api (with packages/shared's built dist/
+#                  resolved alongside it, no devDependencies, no apps/web).
+#   3. `runtime` - slim image containing only that deployed output.
+FROM node:24-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
+WORKDIR /repo
+
+# ---------------------------------------------------------------------------
+FROM base AS deps
+
+# Manifests only, so this layer is cached unless dependencies change.
+# pnpm needs every workspace member's package.json to resolve the lockfile,
+# even though the runtime image only needs apps/api + packages/shared.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+
+RUN pnpm install --frozen-lockfile
+
+# ---------------------------------------------------------------------------
+FROM base AS build
+
+COPY --from=deps /repo /repo
+COPY packages/shared ./packages/shared
+COPY apps/api ./apps/api
+
+RUN pnpm --filter @smash-tracker/shared build \
+  && pnpm --filter @smash-tracker/api build
+
+# Assemble a self-contained, production-only copy of apps/api (workspace
+# dependency on packages/shared included, devDependencies excluded, apps/web
+# excluded). `--legacy` avoids requiring `inject-workspace-packages=true`.
+RUN pnpm --filter @smash-tracker/api deploy --prod --legacy /repo/deploy
+
+# ---------------------------------------------------------------------------
+FROM node:24-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=build /repo/deploy/dist ./dist
+COPY --from=build /repo/deploy/node_modules ./node_modules
+COPY --from=build /repo/deploy/package.json ./package.json
+
+# Cloud Run injects PORT at runtime; the app defaults to 3001 for local use.
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Smash Tracker
 
-Live demo: https://smash-tracker-f97b7.web.app/ _(placeholder — repoint after Phase 6 deploy)_
+Live demo: https://smash-tracker-f97b7.web.app/
 
 Smash Tracker is a match-tracking app for **Super Smash Bros. Ultimate**. Sign in, pick a
 primary/secondary fighter, log wins and losses (opponent, stage, match type, notes) after each
@@ -192,14 +192,61 @@ pnpm test
 
 ### Deployment
 
-- **Web**: static build output (`apps/web/dist`) deploys to Firebase Hosting —
-  `firebase deploy --only hosting` after `pnpm --filter @smash-tracker/web build`. `firebase.json`
-  already points `hosting.public` at `apps/web/dist`.
-- **API**: `apps/api` needs a persistent Node host (it's a long-running Fastify server, not a
-  Cloud Function) — e.g. Cloud Run, Fly.io, or Render. This is **documented but intentionally not
-  implemented in this phase**; `apps/api` builds to `dist/` (`pnpm --filter @smash-tracker/api build`)
-  and runs with `pnpm --filter @smash-tracker/api start`, so containerizing it is the remaining
-  step.
+Production serves the web app from Firebase Hosting and the API from Cloud Run, same-origin —
+Hosting rewrites `/api/**` to the Cloud Run service, so the SPA never makes cross-origin requests
+and the API's CORS config is just a belt-and-braces fallback.
+
+**1. Deploy the API to Cloud Run**
+
+The root `Dockerfile` builds `apps/api` (and its `packages/shared` dependency) into a slim
+production image and runs `node dist/index.js`, listening on `process.env.PORT` (Cloud Run injects
+this) with `HOST=0.0.0.0`. It authenticates via Application Default Credentials — no
+`GOOGLE_APPLICATION_CREDENTIALS` needed in production; Cloud Run's runtime service account
+provides ADC automatically, and that service account needs Realtime Database access.
+
+```sh
+gcloud run deploy smash-tracker-api \
+  --source . \
+  --region us-central1 \
+  --set-env-vars FIREBASE_DATABASE_URL=https://smash-tracker-f97b7-default-rtdb.firebaseio.com
+```
+
+The service name (`smash-tracker-api`) and region (`us-central1`) must match `firebase.json`'s
+`hosting.rewrites` entry for `/api/**`.
+
+**2. Configure `apps/web/.env.production`**
+
+```sh
+# From `firebase apps:sdkconfig web`
+VITE_FIREBASE_API_KEY=...
+VITE_FIREBASE_AUTH_DOMAIN=...
+VITE_FIREBASE_PROJECT_ID=...
+VITE_FIREBASE_APP_ID=...
+
+# Empty — same-origin in production, requests go to /api/** on this origin
+VITE_API_BASE_URL=
+```
+
+**3. Build and deploy the web app to Firebase Hosting**
+
+```sh
+pnpm --filter @smash-tracker/web build
+firebase deploy --only hosting
+```
+
+`firebase.json` points `hosting.public` at `apps/web/dist` and rewrites `/api/**` to the
+`smash-tracker-api` Cloud Run service before falling back to `/index.html` for client-side routing.
+
+**4. Lock down the Realtime Database rules**
+
+`database.rules.json` denies all direct client read/write access (`{"rules": {".read": false,
+".write": false}}`) — only `apps/api`'s firebase-admin SDK talks to the database, and the Admin SDK
+bypasses these rules entirely. Deploy this **after** the hosting cutover above is live and verified,
+so the legacy client-only app (if still pointed at the same database) isn't cut off mid-migration:
+
+```sh
+firebase deploy --only database
+```
 
 ### Data model
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,6 +2,8 @@
 NODE_ENV=development
 
 # Port/host the Fastify server listens on. Defaults shown.
+# On Cloud Run, the platform injects PORT at runtime — do not hardcode it in
+# production; the default/fallback here is only for local development.
 PORT=3001
 HOST=0.0.0.0
 
@@ -12,8 +14,11 @@ FIREBASE_DATABASE_URL=https://your-project-default-rtdb.firebaseio.com
 # --- Credentials (choose ONE of the following for real usage) ---
 
 # Path to a service account JSON key file. Picked up automatically by
-# firebase-admin's applicationDefault() credential. Required for talking to
-# a real Firebase project; not needed when using the RTDB emulator.
+# firebase-admin's applicationDefault() credential. Useful for local
+# development against a real Firebase project. Not needed when using the
+# RTDB emulator, and not needed on Cloud Run — there, applicationDefault()
+# automatically uses the Cloud Run service's runtime service account via the
+# metadata server, so leave this unset in production.
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # --- Local development / emulator ---
@@ -25,5 +30,9 @@ FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000
 
 # --- CORS ---
 
-# Origin allowed to call this API. Defaults to the Vite dev server origin.
-CORS_ORIGIN=http://localhost:5173
+# Comma-separated list of origins allowed to call this API. Defaults to the
+# Vite dev server origin. Production traffic to the deployed API is
+# same-origin (via the Firebase Hosting rewrite of /api/** to Cloud Run), so
+# this mainly matters for local dev; the Firebase Hosting domains are listed
+# here as a belt-and-braces fallback in case the API is ever called directly.
+CORS_ORIGIN=http://localhost:5173,https://smash-tracker-f97b7.web.app,https://smash-tracker-f97b7.firebaseapp.com

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,7 +18,8 @@ import type { FirebaseServices } from './firebase/admin.js';
 
 export interface BuildAppOptions {
   firebase: FirebaseServices;
-  corsOrigin?: string;
+  /** One origin, or multiple (e.g. parsed from a comma-separated env var). */
+  corsOrigin?: string | string[];
   logger?: boolean | FastifyBaseLogger;
 }
 

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { loadEnv } from './env.js';
+import { loadEnv, parseCorsOrigins } from './env.js';
 
 const base = {
   FIREBASE_DATABASE_URL: 'https://example-default-rtdb.firebaseio.com',
@@ -30,5 +30,31 @@ describe('loadEnv', () => {
       FIREBASE_DATABASE_EMULATOR_HOST: '127.0.0.1:9000',
     });
     expect(env.FIREBASE_DATABASE_EMULATOR_HOST).toBe('127.0.0.1:9000');
+  });
+
+  it('does not require GOOGLE_APPLICATION_CREDENTIALS (Cloud Run uses ADC)', () => {
+    const env = loadEnv(base);
+    expect(env.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined();
+  });
+});
+
+describe('parseCorsOrigins', () => {
+  it('splits a comma-separated list into trimmed origins', () => {
+    expect(
+      parseCorsOrigins(
+        'https://smash-tracker-f97b7.web.app, https://smash-tracker-f97b7.firebaseapp.com',
+      ),
+    ).toEqual([
+      'https://smash-tracker-f97b7.web.app',
+      'https://smash-tracker-f97b7.firebaseapp.com',
+    ]);
+  });
+
+  it('returns a single-element array for a single origin', () => {
+    expect(parseCorsOrigins('http://localhost:5173')).toEqual(['http://localhost:5173']);
+  });
+
+  it('drops empty entries', () => {
+    expect(parseCorsOrigins('http://localhost:5173,,')).toEqual(['http://localhost:5173']);
   });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -8,11 +8,17 @@ import { z } from 'zod';
  * - `FIREBASE_DATABASE_URL` is always required — it tells the Admin SDK
  *   which Realtime Database instance to talk to (works for both the real
  *   database and the RTDB emulator).
- * - Credentials come from `GOOGLE_APPLICATION_CREDENTIALS` (a path to a
- *   service account JSON file), which `applicationDefault()` reads
- *   automatically. It is not required here because local/emulator use is
- *   supported via `FIREBASE_DATABASE_EMULATOR_HOST`, which lets the Admin
- *   SDK connect without real credentials.
+ * - Credentials come from Application Default Credentials, which
+ *   `applicationDefault()` resolves automatically: a service account JSON
+ *   file when `GOOGLE_APPLICATION_CREDENTIALS` points at one (typical for
+ *   local development), or the runtime service account's metadata-server
+ *   credentials when running on Cloud Run/GCE/GKE (no env var needed there).
+ *   `GOOGLE_APPLICATION_CREDENTIALS` is therefore never required here — it's
+ *   also unnecessary for local/emulator use, which is supported via
+ *   `FIREBASE_DATABASE_EMULATOR_HOST` and needs no real credentials at all.
+ * - `PORT` defaults to 3001 but is read from `process.env.PORT` in
+ *   production — Cloud Run injects `PORT` at runtime and the server must
+ *   listen on it.
  */
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
@@ -21,6 +27,10 @@ const envSchema = z.object({
   FIREBASE_DATABASE_URL: z.string().min(1, 'FIREBASE_DATABASE_URL is required'),
   FIREBASE_DATABASE_EMULATOR_HOST: z.string().optional(),
   GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
+  // Comma-separated list of allowed origins, e.g.
+  // "https://smash-tracker-f97b7.web.app,https://smash-tracker-f97b7.firebaseapp.com".
+  // Production traffic is same-origin via the Firebase Hosting rewrite, so
+  // this mainly matters for local dev and as a belt-and-braces fallback.
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
 });
 
@@ -37,4 +47,12 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): Env {
   }
 
   return result.data;
+}
+
+/** Splits `CORS_ORIGIN` on commas into a trimmed list of allowed origins. */
+export function parseCorsOrigins(corsOrigin: string): string[] {
+  return corsOrigin
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import { buildApp } from './app.js';
-import { loadEnv } from './config/env.js';
+import { loadEnv, parseCorsOrigins } from './config/env.js';
 import { initFirebase } from './firebase/admin.js';
 
 let env;
@@ -14,7 +14,7 @@ const firebase = initFirebase(env);
 
 const app = buildApp({
   firebase,
-  corsOrigin: env.CORS_ORIGIN,
+  corsOrigin: parseCorsOrigins(env.CORS_ORIGIN),
 });
 
 app

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,5 +7,13 @@ VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
 
-# Base URL of the Fastify API (apps/api). Defaults to the local dev server.
+# Base URL of the Fastify API (apps/api). Defaults to the local dev server
+# when unset.
+#
+# In production, the SPA is served from the same origin as the API (Firebase
+# Hosting rewrites /api/** to the Cloud Run service — see firebase.json), so
+# apps/web/.env.production should set this to an EMPTY string so requests
+# stay relative (e.g. `/api/matches` instead of an absolute cross-origin
+# URL):
+#   VITE_API_BASE_URL=
 VITE_API_BASE_URL=http://localhost:3001

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getApiBaseUrl } from './api';
+
+describe('getApiBaseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('falls back to the local dev API when VITE_API_BASE_URL is unset', () => {
+    vi.stubEnv('VITE_API_BASE_URL', undefined);
+    expect(getApiBaseUrl()).toBe('http://localhost:3001');
+  });
+
+  it('returns an empty string for same-origin production (explicit empty value)', () => {
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    expect(getApiBaseUrl()).toBe('');
+  });
+
+  it('strips a trailing slash so joined paths do not double up', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://example.com/');
+    expect(getApiBaseUrl()).toBe('https://example.com');
+  });
+
+  it('returns a configured absolute base URL unchanged (no trailing slash)', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    expect(getApiBaseUrl()).toBe('https://api.example.com');
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -42,8 +42,21 @@ export class ApiSchemaError extends Error {
   }
 }
 
-function getApiBaseUrl(): string {
-  return import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+/**
+ * Base URL prepended to `/api/**` request paths.
+ *
+ * `VITE_API_BASE_URL` is `undefined` when unset (falls back to the local
+ * dev API) but an explicit empty string in production, where the SPA is
+ * served from the same origin as the API (Firebase Hosting rewrites
+ * `/api/**` to Cloud Run) — in that case requests should stay relative
+ * (`""` + `/api/...` = `/api/...`) rather than falling back to localhost.
+ * A trailing slash is stripped so `path` (which always starts with `/`)
+ * doesn't produce a double slash when joined.
+ */
+export function getApiBaseUrl(): string {
+  const configured = import.meta.env.VITE_API_BASE_URL;
+  const base = configured ?? 'http://localhost:3001';
+  return base.replace(/\/+$/, '');
 }
 
 async function getAuthHeader(): Promise<Record<string, string>> {

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,32 +1,6 @@
 {
   "rules": {
-    "primaryFighters": {
-      "$uid": {
-        ".read": "$uid === auth.uid",
-        ".write": "$uid === auth.uid"
-      }
-    },
-    "secondaryFighters": {
-      "$uid": {
-        ".read": "$uid === auth.uid",
-        ".write": "$uid === auth.uid"
-      }
-    },
-    "sprites": {
-      ".read": true,
-      ".write": false
-    },
-    "matches": {
-      "$uid": {
-        ".read": "$uid === auth.uid",
-        ".write": "$uid === auth.uid"
-      }
-    },
-    "opponents": {
-      "$uid": {
-        ".read": "$uid === auth.uid",
-        ".write": "$uid === auth.uid"
-      }
-    }
+    ".read": false,
+    ".write": false
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,13 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
+        "source": "/api/**",
+        "run": {
+          "serviceId": "smash-tracker-api",
+          "region": "us-central1"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
## Summary

Repo-only changes that prepare smash-tracker for deployment (API on Cloud Run, web on Firebase Hosting, same-origin via a hosting rewrite). Nothing in this PR deploys or touches cloud resources — it's the local scaffolding for a deploy to be run separately afterward.

- **API Cloud Run readiness** (`apps/api`): `CORS_ORIGIN` now accepts a comma-separated list (`parseCorsOrigins`) so the Firebase Hosting domains (`smash-tracker-f97b7.web.app`, `.firebaseapp.com`) can be allow-listed as a belt-and-braces fallback, even though production traffic is same-origin. `PORT`/`HOST` already defaulted correctly (`process.env.PORT` with fallback 3001, host `0.0.0.0`) and `firebase-admin` already initialized via `applicationDefault()` without requiring `GOOGLE_APPLICATION_CREDENTIALS` — exactly what Cloud Run's ADC needs — so those were left as-is, just documented/tested more explicitly.
- **Root `Dockerfile` + `.dockerignore`**: multi-stage, workspace-aware build on `node:24-slim` with corepack-activated pnpm pinned to the root `packageManager` version. Builds `packages/shared` then `apps/api`, assembles a production-only copy via `pnpm deploy --prod --legacy`, and runs `node dist/index.js` in a slim final stage. Verified locally: built the image, ran it with fake env (`FIREBASE_DATABASE_URL` + `FIREBASE_DATABASE_EMULATOR_HOST`, no real credentials), confirmed `GET /healthz` → 200 on both the default port and a Cloud-Run-style injected `PORT`, then stopped/removed the container and image.
- **`firebase.json`**: added a `/api/**` rewrite to the `smash-tracker-api` Cloud Run service (`us-central1`), placed before the SPA catch-all rewrite.
- **Same-origin API base URL** (`apps/web/src/lib/api.ts`): `getApiBaseUrl()` now distinguishes an *unset* `VITE_API_BASE_URL` (falls back to the local dev API) from an *explicitly empty* one (stays empty → relative `/api/**` requests), fixing a bug where `||` treated both cases the same and always fell back to `localhost`. Also strips a trailing slash. Added `apps/web/src/lib/api.test.ts`.
- **`database.rules.json`**: locked down to `{"rules": {".read": false, ".write": false}}` — all reads/writes now go through `apps/api`'s `firebase-admin` SDK, which bypasses these rules entirely.
- **README**: replaced the placeholder deployment section with the real procedure (`gcloud run deploy smash-tracker-api --source .`, hosting rewrite, `apps/web/.env.production` values, `firebase deploy --only hosting`, then `firebase deploy --only database`), and dropped the "placeholder" caveat on the live-demo link.

**Note on rules deploy sequencing:** the `database.rules.json` change here deploys nothing by itself. The actual `firebase deploy --only database` should happen in a separate step *after* the new hosting + Cloud Run API are live and verified, so the cutover isn't disrupted mid-migration.

## Test plan

- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 137 tests pass (24 shared + 34 api + 79 web), including new tests for `parseCorsOrigins` and `getApiBaseUrl`
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean
- [x] `docker build` from the root `Dockerfile` succeeds; container boots and `GET /healthz` returns `200 {"status":"ok"}` with fake env vars (no real credentials); verified with both the default port and an injected `PORT` (Cloud Run behavior)
- [ ] (post-merge, separate step) `gcloud run deploy`, `firebase deploy --only hosting`, then `firebase deploy --only database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)