### PR TITLE
Re-land hosting cache headers and OAuth-domain env docs

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,7 +3,13 @@
 # values come from the Firebase console: Project settings > General > Your
 # apps > SDK setup and configuration.
 VITE_FIREBASE_API_KEY=your-api-key
-VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+# Prefer the domain the app is actually served from (e.g.
+# your-project.web.app) over the default your-project.firebaseapp.com: it
+# keeps the OAuth popup handler same-site with the app, which avoids
+# signInWithPopup breakage under modern browsers' third-party storage
+# partitioning. Firebase Hosting serves the /__/auth/* helpers on both
+# domains.
+VITE_FIREBASE_AUTH_DOMAIN=your-project.web.app
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
 

--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,16 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+      }
     ]
   },
   "storage": {


### PR DESCRIPTION
Re-lands commit 4efc859, which was pushed to the deploy branch after PR #73 was merged and therefore never reached master. Production hosting already runs this config (deployed from the working tree); this brings the repo back in sync:

- firebase.json: no-cache on the HTML shell, immutable caching for hashed /assets — prevents browsers serving a stale pre-deploy app for up to an hour
- apps/web/.env.example: documents using the hosting domain (web.app) as authDomain so the OAuth popup handler stays same-site (avoids Firefox storage-partitioning sign-in breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)