### PR TITLE
V3 Phase B: evidence-aware stats engine + tournament context on imports

### DIFF
--- a/apps/api/src/startgg/client.ts
+++ b/apps/api/src/startgg/client.ts
@@ -88,8 +88,10 @@ const setsPageSchema = z.object({
               completedAt: z.number().int().nullish(),
               event: z
                 .object({
+                  name: z.string().nullish(),
                   isOnline: z.boolean().nullish(),
                   videogame: z.object({ id: z.number() }).nullish(),
+                  tournament: z.object({ name: z.string().nullish() }).nullish(),
                 })
                 .nullish(),
               slots: z
@@ -150,7 +152,7 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
       nodes {
         id
         completedAt
-        event { isOnline videogame { id } }
+        event { name isOnline videogame { id } tournament { name } }
         slots { entrant { id name participants { player { id } } } }
         games {
           winnerId

--- a/apps/api/src/startgg/sync.test.ts
+++ b/apps/api/src/startgg/sync.test.ts
@@ -23,7 +23,12 @@ function makeSet(overrides: Partial<StartggSet> = {}): StartggSet {
   return {
     id: 111,
     completedAt: 1_700_000_000,
-    event: { isOnline: true, videogame: { id: 1386 } },
+    event: {
+      name: 'Ultimate Singles',
+      isOnline: true,
+      videogame: { id: 1386 },
+      tournament: { name: 'Test Weekly 42' },
+    },
     slots: [
       { entrant: { id: 1, name: 'Team | Me', participants: [{ player: { id: PLAYER_ID } }] } },
       { entrant: { id: 2, name: 'PowPow', participants: [{ player: { id: 999 } }] } },
@@ -86,6 +91,8 @@ describe('gamesFromSet', () => {
       win: true,
       source: 'startgg',
       externalId: 'sgg:111:g1',
+      eventName: 'Ultimate Singles',
+      tournamentName: 'Test Weekly 42',
     });
     expect(g1?.record.fighter_id).toBeGreaterThan(0);
     expect(g1?.record.map?.name).toBe('Battlefield');
@@ -151,6 +158,16 @@ describe('gamesFromSet', () => {
     const set = makeSet({ event: { isOnline: false, videogame: { id: 1386 } } });
     const games = gamesFromSet(set, PLAYER_ID, summary);
     expect(games[0]?.record.matchType).toBe('offline-tourney');
+  });
+
+  it('omits event/tournament keys entirely when the API provides none', () => {
+    const summary = emptySummary();
+    const set = makeSet({ event: { isOnline: true, videogame: { id: 1386 } } });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games[0]).toBeDefined();
+    // RTDB rejects undefined values — the keys must be absent, not undefined.
+    expect('eventName' in games[0]!.record).toBe(false);
+    expect('tournamentName' in games[0]!.record).toBe(false);
   });
 });
 

--- a/apps/api/src/startgg/sync.ts
+++ b/apps/api/src/startgg/sync.ts
@@ -61,6 +61,9 @@ export function gamesFromSet(
 
   const opponentTag = normalizeOpponentTag(opponentEntrant.name);
   const matchType = set.event?.isOnline ? 'online-tourney' : 'offline-tourney';
+  // RTDB rejects undefined values — these keys must be OMITTED when absent.
+  const eventName = set.event?.name?.trim();
+  const tournamentName = set.event?.tournament?.name?.trim();
   const results: ImportableGame[] = [];
 
   games.forEach((game, index) => {
@@ -106,6 +109,8 @@ export function gamesFromSet(
         win: game.winnerId === userEntrant.id,
         source: 'startgg',
         externalId,
+        ...(eventName ? { eventName } : {}),
+        ...(tournamentName ? { tournamentName } : {}),
       },
     });
   });

--- a/apps/web/src/lib/stats.ts
+++ b/apps/web/src/lib/stats.ts
@@ -485,3 +485,306 @@ export function getStageUsage(matches: Match[]): Map<number, number> {
   }
   return usage;
 }
+
+// ---------------------------------------------------------------------------
+// V3 stats engine: evidence-aware rankings (docs/analytics-vision.md)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lower bound of the Wilson score interval (default z = 1.96 ≈ 95%): a
+ * pessimistic-but-fair estimate of the true win rate given the sample size.
+ * Ranking by this instead of the raw rate keeps a lucky 1-0 from outranking
+ * a proven 12-3. Returns 0 for an empty sample.
+ */
+export function wilsonLowerBound(wins: number, total: number, z = 1.96): number {
+  if (total === 0) {
+    return 0;
+  }
+  const p = wins / total;
+  const z2 = z * z;
+  const denominator = 1 + z2 / total;
+  const centre = p + z2 / (2 * total);
+  const spread = z * Math.sqrt((p * (1 - p) + z2 / (4 * total)) / total);
+  return Math.max(0, (centre - spread) / denominator);
+}
+
+export interface RankedMatchup extends MatchupStats {
+  /** Wilson lower bound (0-1) for this matchup's win rate. */
+  wilson: number;
+}
+
+/**
+ * Per-opponent-fighter records ranked by Wilson lower bound (best first),
+ * ties broken by sample size. Unlike the legacy-faithful `getMatchupStats`,
+ * this is the v3 evidence-aware ranking; `minMatches` merely hides noise
+ * rows and defaults to 1 because the ranking itself is sample-aware.
+ */
+export function rankMatchupsByEvidence(matches: Match[], minMatches = 1): RankedMatchup[] {
+  const byOpponent = new Map<number, Match[]>();
+  for (const match of matches) {
+    const group = byOpponent.get(match.opponent_id);
+    if (group) {
+      group.push(match);
+    } else {
+      byOpponent.set(match.opponent_id, [match]);
+    }
+  }
+  return [...byOpponent.entries()]
+    .map(([opponentFighterId, ms]) => {
+      const wins = ms.filter((m) => m.win).length;
+      const losses = ms.length - wins;
+      const totalMatches = ms.length;
+      const ratio = losses ? Math.round((wins / totalMatches) * 100) : 100;
+      return {
+        opponentFighterId,
+        wins,
+        losses,
+        totalMatches,
+        ratio,
+        wilson: wilsonLowerBound(wins, totalMatches),
+      };
+    })
+    .filter((entry) => entry.totalMatches >= minMatches)
+    .sort((a, b) =>
+      b.wilson === a.wilson ? b.totalMatches - a.totalMatches : b.wilson - a.wilson,
+    );
+}
+
+export interface RankedStage extends StageRecord {
+  /** Wilson lower bound (0-1) for this stage's win rate. */
+  wilson: number;
+}
+
+/**
+ * Stage records ranked by Wilson lower bound (best first). The unknown-stage
+ * sentinel (id 0) never appears — it isn't an actionable pick.
+ */
+export function rankStagesByEvidence(matches: Match[], minMatches = 1): RankedStage[] {
+  return getStageRecords(matches)
+    .filter((record) => record.stageId !== 0 && record.total >= minMatches)
+    .map((record) => ({ ...record, wilson: wilsonLowerBound(record.wins, record.total) }))
+    .sort((a, b) => (b.wilson === a.wilson ? b.total - a.total : b.wilson - a.wilson));
+}
+
+// ---------------------------------------------------------------------------
+// V3 stats engine: form and time
+// ---------------------------------------------------------------------------
+
+export interface RollingWinRatePoint {
+  /** 1-based match index within the series. */
+  index: number;
+  /** Win rate (0-100) over the trailing `window` matches ending here. */
+  winRate: number;
+  match: Match;
+}
+
+/**
+ * Trailing-window win rate per match, chronologically — the "form curve".
+ * Early points use however many matches exist so the curve starts at match 1.
+ */
+export function getRollingWinRate(matches: Match[], window = 10): RollingWinRatePoint[] {
+  const sorted = [...matches].sort((a, b) => a.time - b.time);
+  return sorted.map((match, i) => {
+    const slice = sorted.slice(Math.max(0, i - window + 1), i + 1);
+    const wins = slice.filter((m) => m.win).length;
+    return { index: i + 1, winRate: (wins / slice.length) * 100, match };
+  });
+}
+
+export interface MonthlyRecord extends WinLossRecord {
+  /** Calendar month key, e.g. '2021-01' (UTC). */
+  month: string;
+}
+
+/** Win/loss record per calendar month (UTC), chronologically ascending. */
+export function getMonthlyRecords(matches: Match[]): MonthlyRecord[] {
+  const byMonth = new Map<string, Match[]>();
+  for (const match of matches) {
+    const d = new Date(match.time);
+    const key = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    const group = byMonth.get(key);
+    if (group) {
+      group.push(match);
+    } else {
+      byMonth.set(key, [match]);
+    }
+  }
+  return [...byMonth.entries()]
+    .map(([month, ms]) => ({ month, ...getWinLossRecord(ms) }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+}
+
+export interface OnlineOfflineSplit {
+  online: WinLossRecord;
+  offline: WinLossRecord;
+  /** Matches whose type doesn't identify a setting ('none', '', missing). */
+  unspecified: WinLossRecord;
+}
+
+/**
+ * Record split by setting. 'quickplay', 'online-friendly', 'online-tourney'
+ * count as online; 'offline-friendly'/'offline-tourney' as offline.
+ */
+export function getOnlineOfflineSplit(matches: Match[]): OnlineOfflineSplit {
+  const online: Match[] = [];
+  const offline: Match[] = [];
+  const unspecified: Match[] = [];
+  for (const match of matches) {
+    const type = match.matchType ?? '';
+    if (type === 'quickplay' || type.startsWith('online')) {
+      online.push(match);
+    } else if (type.startsWith('offline')) {
+      offline.push(match);
+    } else {
+      unspecified.push(match);
+    }
+  }
+  return {
+    online: getWinLossRecord(online),
+    offline: getWinLossRecord(offline),
+    unspecified: getWinLossRecord(unspecified),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// V3 stats engine: sessions
+// ---------------------------------------------------------------------------
+
+export interface SessionStats extends WinLossRecord {
+  /** Epoch ms of the session's first and last match. */
+  start: number;
+  end: number;
+  /** Longest consecutive loss run inside this session (tilt indicator). */
+  longestLossRun: number;
+}
+
+const DEFAULT_SESSION_GAP_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * Groups matches into play sessions: a gap of more than `gapMs` (default 3h)
+ * between consecutive matches starts a new session. Chronological order.
+ */
+export function getSessions(matches: Match[], gapMs = DEFAULT_SESSION_GAP_MS): SessionStats[] {
+  const sorted = [...matches].sort((a, b) => a.time - b.time);
+  const groups: Match[][] = [];
+  for (const match of sorted) {
+    const current = groups[groups.length - 1];
+    const previous = current?.[current.length - 1];
+    if (current && previous && match.time - previous.time <= gapMs) {
+      current.push(match);
+    } else {
+      groups.push([match]);
+    }
+  }
+  return groups.map((group) => {
+    let run = 0;
+    let longestLossRun = 0;
+    for (const match of group) {
+      run = match.win ? 0 : run + 1;
+      longestLossRun = Math.max(longestLossRun, run);
+    }
+    return {
+      start: group[0]!.time,
+      end: group[group.length - 1]!.time,
+      longestLossRun,
+      ...getWinLossRecord(group),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// V3 stats engine: opponent scouting
+// ---------------------------------------------------------------------------
+
+export interface OpponentProfile {
+  /** The lowercased opponent tag. */
+  opponent: string;
+  record: WinLossRecord;
+  firstPlayedAt: number;
+  lastPlayedAt: number;
+  /** Their characters against you, evidence-ranked from YOUR perspective. */
+  byTheirFighter: RankedMatchup[];
+  byStage: StageRecord[];
+  /** Most recent matches first. */
+  recent: Match[];
+}
+
+/** Head-to-head profile vs one human opponent, or null when never played. */
+export function getOpponentProfile(
+  matches: Match[],
+  opponentTag: string,
+  recentLimit = 10,
+): OpponentProfile | null {
+  const versus = matches.filter((m) => m.opponent === opponentTag);
+  if (versus.length === 0) {
+    return null;
+  }
+  const sorted = [...versus].sort((a, b) => a.time - b.time);
+  return {
+    opponent: opponentTag,
+    record: getWinLossRecord(versus),
+    firstPlayedAt: sorted[0]!.time,
+    lastPlayedAt: sorted[sorted.length - 1]!.time,
+    byTheirFighter: rankMatchupsByEvidence(versus),
+    byStage: getStageRecords(versus).sort((a, b) => b.total - a.total),
+    recent: sorted.slice(-recentLimit).reverse(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// V3 stats engine: matchup matrix
+// ---------------------------------------------------------------------------
+
+export interface MatchupMatrixCell extends WinLossRecord {
+  fighterId: number;
+  opponentFighterId: number;
+  /** Wilson lower bound (0-1). */
+  wilson: number;
+}
+
+export interface MatchupMatrix {
+  /** Your fighters, ordered by games played descending. */
+  fighterIds: number[];
+  /** Opponent fighters faced, ordered by games played descending. */
+  opponentFighterIds: number[];
+  /** One cell per (fighter, opponent) pairing that has at least one match. */
+  cells: MatchupMatrixCell[];
+}
+
+/** Your-fighters × opponent-fighters grid for the Matchup Lab heatmap. */
+export function getMatchupMatrix(matches: Match[]): MatchupMatrix {
+  const usage = (keyFn: (m: Match) => number) => {
+    const counts = new Map<number, number>();
+    for (const match of matches) {
+      const key = keyFn(match);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
+  };
+
+  const byPair = new Map<string, Match[]>();
+  for (const match of matches) {
+    const key = `${match.fighter_id}:${match.opponent_id}`;
+    const group = byPair.get(key);
+    if (group) {
+      group.push(match);
+    } else {
+      byPair.set(key, [match]);
+    }
+  }
+
+  return {
+    fighterIds: usage((m) => m.fighter_id),
+    opponentFighterIds: usage((m) => m.opponent_id),
+    cells: [...byPair.entries()].map(([key, ms]) => {
+      const [fighterId, opponentFighterId] = key.split(':').map(Number) as [number, number];
+      const record = getWinLossRecord(ms);
+      return {
+        fighterId,
+        opponentFighterId,
+        ...record,
+        wilson: wilsonLowerBound(record.wins, record.total),
+      };
+    }),
+  };
+}

--- a/apps/web/src/lib/statsV3.test.ts
+++ b/apps/web/src/lib/statsV3.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@smash-tracker/shared';
+import {
+  getMatchupMatrix,
+  getMonthlyRecords,
+  getOnlineOfflineSplit,
+  getOpponentProfile,
+  getRollingWinRate,
+  getSessions,
+  rankMatchupsByEvidence,
+  rankStagesByEvidence,
+  wilsonLowerBound,
+} from './stats';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('wilsonLowerBound', () => {
+  it('is 0 for an empty sample', () => {
+    expect(wilsonLowerBound(0, 0)).toBe(0);
+  });
+
+  it('matches the closed-form value for known inputs', () => {
+    // p=1, n=1, z=1.96: (1 + 1.9208 - 1.96*sqrt(0.9604)/1) / (1 + 3.8416/1)... = 0.2065
+    expect(wilsonLowerBound(1, 1)).toBeCloseTo(0.2065, 3);
+    // p=0.8, n=15: ≈ 0.5481
+    expect(wilsonLowerBound(12, 15)).toBeCloseTo(0.5481, 3);
+    // p=0.5, n=100: ≈ 0.4038
+    expect(wilsonLowerBound(50, 100)).toBeCloseTo(0.4038, 3);
+  });
+
+  it('never lets a small perfect sample outrank a large strong one', () => {
+    expect(wilsonLowerBound(1, 1)).toBeLessThan(wilsonLowerBound(12, 15));
+  });
+
+  it('is monotonic in sample size at a fixed rate', () => {
+    expect(wilsonLowerBound(5, 10)).toBeLessThan(wilsonLowerBound(50, 100));
+  });
+});
+
+describe('rankMatchupsByEvidence', () => {
+  it('ranks a proven record above a lucky 1-0', () => {
+    const matches = [
+      // 1-0 vs opponent 10
+      makeMatch({ id: 'a', time: 1, win: true, opponent_id: 10 }),
+      // 8-2 vs opponent 20
+      ...Array.from({ length: 8 }, (_, i) =>
+        makeMatch({ id: `w${i}`, time: 10 + i, win: true, opponent_id: 20 }),
+      ),
+      ...Array.from({ length: 2 }, (_, i) =>
+        makeMatch({ id: `l${i}`, time: 30 + i, win: false, opponent_id: 20 }),
+      ),
+    ];
+    const ranked = rankMatchupsByEvidence(matches);
+    expect(ranked[0]?.opponentFighterId).toBe(20);
+    expect(ranked[0]?.wilson).toBeGreaterThan(ranked[1]?.wilson ?? 1);
+  });
+
+  it('hides rows below minMatches without affecting ranking math', () => {
+    const matches = [
+      makeMatch({ id: 'a', time: 1, win: true, opponent_id: 10 }),
+      makeMatch({ id: 'b', time: 2, win: true, opponent_id: 20 }),
+      makeMatch({ id: 'c', time: 3, win: false, opponent_id: 20 }),
+    ];
+    expect(rankMatchupsByEvidence(matches, 2)).toHaveLength(1);
+  });
+});
+
+describe('rankStagesByEvidence', () => {
+  it('excludes the unknown-stage sentinel and ranks by wilson', () => {
+    const stage = (id: number, name: string) => ({ id, name });
+    const matches = [
+      makeMatch({ id: 'u', time: 1, win: true }), // stage 0 sentinel
+      makeMatch({ id: 'b1', time: 2, win: true, map: stage(1, 'Battlefield') }),
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeMatch({ id: `s${i}`, time: 10 + i, win: i < 5, map: stage(3, 'Smashville') }),
+      ),
+    ];
+    const ranked = rankStagesByEvidence(matches);
+    expect(ranked.map((r) => r.stageId)).toEqual([3, 1]); // 5-1 beats 1-0
+    expect(ranked.find((r) => r.stageId === 0)).toBeUndefined();
+  });
+});
+
+describe('getRollingWinRate', () => {
+  it('computes trailing-window rates chronologically', () => {
+    // W W L L with window 2 -> 100, 100, 50, 0
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true }),
+      makeMatch({ id: '2', time: 2, win: true }),
+      makeMatch({ id: '3', time: 3, win: false }),
+      makeMatch({ id: '4', time: 4, win: false }),
+    ];
+    const series = getRollingWinRate(matches, 2);
+    expect(series.map((p) => p.winRate)).toEqual([100, 100, 50, 0]);
+  });
+});
+
+describe('getMonthlyRecords', () => {
+  it('groups by UTC calendar month in ascending order', () => {
+    const jan = Date.UTC(2021, 0, 15);
+    const feb = Date.UTC(2021, 1, 2);
+    const records = getMonthlyRecords([
+      makeMatch({ id: 'f', time: feb, win: false }),
+      makeMatch({ id: 'j1', time: jan, win: true }),
+      makeMatch({ id: 'j2', time: jan + 1000, win: true }),
+    ]);
+    expect(records.map((r) => r.month)).toEqual(['2021-01', '2021-02']);
+    expect(records[0]).toMatchObject({ wins: 2, losses: 0 });
+  });
+});
+
+describe('getOnlineOfflineSplit', () => {
+  it('buckets quickplay and online-* as online, offline-* as offline', () => {
+    const split = getOnlineOfflineSplit([
+      makeMatch({ id: '1', time: 1, win: true, matchType: 'quickplay' }),
+      makeMatch({ id: '2', time: 2, win: false, matchType: 'online-tourney' }),
+      makeMatch({ id: '3', time: 3, win: true, matchType: 'offline-friendly' }),
+      makeMatch({ id: '4', time: 4, win: true, matchType: 'none' }),
+      makeMatch({ id: '5', time: 5, win: false, matchType: '' }),
+    ]);
+    expect(split.online).toMatchObject({ wins: 1, losses: 1, total: 2 });
+    expect(split.offline).toMatchObject({ wins: 1, losses: 0, total: 1 });
+    expect(split.unspecified).toMatchObject({ wins: 1, losses: 1, total: 2 });
+  });
+});
+
+describe('getSessions', () => {
+  const HOUR = 60 * 60 * 1000;
+
+  it('splits on gaps beyond the threshold and tracks intra-session tilt', () => {
+    const sessions = getSessions(
+      [
+        // session 1: W L L L (tilt run 3)
+        makeMatch({ id: '1', time: 0, win: true }),
+        makeMatch({ id: '2', time: HOUR, win: false }),
+        makeMatch({ id: '3', time: 2 * HOUR, win: false }),
+        makeMatch({ id: '4', time: 2.5 * HOUR, win: false }),
+        // 5h gap -> session 2: W W
+        makeMatch({ id: '5', time: 7.5 * HOUR, win: true }),
+        makeMatch({ id: '6', time: 8 * HOUR, win: true }),
+      ],
+      3 * HOUR,
+    );
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]).toMatchObject({ wins: 1, losses: 3, longestLossRun: 3 });
+    expect(sessions[1]).toMatchObject({ wins: 2, losses: 0, longestLossRun: 0 });
+    expect(sessions[0]?.start).toBe(0);
+    expect(sessions[0]?.end).toBe(2.5 * HOUR);
+  });
+
+  it('returns no sessions for no matches', () => {
+    expect(getSessions([])).toEqual([]);
+  });
+});
+
+describe('getOpponentProfile', () => {
+  it('builds a head-to-head profile with their characters ranked', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true, opponent: 'powpow', opponent_id: 41 }),
+      makeMatch({ id: '2', time: 2, win: false, opponent: 'powpow', opponent_id: 41 }),
+      makeMatch({ id: '3', time: 3, win: true, opponent: 'powpow', opponent_id: 7 }),
+      makeMatch({ id: '4', time: 4, win: true, opponent: 'someone-else', opponent_id: 41 }),
+    ];
+    const profile = getOpponentProfile(matches, 'powpow');
+    expect(profile).not.toBeNull();
+    expect(profile?.record).toMatchObject({ wins: 2, losses: 1, total: 3 });
+    expect(profile?.firstPlayedAt).toBe(1);
+    expect(profile?.lastPlayedAt).toBe(3);
+    expect(profile?.byTheirFighter.map((f) => f.opponentFighterId).sort((a, b) => a - b)).toEqual([
+      7, 41,
+    ]);
+    expect(profile?.recent[0]?.id).toBe('3'); // newest first
+  });
+
+  it('returns null for an opponent never played', () => {
+    expect(getOpponentProfile([], 'ghost')).toBeNull();
+  });
+});
+
+describe('getMatchupMatrix', () => {
+  it('orders axes by usage and emits one cell per faced pairing', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true, fighter_id: 75, opponent_id: 41 }),
+      makeMatch({ id: '2', time: 2, win: false, fighter_id: 75, opponent_id: 41 }),
+      makeMatch({ id: '3', time: 3, win: true, fighter_id: 75, opponent_id: 7 }),
+      makeMatch({ id: '4', time: 4, win: true, fighter_id: 12, opponent_id: 41 }),
+    ];
+    const matrix = getMatchupMatrix(matches);
+    expect(matrix.fighterIds).toEqual([75, 12]); // by usage
+    expect(matrix.opponentFighterIds).toEqual([41, 7]);
+    expect(matrix.cells).toHaveLength(3);
+    const cell = matrix.cells.find((c) => c.fighterId === 75 && c.opponentFighterId === 41);
+    expect(cell).toMatchObject({ wins: 1, losses: 1, total: 2 });
+    expect(cell?.wilson).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -73,6 +73,10 @@ export const matchRecordSchema = z.object({
    * of duplicating.
    */
   externalId: z.string().optional(),
+  /** Bracket/event name for imported matches (e.g. "Ultimate Singles"). Server-set. */
+  eventName: z.string().optional(),
+  /** Tournament name for imported matches (e.g. "The Big House 9"). Server-set. */
+  tournamentName: z.string().optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 


### PR DESCRIPTION
The analytics core for the V3 dashboard phases (docs/analytics-vision.md, Phase B):

- **Wilson score lower bound** + `rankMatchupsByEvidence` / `rankStagesByEvidence` — all upcoming rankings sort by the 95% lower bound so sample size is priced in (closed-form values verified in tests)
- `getRollingWinRate` (trailing-window form curve), `getMonthlyRecords`, `getOnlineOfflineSplit` (quickplay counts as online)
- `getSessions` — gap-based play-session grouping (default 3h) with per-session records and longest intra-session loss run (tilt indicator)
- `getOpponentProfile` — H2H record, their characters vs you (evidence-ranked), stages, recency — the scouting-page backbone
- `getMatchupMatrix` — usage-ordered fighters × opponents grid with Wilson-scored cells for the Matchup Lab heatmap
- **Import enrichment**: synced matches gain optional `eventName`/`tournamentName` (server-set only, keys omitted when absent since RTDB rejects `undefined`) — enables per-tournament analytics after one resync

Pure library + schema/sync work, no UI. 227 tests (16 new stats + 2 sync). Lint 0 errors, typecheck clean, build green. Rebased onto master post-#80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)