### PR TITLE
V3 Phase E: opponent scouting page

### DIFF
--- a/apps/web/src/layouts/nav.ts
+++ b/apps/web/src/layouts/nav.ts
@@ -5,6 +5,7 @@ import {
   Users,
   UserSearch,
   Swords,
+  Target,
   LineChart,
   type LucideIcon,
 } from 'lucide-react';
@@ -22,6 +23,7 @@ export const navItems: NavItem[] = [
   { title: 'Choose Secondary', href: '/choose-secondary', icon: Users },
   { title: 'Fighter Analysis', href: '/fighter-analysis', icon: UserSearch },
   { title: 'Matchups', href: '/matchups', icon: Swords },
+  { title: 'Scouting', href: '/opponents', icon: Target },
   { title: 'Match Data', href: '/match-data', icon: LineChart },
   { title: 'Integrations', href: '/settings/integrations', icon: Plug },
 ];

--- a/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import {
+  AnalyticsFilterProvider,
+  ANALYTICS_FILTER_STORAGE_KEY,
+} from '@/context/AnalyticsFilterContext';
+import { OpponentsPage } from './OpponentsPage';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+import { SpriteList } from '@/data/sprites';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const listMatches = vi.fn();
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    users: {
+      upsertMe: (...args: unknown[]) => upsertMe(...args),
+    },
+    matches: {
+      list: (...args: unknown[]) => listMatches(...args),
+    },
+  },
+}));
+
+const mario = SpriteList.find((s) => s.id === 1)!; // Mario
+const luigi = SpriteList.find((s) => s.id === 10)!; // Luigi
+const fox = SpriteList.find((s) => s.id === 15)!; // Fox
+
+function makeMatch(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'm1',
+    fighter_id: mario.id,
+    opponent_id: luigi.id,
+    time: 1000,
+    map: { id: 1, name: 'Battlefield' },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'none',
+    win: true,
+    ...overrides,
+  };
+}
+
+function renderOpponents() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/opponents']}>
+        <AuthProvider>
+          <AnalyticsFilterProvider>
+            <Routes>
+              <Route path="/opponents" element={<OpponentsPage />} />
+              <Route path="/dashboard" element={<div>Dashboard page</div>} />
+              <Route path="/settings/integrations" element={<div>Integrations page</div>} />
+            </Routes>
+          </AnalyticsFilterProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('OpponentsPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    setMockUser(makeMockUser());
+  });
+
+  it('shows a hero empty state when the user has no matches at all', async () => {
+    listMatches.mockResolvedValue([]);
+
+    renderOpponents();
+
+    expect(await screen.findByText('No matches to scout yet!')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute(
+      'href',
+      '/dashboard',
+    );
+    expect(screen.getByRole('link', { name: 'Connect start.gg' })).toHaveAttribute(
+      'href',
+      '/settings/integrations',
+    );
+  });
+
+  it('shows an explanatory empty state when no matches have an opponent tag', async () => {
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', opponent: undefined })]);
+
+    renderOpponents();
+
+    expect(
+      await screen.findByText('None of your matches have an opponent tag recorded.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a clear-filters notice when the global filter empties an existing match set', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      ANALYTICS_FILTER_STORAGE_KEY,
+      JSON.stringify({ source: 'startgg', range: 'all' }),
+    );
+    // All matches are manual (no `source`), so the persisted "startgg" filter excludes everything.
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1' }), makeMatch({ id: 'm2' })]);
+
+    renderOpponents();
+
+    expect(await screen.findByText('No matches match the current filters.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('No matches match the current filters.')).not.toBeInTheDocument(),
+    );
+    expect((await screen.findAllByText('rival')).length).toBeGreaterThan(0);
+  });
+
+  describe('opponent list ranking, search, and selection', () => {
+    beforeEach(() => {
+      listMatches.mockResolvedValue([
+        // "rival": 3 games, most-played — should be auto-selected.
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+        makeMatch({ id: 'm2', time: 2, opponent: 'rival', win: true }),
+        makeMatch({ id: 'm3', time: 3, opponent: 'rival', win: false }),
+        // "zeta": 1 game.
+        makeMatch({ id: 'm4', time: 4, opponent: 'zeta', win: true }),
+      ]);
+    });
+
+    it('ranks opponents by games played descending and shows the total count', async () => {
+      renderOpponents();
+
+      expect(await screen.findByText('2 opponents faced')).toBeInTheDocument();
+
+      const list = screen.getByRole('list', { name: 'Opponents' });
+      const rows = within(list).getAllByRole('listitem');
+      expect(rows).toHaveLength(2);
+      // "rival" (3 games) ranks above "zeta" (1 game).
+      expect(within(rows[0]!).getByText('rival')).toBeInTheDocument();
+      expect(within(rows[1]!).getByText('zeta')).toBeInTheDocument();
+    });
+
+    it('auto-selects the most-played opponent and shows their scouting report', async () => {
+      renderOpponents();
+
+      // The scouting report renders "Last 10" pips once a profile loads —
+      // proof the most-played opponent ("rival") was auto-selected.
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+      expect(screen.getAllByText('rival').length).toBeGreaterThan(0);
+    });
+
+    it('filters the opponent list by substring search', async () => {
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await screen.findByText('2 opponents faced');
+      const search = screen.getByLabelText('Search opponents');
+      await user.type(search, 'zet');
+
+      const list = screen.getByRole('list', { name: 'Opponents' });
+      await waitFor(() => {
+        const rows = within(list).getAllByRole('listitem');
+        expect(rows).toHaveLength(1);
+        expect(within(rows[0]!).getByText('zeta')).toBeInTheDocument();
+      });
+    });
+
+    it('selects a different opponent on click and updates the scouting report', async () => {
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await screen.findByText('2 opponents faced');
+      await user.click(screen.getByRole('button', { name: /zeta/ }));
+
+      // The scouting report card title switches to "zeta".
+      await waitFor(() => {
+        const titles = screen.getAllByText('zeta');
+        expect(titles.length).toBeGreaterThan(0);
+      });
+      // zeta's record is 1-0, shown in the report header (scoped by the
+      // "Last 10" pips section landmark that only renders once selected).
+      expect(await screen.findByText('Last 10 (newest first)')).toBeInTheDocument();
+    });
+  });
+
+  describe('scouting report rendering', () => {
+    beforeEach(() => {
+      listMatches.mockResolvedValue([
+        makeMatch({
+          id: 'm1',
+          time: 1,
+          fighter_id: mario.id,
+          opponent_id: luigi.id,
+          opponent: 'rival',
+          win: true,
+          map: { id: 1, name: 'Battlefield' },
+        }),
+        makeMatch({
+          id: 'm2',
+          time: 2,
+          fighter_id: mario.id,
+          opponent_id: fox.id,
+          opponent: 'rival',
+          win: false,
+          map: { id: 3, name: 'Final Destination' },
+        }),
+        makeMatch({
+          id: 'm3',
+          time: 3,
+          fighter_id: mario.id,
+          opponent_id: fox.id,
+          opponent: 'rival',
+          win: true,
+          map: { id: 3, name: 'Final Destination' },
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          source: 'startgg',
+        }),
+      ]);
+    });
+
+    it('renders the H2H record, their-character ordering, and newest-first recent encounters', async () => {
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+
+      // Scouting report header shows the overall H2H record (2-1) and rate.
+      const headerCard = screen
+        .getByText('Last 10 (newest first)')
+        .closest('[data-slot="card"]') as HTMLElement;
+      expect(within(headerCard).getByText('2-1')).toBeInTheDocument();
+      expect(within(headerCard).getByText(/67% over 3 games/)).toBeInTheDocument();
+
+      // "What They Play": both Luigi and Fox appear, with Fox's better record
+      // (1-1, Wilson-ranked among matchups with 2 games) surfacing correctly.
+      expect(screen.getByText('What They Play')).toBeInTheDocument();
+      expect(screen.getByText(luigi.name)).toBeInTheDocument();
+      expect(screen.getAllByText(fox.name).length).toBeGreaterThan(0);
+
+      // Recent encounters, newest first: m3 (with event/tournament name) before m1.
+      const encountersList = screen.getByRole('list', { name: 'Recent encounters' });
+      const encounterItems = within(encountersList).getAllByRole('listitem');
+      expect(encounterItems.length).toBe(3);
+      // Newest match (m3, time 3) is first and shows the tournament name.
+      expect(within(encounterItems[0]!).getByText('The Big House 9')).toBeInTheDocument();
+      expect(within(encounterItems[0]!).getByText('Win')).toBeInTheDocument();
+      // Oldest match (m1, time 1) is last.
+      expect(within(encounterItems[2]!).getByText('Win')).toBeInTheDocument();
+
+      // Stages card shows both stages played against this opponent.
+      expect(screen.getByText('Stages')).toBeInTheDocument();
+      expect(screen.getAllByText('Final Destination').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Battlefield').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/src/pages/Opponents/OpponentsPage.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { useFilteredMatches } from '@/hooks/useFilteredMatches';
+import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
+import { getOpponentProfile, getOpponentRecords } from '@/lib/stats';
+import { OpponentList } from './components/OpponentList';
+import { ScoutingHeader } from './components/ScoutingHeader';
+import { WhatTheyPlayTable } from './components/WhatTheyPlayTable';
+import { ScoutingStagesCard } from './components/ScoutingStagesCard';
+import { ScoutingTrendChart } from './components/ScoutingTrendChart';
+import { RecentEncounters } from './components/RecentEncounters';
+
+/**
+ * Phase E (docs/analytics-vision.md): scouting reports per human opponent —
+ * H2H record + timeline, what they play against you, stages they take you
+ * to, and recent encounters. Searchable list ranked by games played.
+ */
+export function OpponentsPage() {
+  const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
+
+  const opponentRecords = useMemo(() => getOpponentRecords(matches), [matches]);
+
+  const mostPlayed = useMemo(() => {
+    return [...opponentRecords].sort((a, b) => b.total - a.total)[0]?.opponent ?? null;
+  }, [opponentRecords]);
+
+  // Tracks an explicit user selection only; when unset, or when the previous
+  // selection has dropped out of the filtered set (e.g. the global
+  // source/time filter changed), the most-played opponent is used instead —
+  // derived during render like Dashboard's fighter selection, no effect
+  // needed to seed state from data that just loaded.
+  const [selectedOpponent, setSelectedOpponent] = useState<string | null>(null);
+
+  const selected =
+    selectedOpponent && opponentRecords.some((o) => o.opponent === selectedOpponent)
+      ? selectedOpponent
+      : mostPlayed;
+
+  const profile = useMemo(() => {
+    if (!selected) {
+      return null;
+    }
+    return getOpponentProfile(matches, selected);
+  }, [matches, selected]);
+
+  if (isLoading) {
+    return <div className="text-muted-foreground">Loading scouting reports...</div>;
+  }
+
+  if (allMatches.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">No matches to scout yet!</h1>
+        <p className="max-w-md text-muted-foreground">
+          Report a match on the Dashboard, or connect start.gg to sync your tournament sets, and
+          opponent scouting reports will show up here.
+        </p>
+        <div className="flex flex-wrap justify-center gap-2">
+          <Button asChild>
+            <Link to="/dashboard">Go to Dashboard</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/settings/integrations">Connect start.gg</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const allOpponentsNamed = getOpponentRecords(allMatches);
+  if (allOpponentsNamed.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-16 text-center">
+        <h2 className="text-xl font-semibold tracking-tight">
+          None of your matches have an opponent tag recorded.
+        </h2>
+        <p className="max-w-md text-muted-foreground">
+          Add an opponent name when reporting a match to unlock scouting reports for them.
+        </p>
+        <Button asChild className="mt-2">
+          <Link to="/dashboard">Go to Dashboard</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {filterActive && matches.length === 0 && <FilteredEmptyNotice />}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[320px_1fr]">
+        <OpponentList matches={matches} selected={selected} onSelect={setSelectedOpponent} />
+
+        {profile ? (
+          <div key={profile.opponent} className="flex flex-col gap-4">
+            <ScoutingHeader profile={profile} />
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <WhatTheyPlayTable byTheirFighter={profile.byTheirFighter} />
+              <ScoutingStagesCard byStage={profile.byStage} />
+            </div>
+            <ScoutingTrendChart matches={matches.filter((m) => m.opponent === profile.opponent)} />
+            <RecentEncounters matches={profile.recent} />
+          </div>
+        ) : (
+          <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
+            Select an opponent from the list to see their scouting report.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/OpponentList.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentList.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { getOpponentRecords, type OpponentRecord } from '@/lib/stats';
+
+export interface OpponentListProps {
+  matches: Match[];
+  selected: string | null;
+  onSelect: (opponent: string) => void;
+}
+
+/**
+ * Left-column opponent list for the Scouting page: every human opponent
+ * faced (`getOpponentRecords`), ranked by games played descending, with a
+ * substring search filter. Selecting a row calls `onSelect`.
+ */
+export function OpponentList({ matches, selected, onSelect }: OpponentListProps) {
+  const [query, setQuery] = useState('');
+
+  const opponents = useMemo(() => {
+    return [...getOpponentRecords(matches)].sort((a, b) => b.total - a.total);
+  }, [matches]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) {
+      return opponents;
+    }
+    return opponents.filter((o) => o.opponent.toLowerCase().includes(needle));
+  }, [opponents, query]);
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle>Opponents</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            {opponents.length} opponent{opponents.length === 1 ? '' : 's'} faced
+          </span>
+        </div>
+        <div className="relative">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search opponents..."
+            aria-label="Search opponents"
+            className="pl-8"
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1">
+        {filtered.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {opponents.length === 0 ? 'No opponents faced yet.' : 'No opponents match your search.'}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-1" role="list" aria-label="Opponents">
+            {filtered.map((opponent) => (
+              <OpponentRow
+                key={opponent.opponent}
+                opponent={opponent}
+                selected={opponent.opponent === selected}
+                onSelect={onSelect}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function OpponentRow({
+  opponent,
+  selected,
+  onSelect,
+}: {
+  opponent: OpponentRecord;
+  selected: boolean;
+  onSelect: (opponent: string) => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(opponent.opponent)}
+        aria-pressed={selected}
+        className={`flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+          selected
+            ? 'border-primary bg-primary/10'
+            : 'border-transparent hover:bg-accent hover:text-accent-foreground'
+        }`}
+      >
+        <span className="min-w-0 flex-1 truncate font-medium">{opponent.opponent}</span>
+        <span className="text-muted-foreground">
+          {opponent.wins}-{opponent.losses}
+        </span>
+        <span className="w-10 text-right font-medium">{opponent.winRate}%</span>
+        <span className="w-14 text-right text-xs text-muted-foreground">
+          {opponent.total} game{opponent.total === 1 ? '' : 's'}
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/RecentEncounters.tsx
+++ b/apps/web/src/pages/Opponents/components/RecentEncounters.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { Match } from '@smash-tracker/shared';
+import { getFighterById } from '@/data/sprites';
+import { stagesById } from '@/data/stages';
+
+/**
+ * Recent encounters vs this opponent, newest first (matches `profile.recent`
+ * ordering from `getOpponentProfile`): date, your fighter, their fighter,
+ * stage, result badge, and the event/tournament name when present (imported
+ * start.gg matches).
+ */
+export function RecentEncounters({ matches }: { matches: Match[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Encounters</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {matches.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No encounters recorded yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2" aria-label="Recent encounters">
+            {matches.map((match) => {
+              const fighterSprite = getFighterById(match.fighter_id);
+              const opponentSprite = getFighterById(match.opponent_id);
+              const stageName =
+                match.map && match.map.id !== 0
+                  ? (stagesById.get(match.map.id)?.name ?? match.map.name)
+                  : 'unknown';
+              const eventLabel = match.tournamentName ?? match.eventName;
+
+              return (
+                <li
+                  key={match.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm text-muted-foreground">
+                      {new Date(match.time).toLocaleDateString()}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {fighterSprite && (
+                        <img
+                          src={fighterSprite.url}
+                          alt={fighterSprite.name}
+                          className="size-6 object-contain"
+                        />
+                      )}
+                      <span className="text-xs text-muted-foreground">vs</span>
+                      {opponentSprite && (
+                        <img
+                          src={opponentSprite.url}
+                          alt={opponentSprite.name}
+                          className="size-6 object-contain"
+                        />
+                      )}
+                    </div>
+                    <span className="text-sm">{stageName}</span>
+                    {eventLabel && (
+                      <span className="text-xs text-muted-foreground">{eventLabel}</span>
+                    )}
+                  </div>
+                  <Badge variant={match.win ? 'success' : 'destructive'}>
+                    {match.win ? 'Win' : 'Loss'}
+                  </Badge>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { WinLossPips } from '@/components/WinLossPips';
+import type { OpponentProfile } from '@/lib/stats';
+
+/**
+ * Scouting report header: opponent tag, overall H2H record + rate + sample
+ * size, first/last played dates, and last-10 form pips vs this opponent.
+ */
+export function ScoutingHeader({ profile }: { profile: OpponentProfile }) {
+  const { record } = profile;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-4">
+        <div>
+          <CardTitle className="text-2xl">{profile.opponent}</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            First played {new Date(profile.firstPlayedAt).toLocaleDateString()} · Last played{' '}
+            {new Date(profile.lastPlayedAt).toLocaleDateString()}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-semibold">
+            {record.wins}-{record.losses}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {record.winRate}% over {record.total} game{record.total === 1 ? '' : 's'}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">Last 10 (newest first)</h3>
+        <WinLossPips matches={profile.recent} limit={10} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/ScoutingStagesCard.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingStagesCard.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { StageRecord } from '@/lib/stats';
+import { stagesById } from '@/data/stages';
+
+const MAX_STAGES = 6;
+
+/** Stages this opponent takes you to most, sorted by sample size, top 6. */
+export function ScoutingStagesCard({ byStage }: { byStage: StageRecord[] }) {
+  const top = byStage.slice(0, MAX_STAGES);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Stages</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {top.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No stage data recorded yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Stage</TableHead>
+                <TableHead>Record</TableHead>
+                <TableHead className="text-right">Win Rate</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {top.map((record) => (
+                <TableRow key={record.stageId}>
+                  <TableCell>
+                    {record.stageId === 0
+                      ? 'unknown'
+                      : (stagesById.get(record.stageId)?.name ?? 'Unknown')}
+                  </TableCell>
+                  <TableCell>
+                    {record.wins}-{record.losses}
+                  </TableCell>
+                  <TableCell className="text-right">{record.winRate}%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
@@ -1,0 +1,86 @@
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Match } from '@smash-tracker/shared';
+import { getRollingWinRate } from '@/lib/stats';
+import { darkChartOptions, redLineDataset } from '@/lib/chartTheme';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const ROLLING_WINDOW = 5;
+
+/** Rolling (trailing-5) win-rate trend across all matches vs this opponent. */
+export function ScoutingTrendChart({ matches }: { matches: Match[] }) {
+  const series = getRollingWinRate(matches, ROLLING_WINDOW);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>H2H Trend</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {series.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Not enough matches for a trend yet.</p>
+        ) : (
+          <Line data={buildData(series)} options={buildOptions(series)} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function buildData(series: ReturnType<typeof getRollingWinRate>) {
+  return {
+    labels: series.map((point) => point.index.toString()),
+    datasets: [
+      {
+        label: `Rolling win rate (last ${ROLLING_WINDOW})`,
+        ...redLineDataset(),
+        data: series.map((point) => point.winRate),
+      },
+    ],
+  };
+}
+
+function buildOptions(series: ReturnType<typeof getRollingWinRate>): ChartOptions<'line'> {
+  const theme = darkChartOptions();
+  return {
+    scales: {
+      x: theme.scales?.x,
+      y: {
+        ...theme.scales?.y,
+        position: 'right',
+        suggestedMax: 100,
+        suggestedMin: 0,
+      },
+    },
+    plugins: {
+      legend: {
+        display: true,
+        labels: theme.plugins?.legend?.labels,
+      },
+      tooltip: {
+        ...theme.plugins?.tooltip,
+        mode: 'nearest',
+        intersect: true,
+        callbacks: {
+          title: (items) => {
+            const point = series[items[0]?.dataIndex ?? -1];
+            if (!point) return '';
+            return new Date(point.match.time).toLocaleDateString('en-US');
+          },
+          label: (item) => `: ${Math.round(Number(item.formattedValue) * 100) / 100}%`,
+        },
+      },
+    },
+  };
+}

--- a/apps/web/src/pages/Opponents/components/WhatTheyPlayTable.tsx
+++ b/apps/web/src/pages/Opponents/components/WhatTheyPlayTable.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { RankedMatchup } from '@/lib/stats';
+import { getFighterById } from '@/data/sprites';
+
+/**
+ * "What they play" — the opponent's characters against you, your record per
+ * character, evidence-ranked (Wilson lower bound) so the matchups you most
+ * reliably win sit at the top.
+ */
+export function WhatTheyPlayTable({ byTheirFighter }: { byTheirFighter: RankedMatchup[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>What They Play</CardTitle>
+        <CardDescription>Ordered by how reliably you beat it.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {byTheirFighter.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No characters recorded yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Character</TableHead>
+                <TableHead>Record</TableHead>
+                <TableHead>Win Rate</TableHead>
+                <TableHead className="text-right">Games</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {byTheirFighter.map((row) => {
+                const sprite = getFighterById(row.opponentFighterId);
+                return (
+                  <TableRow key={row.opponentFighterId}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {sprite && (
+                          <img src={sprite.url} alt="" className="size-6 object-contain" />
+                        )}
+                        <span>{sprite?.name ?? 'Unknown'}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {row.wins}-{row.losses}
+                    </TableCell>
+                    <TableCell>{row.ratio}%</TableCell>
+                    <TableCell className="text-right">{row.totalMatches}</TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -4,6 +4,7 @@ import { DashboardPage } from '@/pages/Dashboard/DashboardPage';
 import { ChoosePrimaryPage } from '@/pages/CharacterSelect/ChoosePrimaryPage';
 import { ChooseSecondaryPage } from '@/pages/CharacterSelect/ChooseSecondaryPage';
 import { MatchupsPage } from '@/pages/Matchups/MatchupsPage';
+import { OpponentsPage } from '@/pages/Opponents/OpponentsPage';
 import { MatchDataPage } from '@/pages/MatchData/MatchDataPage';
 import { FighterAnalysisPage } from '@/pages/FighterAnalysis/FighterAnalysisPage';
 import { IntegrationsPage } from '@/pages/Integrations/IntegrationsPage';
@@ -59,6 +60,14 @@ export function AppRouter() {
           element={
             <ProtectedRoute>
               <MatchupsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/opponents"
+          element={
+            <ProtectedRoute>
+              <OpponentsPage />
             </ProtectedRoute>
           }
         />


### PR DESCRIPTION
## Summary

Implements Phase E of docs/analytics-vision.md: a new `/opponents` ("Scouting") page for per-human-opponent scouting reports, built entirely on the v3 stats engine merged in #81 (`getOpponentRecords`, `getOpponentProfile`, `wilsonLowerBound`, `getRollingWinRate`). No changes to `stats.ts`, hooks, api, or other shared code — everything consumed already existed on master.

- **Opponent list** (left column): every human opponent faced, ranked by games played descending, with a live substring search and a "N opponents faced" count. Auto-selects the most-played opponent; falls back to most-played if the current selection drops out of the filtered set.
- **Scouting report** for the selected tag:
  - Header: tag, overall H2H record + rate + sample size, first/last played dates, last-10 form pips (`WinLossPips`).
  - **What They Play**: their characters against you, Wilson-ranked (best-for-you first), with a caption explaining the ordering.
  - **Stages**: top 6 stages they've taken you to, sorted by sample size.
  - **H2H Trend**: rolling (window-5) win-rate line chart vs this opponent, styled via `lib/chartTheme` to match other charts.
  - **Recent Encounters**: newest-first, with fighter sprites, stage, win/loss badge (success/destructive), and event/tournament name when present on imported start.gg matches.
- **Empty states**: hero prompting to report matches / connect start.gg when there are no matches at all; `FilteredEmptyNotice` when the global filter empties an existing match set; a dedicated explanatory state when no matches have an opponent tag recorded.
- **Nav**: "Scouting" added between Matchups and Match Data, using the `Target` icon (`UserSearch` was already taken by Fighter Analysis).

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing warnings only, none in new files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 211/211 passing (142 web incl. 8 new OpponentsPage tests; 69 api unchanged)
- [x] `pnpm build` — succeeds
- [x] `pnpm format:check` — clean
- [x] Visual check: rendered the page with a realistic mixed dataset (manual + start.gg-sourced matches, event/tournament names, multiple opponents/characters/stages) via a temporary preview harness — confirmed list ranking/search/selection, report sections, chart, and recent encounters all render correctly, then fully reverted before committing (`git status` clean of any harness artifacts).

New tests cover: list ranking + search + selection, profile rendering (record, their-character ordering, recent newest-first with event names), and all three page-level empty states.

**Note:** This PR touches `apps/web/src/routes/AppRouter.tsx` (one new `<Route>`) and `apps/web/src/layouts/nav.ts` (one new nav entry) — both minimal, append-only changes. If this merges after the concurrent Dashboard / Matchup Lab PRs, a trivial rebase may be needed on those two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)