### PR TITLE
start.gg web UI: connect, login, and source filters

### DIFF
--- a/apps/web/src/components/SourceFilterTabs.test.ts
+++ b/apps/web/src/components/SourceFilterTabs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@smash-tracker/shared';
+import { filterBySource } from './SourceFilterTabs';
+
+const manual = { id: 'm1', fighter_id: 1, opponent_id: 2, time: 1, win: true } as Match;
+const imported = {
+  id: 'sgg-1-g1',
+  fighter_id: 1,
+  opponent_id: 2,
+  time: 2,
+  win: false,
+  source: 'startgg',
+  externalId: 'sgg:1:g1',
+} as Match;
+
+describe('filterBySource', () => {
+  it('passes everything through for all', () => {
+    expect(filterBySource([manual, imported], 'all')).toHaveLength(2);
+  });
+
+  it('keeps only untagged records for manual', () => {
+    expect(filterBySource([manual, imported], 'manual')).toEqual([manual]);
+  });
+
+  it('keeps only startgg-tagged records for startgg', () => {
+    expect(filterBySource([manual, imported], 'startgg')).toEqual([imported]);
+  });
+});

--- a/apps/web/src/components/SourceFilterTabs.tsx
+++ b/apps/web/src/components/SourceFilterTabs.tsx
@@ -1,0 +1,43 @@
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import type { Match } from '@smash-tracker/shared';
+
+export type MatchSourceFilter = 'all' | 'manual' | 'startgg';
+
+/** Filters matches by origin: manually-entered vs imported from start.gg. */
+export function filterBySource(matches: Match[], filter: MatchSourceFilter): Match[] {
+  if (filter === 'all') {
+    return matches;
+  }
+  if (filter === 'startgg') {
+    return matches.filter((m) => m.source === 'startgg');
+  }
+  return matches.filter((m) => m.source == null);
+}
+
+/** All / Manual / Competitive segmented control shared by data pages. */
+export function SourceFilterTabs({
+  value,
+  onChange,
+}: {
+  value: MatchSourceFilter;
+  onChange: (next: MatchSourceFilter) => void;
+}) {
+  return (
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      size="sm"
+      value={value}
+      onValueChange={(next) => {
+        if (next) {
+          onChange(next as MatchSourceFilter);
+        }
+      }}
+      aria-label="Filter matches by source"
+    >
+      <ToggleGroupItem value="all">All</ToggleGroupItem>
+      <ToggleGroupItem value="manual">Manual</ToggleGroupItem>
+      <ToggleGroupItem value="startgg">Competitive</ToggleGroupItem>
+    </ToggleGroup>
+  );
+}

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import {
   createUserWithEmailAndPassword,
   onAuthStateChanged,
+  signInWithCustomToken,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut as firebaseSignOut,
@@ -16,6 +17,8 @@ export interface AuthContextValue {
   signInWithEmail: (email: string, password: string) => Promise<void>;
   signUpWithEmail: (email: string, password: string) => Promise<void>;
   signInWithGoogle: () => Promise<void>;
+  /** Completes "login with start.gg": the API mints a Firebase custom token and the SPA signs in with it. */
+  signInWithToken: (customToken: string) => Promise<void>;
   signOut: () => Promise<void>;
   getIdToken: () => Promise<string | null>;
 }
@@ -64,6 +67,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
       signInWithGoogle: async () => {
         await signInWithPopup(getFirebaseAuth(), createGoogleAuthProvider());
+        await provisionUser();
+      },
+      signInWithToken: async (customToken) => {
+        await signInWithCustomToken(getFirebaseAuth(), customToken);
         await provisionUser();
       },
       signOut: async () => {

--- a/apps/web/src/hooks/useStartgg.ts
+++ b/apps/web/src/hooks/useStartgg.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useAuth } from '@/hooks/useAuth';
+
+/** Link status for the signed-in user; refetches after link/unlink/sync. */
+export function useStartggStatus() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['startgg', 'status'],
+    queryFn: () => api.startgg.status(),
+    enabled: user != null,
+  });
+}
+
+/** Starts the link flow: asks the API for the authorize URL and navigates to it. */
+export function useStartggConnect() {
+  return useMutation({
+    mutationFn: async () => {
+      const { url } = await api.startgg.authorize();
+      window.location.assign(url);
+    },
+  });
+}
+
+/** Runs a tournament sync; imported matches/opponents invalidate immediately. */
+export function useStartggSync() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.startgg.sync(),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['matches'] }),
+        queryClient.invalidateQueries({ queryKey: ['opponents'] }),
+        queryClient.invalidateQueries({ queryKey: ['startgg', 'status'] }),
+      ]);
+    },
+  });
+}
+
+export function useStartggUnlink() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.startgg.unlink(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['startgg', 'status'] });
+    },
+  });
+}

--- a/apps/web/src/layouts/nav.ts
+++ b/apps/web/src/layouts/nav.ts
@@ -1,5 +1,6 @@
 import {
   LayoutDashboard,
+  Plug,
   User,
   Users,
   UserSearch,
@@ -22,4 +23,5 @@ export const navItems: NavItem[] = [
   { title: 'Fighter Analysis', href: '/fighter-analysis', icon: UserSearch },
   { title: 'Matchups', href: '/matchups', icon: Swords },
   { title: 'Match Data', href: '/match-data', icon: LineChart },
+  { title: 'Integrations', href: '/settings/integrations', icon: Plug },
 ];

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,6 +4,9 @@ import {
   fighterSelectionSchema,
   matchSchema,
   opponentListSchema,
+  startggAuthorizeResponseSchema,
+  startggStatusSchema,
+  startggSyncSummarySchema,
   userProfileSchema,
   type CreateMatchInput,
   type FighterSelectionInput,
@@ -168,6 +171,25 @@ export const api = {
     /** GET /api/opponents */
     list: () => apiRequestParsed('/api/opponents', opponentListSchema),
   },
+  startgg: {
+    /** GET /api/integrations/startgg/status */
+    status: () => apiRequestParsed('/api/integrations/startgg/status', startggStatusSchema),
+    /** GET /api/integrations/startgg/authorize — returns the URL to send the user to. */
+    authorize: () =>
+      apiRequestParsed('/api/integrations/startgg/authorize', startggAuthorizeResponseSchema),
+    /** POST /api/integrations/startgg/sync */
+    sync: () =>
+      apiRequestParsed('/api/integrations/startgg/sync', startggSyncSummarySchema, {
+        method: 'POST',
+      }),
+    /** DELETE /api/integrations/startgg/link */
+    unlink: () => apiRequest<void>('/api/integrations/startgg/link', { method: 'DELETE' }),
+  },
 };
+
+/** Public "login with start.gg" entrypoint — a full-page navigation, not an XHR. */
+export function getStartggLoginUrl(): string {
+  return `${getApiBaseUrl()}/api/auth/startgg/login`;
+}
 
 export type { Match };

--- a/apps/web/src/pages/Home/SignInCard.tsx
+++ b/apps/web/src/pages/Home/SignInCard.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/useAuth';
+import { getStartggLoginUrl } from '@/lib/api';
 import { getAuthErrorMessage } from '@/lib/firebaseErrors';
 
 const credentialsSchema = z.object({
@@ -136,6 +137,15 @@ export function SignInCard() {
               onClick={handleGoogleSignIn}
             >
               Continue with Google
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              disabled={submitting}
+              onClick={() => window.location.assign(getStartggLoginUrl())}
+            >
+              Continue with start.gg
             </Button>
             <button
               type="button"

--- a/apps/web/src/pages/Integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/pages/Integrations/IntegrationsPage.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import { IntegrationsPage } from './IntegrationsPage';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signInWithCustomToken: mock.signInWithCustomToken,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const status = vi.fn();
+const authorize = vi.fn();
+const sync = vi.fn();
+const unlink = vi.fn();
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    users: { upsertMe: (...args: unknown[]) => upsertMe(...args) },
+    startgg: {
+      status: (...args: unknown[]) => status(...args),
+      authorize: (...args: unknown[]) => authorize(...args),
+      sync: (...args: unknown[]) => sync(...args),
+      unlink: (...args: unknown[]) => unlink(...args),
+    },
+  },
+}));
+
+function renderPage(initialEntry = '/settings/integrations') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/settings/integrations" element={<IntegrationsPage />} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('IntegrationsPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    setMockUser(makeMockUser());
+  });
+
+  it('offers to connect when no account is linked', async () => {
+    status.mockResolvedValue({ linked: false });
+
+    renderPage();
+
+    expect(await screen.findByRole('button', { name: 'Connect start.gg account' })).toBeEnabled();
+  });
+
+  it('starts the link flow via the authorize endpoint', async () => {
+    const user = userEvent.setup();
+    status.mockResolvedValue({ linked: false });
+    // jsdom's window.location.assign throws a "not implemented" that the
+    // mutation surfaces as an error state — the assertion below only cares
+    // that the authorize endpoint was hit.
+    authorize.mockResolvedValue({ url: 'https://start.gg/oauth/authorize?x=1' });
+
+    renderPage();
+    await user.click(await screen.findByRole('button', { name: 'Connect start.gg account' }));
+
+    await waitFor(() => expect(authorize).toHaveBeenCalled());
+  });
+
+  it('shows linked status and runs a sync with a summary toast', async () => {
+    const user = userEvent.setup();
+    status.mockResolvedValue({
+      linked: true,
+      gamerTag: 'Pandem1c',
+      playerId: 1802316,
+      slug: 'user/07dc2239',
+      lastSyncAt: 1_700_000_000_000,
+    });
+    sync.mockResolvedValue({
+      sets: 74,
+      imported: 112,
+      setsWithoutGames: 24,
+      gamesUnmappedCharacter: 0,
+      gamesMissingSelections: 0,
+      gamesUnknownStage: 0,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Pandem1c')).toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Sync now/ }));
+    await waitFor(() => expect(sync).toHaveBeenCalled());
+    expect(await screen.findByText(/Imported 112 games from 74 sets/)).toBeInTheDocument();
+  });
+
+  it('unlinks after confirmation', async () => {
+    const user = userEvent.setup();
+    status.mockResolvedValue({ linked: true, gamerTag: 'Pandem1c', playerId: 1, slug: 's' });
+    unlink.mockResolvedValue(undefined);
+
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: /Unlink/ }));
+    await user.click(await screen.findByRole('button', { name: 'Unlink' }));
+    await waitFor(() => expect(unlink).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/pages/Integrations/IntegrationsPage.tsx
+++ b/apps/web/src/pages/Integrations/IntegrationsPage.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import { toast } from 'sonner';
+import { RefreshCw, Unlink } from 'lucide-react';
+import type { StartggSyncSummary } from '@smash-tracker/shared';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import {
+  useStartggConnect,
+  useStartggStatus,
+  useStartggSync,
+  useStartggUnlink,
+} from '@/hooks/useStartgg';
+
+function describeSummary(summary: StartggSyncSummary): string {
+  const skipped =
+    summary.setsWithoutGames + summary.gamesUnmappedCharacter + summary.gamesMissingSelections;
+  const parts = [`Imported ${summary.imported} games from ${summary.sets} sets`];
+  if (skipped > 0) {
+    parts.push(`${skipped} without importable detail`);
+  }
+  if (summary.gamesUnknownStage > 0) {
+    parts.push(`${summary.gamesUnknownStage} with unrecognized stages`);
+  }
+  return parts.join(' · ');
+}
+
+/** Settings > Integrations: link a start.gg account and sync tournament matches. */
+export function IntegrationsPage() {
+  const { data: status, isLoading } = useStartggStatus();
+  const connect = useStartggConnect();
+  const sync = useStartggSync();
+  const unlink = useStartggUnlink();
+  const [confirmUnlink, setConfirmUnlink] = useState(false);
+  const [lastSummary, setLastSummary] = useState<StartggSyncSummary | null>(null);
+
+  // Surface the OAuth callback outcome (the API redirects back with a query param).
+  const [searchParams, setSearchParams] = useSearchParams();
+  const announcedCallback = useRef(false);
+  useEffect(() => {
+    const outcome = searchParams.get('startgg');
+    if (!outcome || announcedCallback.current) {
+      return;
+    }
+    announcedCallback.current = true;
+    if (outcome === 'linked') {
+      toast.success('start.gg account linked!');
+    } else {
+      toast.error(`start.gg linking failed (${searchParams.get('reason') ?? 'unknown error'})`);
+    }
+    setSearchParams({}, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const handleSync = async () => {
+    try {
+      const summary = await sync.mutateAsync();
+      setLastSummary(summary);
+      toast.success(describeSummary(summary));
+    } catch {
+      toast.error('Sync failed. Please try again.');
+    }
+  };
+
+  const handleUnlink = async () => {
+    setConfirmUnlink(false);
+    try {
+      await unlink.mutateAsync();
+      setLastSummary(null);
+      toast.success('start.gg account unlinked.');
+    } catch {
+      toast.error('Failed to unlink. Please try again.');
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Integrations</h1>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>start.gg</CardTitle>
+            {status?.linked && <Badge variant="secondary">Connected</Badge>}
+          </div>
+          <CardDescription>
+            Link your start.gg account to automatically import your Smash Ultimate tournament
+            matches. Imported games join your match pool with a competitive tag.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Checking link status…</p>
+          ) : status?.linked ? (
+            <>
+              <dl className="grid grid-cols-2 gap-2 text-sm">
+                <dt className="text-muted-foreground">Gamer tag</dt>
+                <dd className="font-medium">{status.gamerTag}</dd>
+                <dt className="text-muted-foreground">Last synced</dt>
+                <dd>
+                  {status.lastSyncAt ? new Date(status.lastSyncAt).toLocaleString() : 'Never'}
+                </dd>
+              </dl>
+              {lastSummary && (
+                <p className="text-sm text-muted-foreground">{describeSummary(lastSummary)}</p>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={handleSync} disabled={sync.isPending}>
+                  <RefreshCw className={sync.isPending ? 'animate-spin' : ''} />
+                  {sync.isPending ? 'Syncing…' : 'Sync now'}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => setConfirmUnlink(true)}
+                  disabled={unlink.isPending}
+                >
+                  <Unlink />
+                  Unlink
+                </Button>
+              </div>
+            </>
+          ) : (
+            <div>
+              <Button onClick={() => connect.mutate()} disabled={connect.isPending}>
+                Connect start.gg account
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={confirmUnlink} onOpenChange={(open) => !open && setConfirmUnlink(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink start.gg?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Already-imported matches stay in your history; new tournament results just stop
+              syncing until you reconnect.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleUnlink}>Unlink</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/pages/MatchData/MatchDataPage.tsx
+++ b/apps/web/src/pages/MatchData/MatchDataPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import type { Fighter } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
@@ -6,14 +6,24 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFighters } from '@/hooks/useFighters';
 import { useMatches } from '@/hooks/useMatches';
 import { getFighterById } from '@/data/sprites';
+import {
+  SourceFilterTabs,
+  filterBySource,
+  type MatchSourceFilter,
+} from '@/components/SourceFilterTabs';
 import { MatchTable } from './components/MatchTable';
 import { FighterPieChart } from './components/FighterPieChart';
 import { StageBreakdown } from './components/StageBreakdown';
 
-/** Ports legacy/src/screens/MatchData. */
+/** Ports legacy/src/screens/MatchData, plus the v2 source filter (manual vs start.gg imports). */
 export function MatchDataPage() {
   const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
-  const { data: matches = [], isLoading: matchesLoading } = useMatches();
+  const { data: allMatches = [], isLoading: matchesLoading } = useMatches();
+  const [sourceFilter, setSourceFilter] = useState<MatchSourceFilter>('all');
+  const matches = useMemo(
+    () => filterBySource(allMatches, sourceFilter),
+    [allMatches, sourceFilter],
+  );
 
   const fighterSprites = useMemo<Fighter[]>(() => {
     const ids = [...(fighterSelection?.primary ?? []), ...(fighterSelection?.secondary ?? [])];
@@ -47,7 +57,7 @@ export function MatchDataPage() {
     );
   }
 
-  if (matches.length === 0) {
+  if (allMatches.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-16 text-center">
         <h2 className="text-xl font-semibold tracking-tight">
@@ -63,8 +73,9 @@ export function MatchDataPage() {
   return (
     <div className="flex flex-col gap-6">
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Match History</CardTitle>
+          <SourceFilterTabs value={sourceFilter} onChange={setSourceFilter} />
         </CardHeader>
         <CardContent>
           <MatchTable matches={matches} fighterSprites={fighterSprites} />

--- a/apps/web/src/pages/StartggAuth/StartggAuthPage.test.tsx
+++ b/apps/web/src/pages/StartggAuth/StartggAuthPage.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import { StartggAuthPage } from './StartggAuthPage';
+import { resetAuthMock, signInWithCustomToken } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signInWithCustomToken: mock.signInWithCustomToken,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+vi.mock('@/lib/api', () => ({
+  api: { users: { upsertMe: (...args: unknown[]) => upsertMe(...args) } },
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/auth/startgg']}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/auth/startgg" element={<StartggAuthPage />} />
+            <Route path="/dashboard" element={<div>Dashboard destination</div>} />
+            <Route path="/" element={<div>Home page</div>} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('StartggAuthPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    window.location.hash = '';
+  });
+
+  it('signs in with the fragment token and navigates to the dashboard', async () => {
+    window.location.hash = '#token=custom-token-abc';
+    signInWithCustomToken.mockResolvedValue({ user: { uid: 'u' } });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Dashboard destination')).toBeInTheDocument());
+    expect(signInWithCustomToken).toHaveBeenCalledWith(expect.anything(), 'custom-token-abc');
+    expect(upsertMe).toHaveBeenCalled();
+  });
+
+  it('shows a failure state when the token is missing', async () => {
+    renderPage();
+    expect(await screen.findByText('start.gg sign-in failed')).toBeInTheDocument();
+    expect(signInWithCustomToken).not.toHaveBeenCalled();
+  });
+
+  it('shows a failure state when sign-in is rejected', async () => {
+    window.location.hash = '#token=expired-token';
+    signInWithCustomToken.mockRejectedValue(new Error('auth/invalid-custom-token'));
+
+    renderPage();
+
+    expect(await screen.findByText('start.gg sign-in failed')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/StartggAuth/StartggAuthPage.tsx
+++ b/apps/web/src/pages/StartggAuth/StartggAuthPage.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * Landing point for "login with start.gg": the API redirects here with a
+ * Firebase custom token in the URL fragment (fragments never reach servers
+ * or logs). Signs in with it and heads to the dashboard.
+ */
+export function StartggAuthPage() {
+  const { signInWithToken } = useAuth();
+  const navigate = useNavigate();
+  // Read the fragment once, at first render — no token means instant failure
+  // state (derived, not set in an effect).
+  const [token] = useState(() => new URLSearchParams(window.location.hash.slice(1)).get('token'));
+  const [failed, setFailed] = useState(token == null);
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (!token || attempted.current) {
+      return;
+    }
+    attempted.current = true;
+
+    // Clear the token from the address bar before doing anything else.
+    window.history.replaceState(null, '', window.location.pathname);
+
+    signInWithToken(token)
+      .then(() => navigate('/dashboard', { replace: true }))
+      .catch(() => setFailed(true));
+  }, [token, signInWithToken, navigate]);
+
+  if (failed) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">start.gg sign-in failed</h1>
+        <p className="max-w-md text-muted-foreground">
+          The sign-in link was missing or expired. Head back home and try again.
+        </p>
+        <Button asChild>
+          <Link to="/">Back to Home</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return <div className="py-16 text-center text-muted-foreground">Signing you in…</div>;
+}

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -6,6 +6,8 @@ import { ChooseSecondaryPage } from '@/pages/CharacterSelect/ChooseSecondaryPage
 import { MatchupsPage } from '@/pages/Matchups/MatchupsPage';
 import { MatchDataPage } from '@/pages/MatchData/MatchDataPage';
 import { FighterAnalysisPage } from '@/pages/FighterAnalysis/FighterAnalysisPage';
+import { IntegrationsPage } from '@/pages/Integrations/IntegrationsPage';
+import { StartggAuthPage } from '@/pages/StartggAuth/StartggAuthPage';
 import { NotFoundPage } from '@/pages/NotFound/NotFoundPage';
 import { ProtectedRoute } from './ProtectedRoute';
 
@@ -68,6 +70,16 @@ export function AppRouter() {
             </ProtectedRoute>
           }
         />
+        <Route
+          path="/settings/integrations"
+          element={
+            <ProtectedRoute>
+              <IntegrationsPage />
+            </ProtectedRoute>
+          }
+        />
+        {/* Public: receives the custom token from the "login with start.gg" flow. */}
+        <Route path="/auth/startgg" element={<StartggAuthPage />} />
         <Route path="/not-found" element={<NotFoundPage />} />
         <Route path="*" element={<Navigate to="/not-found" replace />} />
       </Routes>

--- a/apps/web/src/test/mockAuth.ts
+++ b/apps/web/src/test/mockAuth.ts
@@ -42,6 +42,7 @@ export const onAuthStateChanged = vi.fn(
 export const signInWithEmailAndPassword = vi.fn();
 export const createUserWithEmailAndPassword = vi.fn();
 export const signInWithPopup = vi.fn();
+export const signInWithCustomToken = vi.fn();
 export const signOut = vi.fn();
 export const getAuth = vi.fn(() => mockAuthInstance);
 
@@ -60,6 +61,7 @@ export function resetAuthMock() {
   signInWithEmailAndPassword.mockReset();
   createUserWithEmailAndPassword.mockReset();
   signInWithPopup.mockReset();
+  signInWithCustomToken.mockReset();
   signOut.mockReset();
 }
 


### PR DESCRIPTION
Stacked on #77 (backend) — retargets to master automatically when #77 merges.

The user-facing half of the start.gg integration:

- **Integrations page** (`/settings/integrations`, in the sidebar): connect (redirects through the API's authorize endpoint), linked status (gamer tag, last synced), **Sync now** with a human-readable import summary toast, and unlink behind a confirmation.
- **Login with start.gg**: button on the sign-in card → API OAuth flow → `/auth/startgg` completes `signInWithCustomToken` from the URL fragment (scrubbed from the address bar immediately) and lands on the dashboard; failure states covered.
- **Source filter**: All / Manual / Competitive tabs on Match Data via a shared `SourceFilterTabs` + `filterBySource`. Fighter Analysis/Matchups get the same treatment in a small follow-up after #76 merges (their pages are rewritten there; adding it now would conflict).

Tests: 89 web (10 new) + 67 api + 24 shared, all passing. Lint 0 errors, typecheck clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)