### PR TITLE
V3 Phase F: trends, sessions, and tournaments

### DIFF
--- a/apps/web/src/layouts/nav.ts
+++ b/apps/web/src/layouts/nav.ts
@@ -6,6 +6,7 @@ import {
   UserSearch,
   Swords,
   LineChart,
+  TrendingUp,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -23,5 +24,6 @@ export const navItems: NavItem[] = [
   { title: 'Fighter Analysis', href: '/fighter-analysis', icon: UserSearch },
   { title: 'Matchups', href: '/matchups', icon: Swords },
   { title: 'Match Data', href: '/match-data', icon: LineChart },
+  { title: 'Trends', href: '/trends', icon: TrendingUp },
   { title: 'Integrations', href: '/settings/integrations', icon: Plug },
 ];

--- a/apps/web/src/pages/Trends/TrendsPage.test.tsx
+++ b/apps/web/src/pages/Trends/TrendsPage.test.tsx
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import {
+  AnalyticsFilterProvider,
+  ANALYTICS_FILTER_STORAGE_KEY,
+} from '@/context/AnalyticsFilterContext';
+import { TrendsPage } from './TrendsPage';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const listMatches = vi.fn();
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    users: {
+      upsertMe: (...args: unknown[]) => upsertMe(...args),
+    },
+    matches: {
+      list: (...args: unknown[]) => listMatches(...args),
+    },
+  },
+}));
+
+function makeMatch(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'm1',
+    fighter_id: 1,
+    opponent_id: 2,
+    time: 1_700_000_000_000,
+    map: { id: 0, name: 'no selection' },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'none',
+    win: true,
+    ...overrides,
+  };
+}
+
+function renderTrends() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/trends']}>
+        <AuthProvider>
+          <AnalyticsFilterProvider>
+            <Routes>
+              <Route path="/trends" element={<TrendsPage />} />
+              <Route path="/dashboard" element={<div>Dashboard page</div>} />
+            </Routes>
+          </AnalyticsFilterProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TrendsPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    setMockUser(makeMockUser());
+  });
+
+  it('shows a no-matches empty state when the user has no matches', async () => {
+    listMatches.mockResolvedValue([]);
+
+    renderTrends();
+
+    expect(
+      await screen.findByText(
+        'You have no matches, report a match and check back here to view trends!',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute(
+      'href',
+      '/dashboard',
+    );
+  });
+
+  it('renders all five trend sections once matches exist', async () => {
+    listMatches.mockResolvedValue([
+      makeMatch({ id: 'm1', win: true, time: Date.UTC(2021, 0, 1), matchType: 'quickplay' }),
+      makeMatch({ id: 'm2', win: false, time: Date.UTC(2021, 1, 1), matchType: 'offline-tourney' }),
+    ]);
+
+    renderTrends();
+
+    expect(await screen.findByText('Monthly Performance')).toBeInTheDocument();
+    expect(screen.getByText('Sessions & Tilt')).toBeInTheDocument();
+    expect(screen.getByText('Setting Comparison')).toBeInTheDocument();
+    expect(screen.getByText('Tournaments')).toBeInTheDocument();
+    expect(screen.getByText('Match-Type Mix Over Time')).toBeInTheDocument();
+  });
+
+  it('shows the resync hint in the tournaments section when no match has a tournamentName', async () => {
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', win: true })]);
+
+    renderTrends();
+
+    expect(
+      await screen.findByText(/Tournament names attach on your next start\.gg sync/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a clear-filters notice when the global filter empties an existing match set', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      ANALYTICS_FILTER_STORAGE_KEY,
+      JSON.stringify({ source: 'startgg', range: 'all' }),
+    );
+    // All matches are manual (no `source`), so the persisted "startgg" filter excludes everything.
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1' }), makeMatch({ id: 'm2' })]);
+
+    renderTrends();
+
+    expect(await screen.findByText('No matches match the current filters.')).toBeInTheDocument();
+    // Page itself still renders (not the page-level "no matches at all" hero).
+    expect(screen.getByText('Monthly Performance')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Go to Dashboard' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('No matches match the current filters.')).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/src/pages/Trends/TrendsPage.tsx
+++ b/apps/web/src/pages/Trends/TrendsPage.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { useFilteredMatches } from '@/hooks/useFilteredMatches';
+import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
+import { MonthlyPerformance } from './components/MonthlyPerformance';
+import { SessionsAndTilt } from './components/SessionsAndTilt';
+import { SettingComparison } from './components/SettingComparison';
+import { Tournaments } from './components/Tournaments';
+import { MatchTypeMix } from './components/MatchTypeMix';
+
+/**
+ * V3 Phase F (docs/analytics-vision.md): monthly performance, sessions/tilt,
+ * online-vs-offline comparison, per-tournament results, and match-type mix
+ * over time. Account-wide (not per-fighter), honoring the global
+ * source/time-range filter like the other analytics pages.
+ */
+export function TrendsPage() {
+  const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
+
+  if (isLoading) {
+    return <div className="text-muted-foreground">Loading trends...</div>;
+  }
+
+  if (allMatches.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-16 text-center">
+        <h2 className="text-xl font-semibold tracking-tight">
+          You have no matches, report a match and check back here to view trends!
+        </h2>
+        <Button asChild className="mt-2">
+          <Link to="/dashboard">Go to Dashboard</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {filterActive && matches.length === 0 && <FilteredEmptyNotice />}
+
+      <MonthlyPerformance matches={matches} />
+      <SessionsAndTilt matches={matches} />
+      <SettingComparison matches={matches} />
+      <Tournaments matches={matches} />
+      <MatchTypeMix matches={matches} />
+    </div>
+  );
+}

--- a/apps/web/src/pages/Trends/components/MatchTypeMix.test.tsx
+++ b/apps/web/src/pages/Trends/components/MatchTypeMix.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match } from '@smash-tracker/shared';
+import { MatchTypeMix, bucketMatchType, buildMonthlyMatchTypeMix } from './MatchTypeMix';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('bucketMatchType', () => {
+  it('buckets tourney types (online/offline) together', () => {
+    expect(bucketMatchType('online-tourney')).toBe('tourney');
+    expect(bucketMatchType('offline-tourney')).toBe('tourney');
+  });
+
+  it('buckets friendly types (online/offline) together', () => {
+    expect(bucketMatchType('online-friendly')).toBe('friendly');
+    expect(bucketMatchType('offline-friendly')).toBe('friendly');
+  });
+
+  it('buckets quickplay on its own', () => {
+    expect(bucketMatchType('quickplay')).toBe('quickplay');
+  });
+
+  it('buckets missing/none/empty as unspecified', () => {
+    expect(bucketMatchType('none')).toBe('unspecified');
+    expect(bucketMatchType('')).toBe('unspecified');
+    expect(bucketMatchType(undefined)).toBe('unspecified');
+  });
+});
+
+describe('buildMonthlyMatchTypeMix', () => {
+  it('groups counts per month per bucket', () => {
+    const matches = [
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true, matchType: 'quickplay' }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 0, 2), win: true, matchType: 'online-tourney' }),
+      makeMatch({ id: '3', time: Date.UTC(2021, 1, 1), win: true, matchType: 'offline-friendly' }),
+    ];
+    const mix = buildMonthlyMatchTypeMix(matches);
+
+    expect(mix).toEqual([
+      { month: '2021-01', counts: { tourney: 1, friendly: 0, quickplay: 1, unspecified: 0 } },
+      { month: '2021-02', counts: { tourney: 0, friendly: 1, quickplay: 0, unspecified: 0 } },
+    ]);
+  });
+
+  it('returns an empty array for no matches', () => {
+    expect(buildMonthlyMatchTypeMix([])).toEqual([]);
+  });
+});
+
+describe('MatchTypeMix component', () => {
+  it('shows an empty state with no match data', () => {
+    render(<MatchTypeMix matches={[]} />);
+    expect(screen.getByText('No match data to report yet.')).toBeInTheDocument();
+  });
+
+  it('renders the card title when data exists', () => {
+    const matches = [makeMatch({ id: '1', time: 1, win: true, matchType: 'quickplay' })];
+    render(<MatchTypeMix matches={matches} />);
+    expect(screen.getByText('Match-Type Mix Over Time')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
+++ b/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
@@ -1,0 +1,130 @@
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartColors, darkChartOptions } from '@/lib/chartTheme';
+import { formatMonthLabel } from './MonthlyPerformance';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+/** The four buckets matches are grouped into for the mix chart, in stack/legend order. */
+export const MATCH_TYPE_BUCKETS = ['tourney', 'friendly', 'quickplay', 'unspecified'] as const;
+export type MatchTypeBucket = (typeof MATCH_TYPE_BUCKETS)[number];
+
+const BUCKET_COLORS: Record<MatchTypeBucket, string> = {
+  tourney: '#e60012',
+  friendly: '#3b82f6',
+  quickplay: '#eab308',
+  unspecified: '#71717a',
+};
+
+const BUCKET_LABELS: Record<MatchTypeBucket, string> = {
+  tourney: 'Tourney',
+  friendly: 'Friendly',
+  quickplay: 'Quickplay',
+  unspecified: 'Unspecified',
+};
+
+/** Buckets a stored `matchType` literal into one of the four mix categories. */
+export function bucketMatchType(matchType: Match['matchType']): MatchTypeBucket {
+  const type = matchType ?? '';
+  if (type === 'online-tourney' || type === 'offline-tourney') return 'tourney';
+  if (type === 'online-friendly' || type === 'offline-friendly') return 'friendly';
+  if (type === 'quickplay') return 'quickplay';
+  return 'unspecified';
+}
+
+export interface MonthlyMatchTypeMix {
+  month: string;
+  counts: Record<MatchTypeBucket, number>;
+}
+
+/**
+ * Games played per month, split by match-type bucket. Exported as a pure
+ * builder so the bucketing + monthly grouping is unit-testable without
+ * rendering chart.js. Months are chronological ascending (same convention as
+ * `getMonthlyRecords`).
+ */
+export function buildMonthlyMatchTypeMix(matches: Match[]): MonthlyMatchTypeMix[] {
+  const byMonth = new Map<string, Record<MatchTypeBucket, number>>();
+  for (const match of matches) {
+    const d = new Date(match.time);
+    const month = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    const bucket = bucketMatchType(match.matchType);
+    const counts = byMonth.get(month) ?? {
+      tourney: 0,
+      friendly: 0,
+      quickplay: 0,
+      unspecified: 0,
+    };
+    counts[bucket] += 1;
+    byMonth.set(month, counts);
+  }
+  return [...byMonth.entries()]
+    .map(([month, counts]) => ({ month, counts }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+}
+
+function buildChartData(mix: MonthlyMatchTypeMix[]) {
+  return {
+    labels: mix.map((m) => formatMonthLabel(m.month)),
+    datasets: MATCH_TYPE_BUCKETS.map((bucket) => ({
+      label: BUCKET_LABELS[bucket],
+      data: mix.map((m) => m.counts[bucket]),
+      backgroundColor: BUCKET_COLORS[bucket],
+      stack: 'games',
+    })),
+  };
+}
+
+function buildChartOptions(): ChartOptions<'bar'> {
+  const theme = darkChartOptions();
+  return {
+    scales: {
+      x: { ...theme.scales?.x, stacked: true },
+      y: { ...theme.scales?.y, stacked: true, beginAtZero: true },
+    },
+    plugins: {
+      legend: { display: true, labels: theme.plugins?.legend?.labels },
+      tooltip: {
+        backgroundColor: chartColors.tooltipBg,
+        borderColor: chartColors.tooltipBorder,
+        borderWidth: 1,
+      },
+    },
+  };
+}
+
+/**
+ * V3 Phase F (item 5): games played per month, stacked by match-type bucket
+ * (tourney/friendly/quickplay/unspecified). Kept intentionally simple — no
+ * interactivity beyond the chart.js default tooltip.
+ */
+export function MatchTypeMix({ matches }: { matches: Match[] }) {
+  const mix = buildMonthlyMatchTypeMix(matches);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Match-Type Mix Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {mix.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+        ) : (
+          <div className="h-56">
+            <Bar data={buildChartData(mix)} options={buildChartOptions()} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Trends/components/MonthlyPerformance.test.tsx
+++ b/apps/web/src/pages/Trends/components/MonthlyPerformance.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match } from '@smash-tracker/shared';
+import {
+  MonthlyPerformance,
+  SMALL_SAMPLE_THRESHOLD,
+  buildMonthlyChartData,
+  formatMonthLabel,
+} from './MonthlyPerformance';
+import { getMonthlyRecords } from '@/lib/stats';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('formatMonthLabel', () => {
+  it('formats a YYYY-MM key as a short month/year label', () => {
+    expect(formatMonthLabel('2021-01')).toBe('Jan 2021');
+    expect(formatMonthLabel('2021-12')).toBe('Dec 2021');
+  });
+
+  it('falls back to the raw key for malformed input', () => {
+    expect(formatMonthLabel('garbage')).toBe('garbage');
+  });
+});
+
+describe('buildMonthlyChartData', () => {
+  it('marks months under the small-sample threshold with the reduced-opacity color', () => {
+    const matches = [
+      // 2021-01: 2 games (below threshold of 3)
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 0, 2), win: false }),
+      // 2021-02: 3 games (at threshold)
+      makeMatch({ id: '3', time: Date.UTC(2021, 1, 1), win: true }),
+      makeMatch({ id: '4', time: Date.UTC(2021, 1, 2), win: true }),
+      makeMatch({ id: '5', time: Date.UTC(2021, 1, 3), win: false }),
+    ];
+    const records = getMonthlyRecords(matches);
+    const data = buildMonthlyChartData(records);
+
+    expect(records[0]?.total).toBe(2);
+    expect(records[1]?.total).toBe(3);
+    // First bar (small sample) should differ in color from the second (full opacity).
+    const colors = data.datasets[0]?.backgroundColor as string[];
+    expect(colors[0]).not.toBe(colors[1]);
+  });
+
+  it('carries win rate and games-played data for each month', () => {
+    const matches = [
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 0, 2), win: true }),
+      makeMatch({ id: '3', time: Date.UTC(2021, 0, 3), win: false }),
+    ];
+    const records = getMonthlyRecords(matches);
+    const data = buildMonthlyChartData(records);
+
+    expect(data.labels).toEqual(['Jan 2021']);
+    expect(data.datasets[0]?.data).toEqual([67]);
+    expect(data.datasets[0]?.games).toEqual([3]);
+  });
+
+  it('returns an empty dataset for no matches', () => {
+    const data = buildMonthlyChartData(getMonthlyRecords([]));
+    expect(data.labels).toEqual([]);
+    expect(data.datasets[0]?.data).toEqual([]);
+  });
+});
+
+describe('MonthlyPerformance component', () => {
+  it('shows an empty state with no match data', () => {
+    render(<MonthlyPerformance matches={[]} />);
+    expect(screen.getByText('No match data to report yet.')).toBeInTheDocument();
+  });
+
+  it('renders the small-sample caption and a table row per month', () => {
+    const matches = [
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 1, 1), win: true }),
+      makeMatch({ id: '3', time: Date.UTC(2021, 1, 2), win: true }),
+      makeMatch({ id: '4', time: Date.UTC(2021, 1, 3), win: false }),
+    ];
+    render(<MonthlyPerformance matches={matches} />);
+
+    expect(
+      screen.getByText(
+        `Faded bars mark months with fewer than ${SMALL_SAMPLE_THRESHOLD} games — small sample, read with caution.`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Jan 2021')).toBeInTheDocument();
+    expect(screen.getByText('Feb 2021')).toBeInTheDocument();
+    // Table shows most recent month first.
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('Feb 2021');
+  });
+});

--- a/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
+++ b/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
@@ -1,0 +1,153 @@
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getMonthlyRecords, type MonthlyRecord } from '@/lib/stats';
+import { chartColors, darkChartOptions } from '@/lib/chartTheme';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+/** Below this many games in a month, the bar renders at reduced opacity as a small-sample cue. */
+export const SMALL_SAMPLE_THRESHOLD = 3;
+
+/** Formats a `YYYY-MM` month key as a short human label, e.g. '2021-01' -> 'Jan 2021'. */
+export function formatMonthLabel(month: string): string {
+  const [year, monthNum] = month.split('-').map(Number);
+  if (!year || !monthNum) return month;
+  const date = new Date(Date.UTC(year, monthNum - 1, 1));
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+/**
+ * Builds the chart.js dataset for the monthly win-rate bar chart. Exported so
+ * the bucketing + opacity + tooltip-detail math can be unit-tested without
+ * rendering chart.js. Bars for months under `SMALL_SAMPLE_THRESHOLD` games
+ * get a reduced-opacity fill as a small-sample visual cue.
+ */
+export function buildMonthlyChartData(records: MonthlyRecord[]) {
+  return {
+    labels: records.map((r) => formatMonthLabel(r.month)),
+    datasets: [
+      {
+        label: 'Win Rate',
+        data: records.map((r) => r.winRate),
+        backgroundColor: records.map((r) =>
+          r.total < SMALL_SAMPLE_THRESHOLD ? chartColors.redSoft : chartColors.red,
+        ),
+        borderColor: chartColors.red,
+        borderWidth: 1,
+        borderRadius: 4,
+        // Carried through purely for the tooltip callback below.
+        games: records.map((r) => r.total),
+      },
+    ],
+  };
+}
+
+function buildMonthlyChartOptions(records: MonthlyRecord[]): ChartOptions<'bar'> {
+  const theme = darkChartOptions();
+  return {
+    scales: {
+      x: theme.scales?.x,
+      y: {
+        ...theme.scales?.y,
+        suggestedMax: 100,
+        beginAtZero: true,
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: chartColors.tooltipBg,
+        borderColor: chartColors.tooltipBorder,
+        borderWidth: 1,
+        callbacks: {
+          label: (item) => `Win rate: ${item.formattedValue}%`,
+          afterLabel: (item) => {
+            const record = records[item.dataIndex];
+            return record ? `Games played: ${record.total}` : '';
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * V3 Phase F: monthly performance bar chart (win rate per month) plus a
+ * compact table below it. Months under `SMALL_SAMPLE_THRESHOLD` games render
+ * at reduced opacity, called out in a caption.
+ */
+export function MonthlyPerformance({ matches }: { matches: Match[] }) {
+  const records = getMonthlyRecords(matches);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Monthly Performance</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {records.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+        ) : (
+          <>
+            <div className="h-64">
+              <Bar
+                data={buildMonthlyChartData(records)}
+                options={buildMonthlyChartOptions(records)}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Faded bars mark months with fewer than {SMALL_SAMPLE_THRESHOLD} games — small sample,
+              read with caution.
+            </p>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Month</TableHead>
+                  <TableHead>W-L</TableHead>
+                  <TableHead>Rate</TableHead>
+                  <TableHead>Games</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[...records].reverse().map((record) => (
+                  <TableRow key={record.month}>
+                    <TableCell>{formatMonthLabel(record.month)}</TableCell>
+                    <TableCell>
+                      {record.wins}-{record.losses}
+                    </TableCell>
+                    <TableCell>{record.winRate}%</TableCell>
+                    <TableCell
+                      className={
+                        record.total < SMALL_SAMPLE_THRESHOLD ? 'text-muted-foreground' : undefined
+                      }
+                    >
+                      {record.total}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Trends/components/SessionsAndTilt.test.tsx
+++ b/apps/web/src/pages/Trends/components/SessionsAndTilt.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match } from '@smash-tracker/shared';
+import {
+  SessionsAndTilt,
+  TILT_HIGHLIGHT_THRESHOLD,
+  buildSessionsHeadline,
+} from './SessionsAndTilt';
+import { getSessions } from '@/lib/stats';
+
+const HOUR = 60 * 60 * 1000;
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('buildSessionsHeadline', () => {
+  it('returns zeroed/null headline for no sessions', () => {
+    expect(buildSessionsHeadline([])).toEqual({
+      totalSessions: 0,
+      avgGamesPerSession: 0,
+      bestSession: null,
+      worstTiltSession: null,
+    });
+  });
+
+  it('computes total sessions and average games per session', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: 1, win: true }),
+      // gap > default 3h starts a new session
+      makeMatch({ id: '3', time: 5 * HOUR, win: false }),
+    ];
+    const sessions = getSessions(matches);
+    const headline = buildSessionsHeadline(sessions);
+
+    expect(headline.totalSessions).toBe(2);
+    expect(headline.avgGamesPerSession).toBe(1.5);
+  });
+
+  it('picks the session with the best net wins as bestSession', () => {
+    const matches = [
+      // Session A: 1-2 (net -1)
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: 1, win: false }),
+      makeMatch({ id: '3', time: 2, win: false }),
+      // Session B: 3-0 (net +3) — should win
+      makeMatch({ id: '4', time: 10 * HOUR, win: true }),
+      makeMatch({ id: '5', time: 10 * HOUR + 1, win: true }),
+      makeMatch({ id: '6', time: 10 * HOUR + 2, win: true }),
+    ];
+    const sessions = getSessions(matches);
+    const headline = buildSessionsHeadline(sessions);
+
+    expect(headline.bestSession?.wins).toBe(3);
+    expect(headline.bestSession?.losses).toBe(0);
+  });
+
+  it('picks the session with the longest loss run as worstTiltSession', () => {
+    const matches = [
+      // Session A: loss run of 1
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: 1, win: false }),
+      // Session B: loss run of 3
+      makeMatch({ id: '3', time: 10 * HOUR, win: false }),
+      makeMatch({ id: '4', time: 10 * HOUR + 1, win: false }),
+      makeMatch({ id: '5', time: 10 * HOUR + 2, win: false }),
+    ];
+    const sessions = getSessions(matches);
+    const headline = buildSessionsHeadline(sessions);
+
+    expect(headline.worstTiltSession?.longestLossRun).toBe(3);
+  });
+
+  it('reports worstTiltSession as null when there are no losses at all', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: 1, win: true }),
+    ];
+    const headline = buildSessionsHeadline(getSessions(matches));
+    expect(headline.worstTiltSession).toBeNull();
+  });
+});
+
+describe('SessionsAndTilt component', () => {
+  it('shows an empty state with no match data', () => {
+    render(<SessionsAndTilt matches={[]} />);
+    expect(screen.getByText('No match data to report yet.')).toBeInTheDocument();
+  });
+
+  it('renders headline stats and a recent-sessions table row', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: 1, win: false }),
+    ];
+    render(<SessionsAndTilt matches={matches} />);
+
+    expect(screen.getByText('Total Sessions')).toBeInTheDocument();
+    expect(screen.getByText('Avg Games / Session')).toBeInTheDocument();
+    expect(screen.getByText('Best Session')).toBeInTheDocument();
+    expect(screen.getByText('Worst Tilt')).toBeInTheDocument();
+    expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+  });
+
+  it(`highlights a loss run >= ${TILT_HIGHLIGHT_THRESHOLD} with the destructive badge`, () => {
+    const matches = [
+      makeMatch({ id: '1', time: 0, win: false }),
+      makeMatch({ id: '2', time: 1, win: false }),
+      makeMatch({ id: '3', time: 2, win: false }),
+    ];
+    render(<SessionsAndTilt matches={matches} />);
+
+    const badge = document.querySelector('[data-slot="badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge).toHaveTextContent('3');
+    expect(badge?.className).toContain('destructive');
+  });
+
+  it('does not highlight a loss run below the threshold', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 0, win: false }),
+      makeMatch({ id: '2', time: 1, win: true }),
+    ];
+    render(<SessionsAndTilt matches={matches} />);
+
+    // Longest loss run of 1 rendered as plain text, not a badge.
+    const cell = screen.getAllByRole('cell').find((c) => c.textContent === '1');
+    expect(cell?.querySelector('[data-slot="badge"]')).toBeNull();
+  });
+});

--- a/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
+++ b/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
@@ -1,0 +1,182 @@
+import type { Match } from '@smash-tracker/shared';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getSessions, type SessionStats } from '@/lib/stats';
+
+/** Loss runs at or above this length are highlighted in destructive tone in the recent-sessions table. */
+export const TILT_HIGHLIGHT_THRESHOLD = 3;
+
+/** How many of the most recent sessions to list in the table. */
+const RECENT_SESSION_LIMIT = 10;
+
+export interface SessionsHeadline {
+  totalSessions: number;
+  /** Average games per session, rounded to 1 decimal. 0 when there are no sessions. */
+  avgGamesPerSession: number;
+  /** The session with the best net wins (wins - losses); null when there are no sessions. */
+  bestSession: SessionStats | null;
+  /** The session containing the single longest intra-session loss run ("worst tilt"); null when there are no sessions or no losses at all. */
+  worstTiltSession: SessionStats | null;
+}
+
+/**
+ * Headline stats for the sessions section. Exported as a pure builder so the
+ * "best session" / "worst tilt" tie-break math can be unit-tested without
+ * rendering. Ties for best session break toward the earliest session (stable
+ * sort over `getSessions`' chronological order); ties for worst tilt do the
+ * same.
+ */
+export function buildSessionsHeadline(sessions: SessionStats[]): SessionsHeadline {
+  if (sessions.length === 0) {
+    return { totalSessions: 0, avgGamesPerSession: 0, bestSession: null, worstTiltSession: null };
+  }
+
+  const totalGames = sessions.reduce((sum, s) => sum + s.total, 0);
+  const avgGamesPerSession = Math.round((totalGames / sessions.length) * 10) / 10;
+
+  const bestSession = sessions.reduce((best, session) => {
+    const bestNet = best.wins - best.losses;
+    const net = session.wins - session.losses;
+    return net > bestNet ? session : best;
+  }, sessions[0]!);
+
+  const maxLossRun = Math.max(...sessions.map((s) => s.longestLossRun));
+  const worstTiltSession =
+    maxLossRun > 0 ? (sessions.find((s) => s.longestLossRun === maxLossRun) ?? null) : null;
+
+  return { totalSessions: sessions.length, avgGamesPerSession, bestSession, worstTiltSession };
+}
+
+function formatDate(time: number): string {
+  return new Date(time).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatDuration(session: SessionStats): string {
+  const ms = session.end - session.start;
+  if (ms <= 0) return '< 1 min';
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+}
+
+/**
+ * V3 Phase F: session grouping (default gap from `getSessions`) with a
+ * headline stats row and a recent-sessions table. "Tilt" = the longest
+ * intra-session loss streak; the worst one across all sessions is called out
+ * by date.
+ */
+export function SessionsAndTilt({ matches }: { matches: Match[] }) {
+  const sessions = getSessions(matches);
+  const headline = buildSessionsHeadline(sessions);
+  const recentSessions = [...sessions].reverse().slice(0, RECENT_SESSION_LIMIT);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sessions &amp; Tilt</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Headline label="Total Sessions" value={headline.totalSessions} />
+              <Headline label="Avg Games / Session" value={headline.avgGamesPerSession} />
+              <Headline
+                label="Best Session"
+                value={
+                  headline.bestSession
+                    ? `${headline.bestSession.wins}-${headline.bestSession.losses}`
+                    : '—'
+                }
+                sub={headline.bestSession ? formatDate(headline.bestSession.start) : undefined}
+              />
+              <Headline
+                label="Worst Tilt"
+                value={
+                  headline.worstTiltSession
+                    ? `${headline.worstTiltSession.longestLossRun}L run`
+                    : '—'
+                }
+                sub={
+                  headline.worstTiltSession
+                    ? formatDate(headline.worstTiltSession.start)
+                    : undefined
+                }
+                tone={headline.worstTiltSession ? 'destructive' : undefined}
+              />
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Duration</TableHead>
+                  <TableHead>W-L</TableHead>
+                  <TableHead>Rate</TableHead>
+                  <TableHead>Longest Loss Run</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {recentSessions.map((session) => (
+                  <TableRow key={session.start}>
+                    <TableCell>{formatDate(session.start)}</TableCell>
+                    <TableCell>{formatDuration(session)}</TableCell>
+                    <TableCell>
+                      {session.wins}-{session.losses}
+                    </TableCell>
+                    <TableCell>{session.winRate}%</TableCell>
+                    <TableCell>
+                      {session.longestLossRun >= TILT_HIGHLIGHT_THRESHOLD ? (
+                        <Badge variant="destructive">{session.longestLossRun}</Badge>
+                      ) : (
+                        session.longestLossRun
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Headline({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  tone?: 'destructive';
+}) {
+  return (
+    <div>
+      <h3 className="text-sm text-muted-foreground">{label}</h3>
+      <p className={`text-xl font-semibold ${tone === 'destructive' ? 'text-destructive' : ''}`}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Trends/components/SettingComparison.test.tsx
+++ b/apps/web/src/pages/Trends/components/SettingComparison.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match } from '@smash-tracker/shared';
+import { SettingComparison, TAKEAWAY_MIN_SAMPLE, buildSettingTakeaway } from './SettingComparison';
+import { getOnlineOfflineSplit } from '@/lib/stats';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+function matchesOfType(count: number, type: Match['matchType'], winCount: number): Match[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeMatch({ id: `${type}-${i}`, time: i, win: i < winCount, matchType: type }),
+  );
+}
+
+describe('buildSettingTakeaway', () => {
+  it('reports small-sample when either side is under the threshold', () => {
+    const split = getOnlineOfflineSplit([
+      ...matchesOfType(TAKEAWAY_MIN_SAMPLE - 1, 'quickplay', TAKEAWAY_MIN_SAMPLE - 1),
+      ...matchesOfType(TAKEAWAY_MIN_SAMPLE, 'offline-friendly', 5),
+    ]);
+    expect(buildSettingTakeaway(split)).toEqual({ kind: 'small-sample' });
+  });
+
+  it('reports a takeaway favoring online when both sides meet the threshold and online is higher', () => {
+    const split = getOnlineOfflineSplit([
+      ...matchesOfType(10, 'quickplay', 8), // 80%
+      ...matchesOfType(10, 'offline-friendly', 5), // 50%
+    ]);
+    const takeaway = buildSettingTakeaway(split);
+    expect(takeaway.kind).toBe('takeaway');
+    expect(takeaway.better).toBe('online');
+    expect(takeaway.deltaPoints).toBe(30);
+  });
+
+  it('reports a takeaway favoring offline when offline is higher', () => {
+    const split = getOnlineOfflineSplit([
+      ...matchesOfType(10, 'quickplay', 3), // 30%
+      ...matchesOfType(10, 'offline-friendly', 7), // 70%
+    ]);
+    const takeaway = buildSettingTakeaway(split);
+    expect(takeaway.kind).toBe('takeaway');
+    expect(takeaway.better).toBe('offline');
+    expect(takeaway.deltaPoints).toBe(40);
+  });
+
+  it('reports a zero delta as even when rates match exactly', () => {
+    const split = getOnlineOfflineSplit([
+      ...matchesOfType(10, 'quickplay', 5),
+      ...matchesOfType(10, 'offline-friendly', 5),
+    ]);
+    const takeaway = buildSettingTakeaway(split);
+    expect(takeaway.kind).toBe('takeaway');
+    expect(takeaway.deltaPoints).toBe(0);
+  });
+});
+
+describe('SettingComparison component', () => {
+  it('shows an empty state with no match data', () => {
+    render(<SettingComparison matches={[]} />);
+    expect(screen.getByText('No match data to report yet.')).toBeInTheDocument();
+  });
+
+  it('renders the three stat blocks', () => {
+    const matches = [
+      ...matchesOfType(2, 'quickplay', 1),
+      ...matchesOfType(2, 'offline-friendly', 1),
+    ];
+    render(<SettingComparison matches={matches} />);
+
+    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+    expect(screen.getByText('Unspecified')).toBeInTheDocument();
+  });
+
+  it('shows the small-sample note instead of a takeaway when samples are thin', () => {
+    const matches = [
+      ...matchesOfType(2, 'quickplay', 1),
+      ...matchesOfType(2, 'offline-friendly', 1),
+    ];
+    render(<SettingComparison matches={matches} />);
+
+    expect(
+      screen.getByText(
+        `Need at least ${TAKEAWAY_MIN_SAMPLE} games both online and offline for a reliable comparison.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the one-line takeaway when both samples meet the threshold', () => {
+    const matches = [
+      ...matchesOfType(10, 'quickplay', 8),
+      ...matchesOfType(10, 'offline-friendly', 5),
+    ];
+    render(<SettingComparison matches={matches} />);
+
+    expect(screen.getByText(/more online than offline/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Trends/components/SettingComparison.tsx
+++ b/apps/web/src/pages/Trends/components/SettingComparison.tsx
@@ -1,0 +1,104 @@
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getOnlineOfflineSplit, type OnlineOfflineSplit, type WinLossRecord } from '@/lib/stats';
+
+/** Minimum sample size (each side) required before the takeaway line is shown, rather than a small-sample note. */
+export const TAKEAWAY_MIN_SAMPLE = 10;
+
+export interface SettingTakeaway {
+  kind: 'takeaway' | 'small-sample';
+  /** Populated when `kind === 'takeaway'`: which setting wins and by how many points. Absolute value; sign is implied by `better`. */
+  deltaPoints?: number;
+  better?: 'online' | 'offline';
+}
+
+/**
+ * Builds the one-line online-vs-offline takeaway. Only compares when both
+ * samples meet `TAKEAWAY_MIN_SAMPLE`; otherwise reports `small-sample` so the
+ * caller renders a neutral note instead of a possibly-noisy claim. A tie
+ * (equal win rate) reports `better: 'online'` with a zero delta — callers
+ * should treat a zero delta as "even", not "online wins".
+ */
+export function buildSettingTakeaway(split: OnlineOfflineSplit): SettingTakeaway {
+  if (split.online.total < TAKEAWAY_MIN_SAMPLE || split.offline.total < TAKEAWAY_MIN_SAMPLE) {
+    return { kind: 'small-sample' };
+  }
+  const delta = split.online.winRate - split.offline.winRate;
+  return {
+    kind: 'takeaway',
+    deltaPoints: Math.abs(delta),
+    better: delta >= 0 ? 'online' : 'offline',
+  };
+}
+
+/**
+ * V3 Phase F: online vs offline vs unspecified setting comparison. Three
+ * stat blocks plus a one-line takeaway, gated on both online and offline
+ * having at least `TAKEAWAY_MIN_SAMPLE` games.
+ */
+export function SettingComparison({ matches }: { matches: Match[] }) {
+  const split = getOnlineOfflineSplit(matches);
+  const takeaway = buildSettingTakeaway(split);
+  const hasAny = split.online.total > 0 || split.offline.total > 0 || split.unspecified.total > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Setting Comparison</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {!hasAny ? (
+          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <SettingBlock label="Online" record={split.online} />
+              <SettingBlock label="Offline" record={split.offline} />
+              <SettingBlock label="Unspecified" record={split.unspecified} />
+            </div>
+
+            {takeaway.kind === 'takeaway' ? (
+              <p className="text-sm">
+                {takeaway.deltaPoints === 0 ? (
+                  <span>You win about the same rate online and offline.</span>
+                ) : (
+                  <span>
+                    You win{' '}
+                    <span className="font-semibold text-foreground">{takeaway.deltaPoints}%</span>{' '}
+                    more{' '}
+                    {takeaway.better === 'online' ? 'online than offline' : 'offline than online'}.
+                  </span>
+                )}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Need at least {TAKEAWAY_MIN_SAMPLE} games both online and offline for a reliable
+                comparison.
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SettingBlock({ label, record }: { label: string; record: WinLossRecord }) {
+  if (record.total === 0) {
+    return (
+      <div className="rounded-md border p-3">
+        <h3 className="text-sm text-muted-foreground">{label}</h3>
+        <p className="text-sm text-muted-foreground">no data</p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border p-3">
+      <h3 className="text-sm text-muted-foreground">{label}</h3>
+      <p className="text-2xl font-semibold">{record.winRate}%</p>
+      <p className="text-xs text-muted-foreground">
+        {record.wins}-{record.losses} ({record.total} games)
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Trends/components/Tournaments.test.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import type { Match } from '@smash-tracker/shared';
+import { Tournaments, buildTournamentSummaries } from './Tournaments';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('buildTournamentSummaries', () => {
+  it('excludes matches without a tournamentName', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true }),
+      makeMatch({ id: '2', time: 2, win: false, tournamentName: '' }),
+    ];
+    expect(buildTournamentSummaries(matches)).toEqual([]);
+  });
+
+  it('groups matches by tournamentName, computing date range and record', () => {
+    const matches = [
+      makeMatch({
+        id: '1',
+        time: Date.UTC(2021, 0, 1),
+        win: true,
+        tournamentName: 'The Big House 9',
+        eventName: 'Ultimate Singles',
+        source: 'startgg',
+      }),
+      makeMatch({
+        id: '2',
+        time: Date.UTC(2021, 0, 3),
+        win: false,
+        tournamentName: 'The Big House 9',
+        eventName: 'Ultimate Singles',
+        source: 'startgg',
+      }),
+    ];
+    const summaries = buildTournamentSummaries(matches);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      tournamentName: 'The Big House 9',
+      eventNames: ['Ultimate Singles'],
+      wins: 1,
+      losses: 1,
+      total: 2,
+    });
+    expect(summaries[0]?.startTime).toBe(Date.UTC(2021, 0, 1));
+    expect(summaries[0]?.endTime).toBe(Date.UTC(2021, 0, 3));
+  });
+
+  it('collects distinct event names in first-seen order', () => {
+    const matches = [
+      makeMatch({
+        id: '1',
+        time: 1,
+        win: true,
+        tournamentName: 'Genesis 9',
+        eventName: 'Singles',
+      }),
+      makeMatch({
+        id: '2',
+        time: 2,
+        win: true,
+        tournamentName: 'Genesis 9',
+        eventName: 'Doubles',
+      }),
+      makeMatch({
+        id: '3',
+        time: 3,
+        win: true,
+        tournamentName: 'Genesis 9',
+        eventName: 'Singles',
+      }),
+    ];
+    const summaries = buildTournamentSummaries(matches);
+    expect(summaries[0]?.eventNames).toEqual(['Singles', 'Doubles']);
+  });
+
+  it('sorts tournaments by most recent (endTime descending)', () => {
+    const matches = [
+      makeMatch({ id: '1', time: Date.UTC(2020, 0, 1), win: true, tournamentName: 'Older Event' }),
+      makeMatch({ id: '2', time: Date.UTC(2022, 0, 1), win: true, tournamentName: 'Newer Event' }),
+    ];
+    const summaries = buildTournamentSummaries(matches);
+    expect(summaries.map((s) => s.tournamentName)).toEqual(['Newer Event', 'Older Event']);
+  });
+});
+
+function renderTournaments(matches: Match[]) {
+  return render(
+    <MemoryRouter>
+      <Tournaments matches={matches} />
+    </MemoryRouter>,
+  );
+}
+
+describe('Tournaments component', () => {
+  it('shows the resync hint when no match has a tournamentName', () => {
+    const matches = [makeMatch({ id: '1', time: 1, win: true })];
+    renderTournaments(matches);
+
+    expect(
+      screen.getByText(/Tournament names attach on your next start\.gg sync/),
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Integrations' });
+    expect(link).toHaveAttribute('href', '/settings/integrations');
+  });
+
+  it('renders a table row per tournament when tournamentName data exists', () => {
+    const matches = [
+      makeMatch({
+        id: '1',
+        time: 1,
+        win: true,
+        tournamentName: 'The Big House 9',
+        eventName: 'Ultimate Singles',
+      }),
+    ];
+    renderTournaments(matches);
+
+    expect(screen.getByText('The Big House 9')).toBeInTheDocument();
+    expect(screen.getByText('Ultimate Singles')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Tournament names attach on your next start\.gg sync/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Trends/components/Tournaments.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.tsx
@@ -1,0 +1,142 @@
+import { Link } from 'react-router';
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getWinLossRecord } from '@/lib/stats';
+
+export interface TournamentSummary {
+  tournamentName: string;
+  /** Distinct event names within this tournament, in first-seen order. */
+  eventNames: string[];
+  /** Epoch ms of the earliest and latest match in this tournament. */
+  startTime: number;
+  endTime: number;
+  wins: number;
+  losses: number;
+  total: number;
+  winRate: number;
+}
+
+/**
+ * Groups matches that have a `tournamentName` set, one summary row per
+ * tournament, sorted by most recent (`endTime` descending). Matches missing
+ * `tournamentName` are excluded entirely — callers use that to detect the
+ * "no tournament names yet" resync-hint state. Exported as a pure builder so
+ * the grouping/date-range/sort math is unit-testable without rendering.
+ */
+export function buildTournamentSummaries(matches: Match[]): TournamentSummary[] {
+  const withTournament = matches.filter(
+    (m): m is Match & { tournamentName: string } =>
+      m.tournamentName != null && m.tournamentName !== '',
+  );
+
+  const byTournament = new Map<string, Match[]>();
+  for (const match of withTournament) {
+    const group = byTournament.get(match.tournamentName);
+    if (group) {
+      group.push(match);
+    } else {
+      byTournament.set(match.tournamentName, [match]);
+    }
+  }
+
+  const summaries: TournamentSummary[] = [...byTournament.entries()].map(([tournamentName, ms]) => {
+    const sorted = [...ms].sort((a, b) => a.time - b.time);
+    const eventNames: string[] = [];
+    for (const m of sorted) {
+      if (m.eventName && !eventNames.includes(m.eventName)) {
+        eventNames.push(m.eventName);
+      }
+    }
+    const record = getWinLossRecord(ms);
+    return {
+      tournamentName,
+      eventNames,
+      startTime: sorted[0]!.time,
+      endTime: sorted[sorted.length - 1]!.time,
+      ...record,
+    };
+  });
+
+  return summaries.sort((a, b) => b.endTime - a.endTime);
+}
+
+function formatDate(time: number): string {
+  return new Date(time).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatDateRange(summary: TournamentSummary): string {
+  const start = formatDate(summary.startTime);
+  const end = formatDate(summary.endTime);
+  return start === end ? start : `${start} – ${end}`;
+}
+
+/**
+ * V3 Phase F: per-tournament results, grouped from matches carrying the
+ * optional `tournamentName`/`eventName` fields (Phase B sync enrichment).
+ * Imported matches synced before that enrichment shipped lack these fields
+ * entirely, so when no match has a `tournamentName` this renders a friendly
+ * resync hint instead of an empty table.
+ */
+export function Tournaments({ matches }: { matches: Match[] }) {
+  const summaries = buildTournamentSummaries(matches);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tournaments</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {summaries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Tournament names attach on your next start.gg sync — head to{' '}
+            <Link to="/settings/integrations" className="font-medium text-primary underline">
+              Integrations
+            </Link>{' '}
+            and hit Sync now.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Tournament</TableHead>
+                <TableHead>Event(s)</TableHead>
+                <TableHead>Dates</TableHead>
+                <TableHead>W-L</TableHead>
+                <TableHead>Rate</TableHead>
+                <TableHead>Games</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {summaries.map((summary) => (
+                <TableRow key={summary.tournamentName}>
+                  <TableCell className="font-medium">{summary.tournamentName}</TableCell>
+                  <TableCell className="whitespace-normal">
+                    {summary.eventNames.length > 0 ? summary.eventNames.join(', ') : '—'}
+                  </TableCell>
+                  <TableCell>{formatDateRange(summary)}</TableCell>
+                  <TableCell>
+                    {summary.wins}-{summary.losses}
+                  </TableCell>
+                  <TableCell>{summary.winRate}%</TableCell>
+                  <TableCell>{summary.total}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -5,6 +5,7 @@ import { ChoosePrimaryPage } from '@/pages/CharacterSelect/ChoosePrimaryPage';
 import { ChooseSecondaryPage } from '@/pages/CharacterSelect/ChooseSecondaryPage';
 import { MatchupsPage } from '@/pages/Matchups/MatchupsPage';
 import { MatchDataPage } from '@/pages/MatchData/MatchDataPage';
+import { TrendsPage } from '@/pages/Trends/TrendsPage';
 import { FighterAnalysisPage } from '@/pages/FighterAnalysis/FighterAnalysisPage';
 import { IntegrationsPage } from '@/pages/Integrations/IntegrationsPage';
 import { StartggAuthPage } from '@/pages/StartggAuth/StartggAuthPage';
@@ -67,6 +68,14 @@ export function AppRouter() {
           element={
             <ProtectedRoute>
               <MatchDataPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/trends"
+          element={
+            <ProtectedRoute>
+              <TrendsPage />
             </ProtectedRoute>
           }
         />


### PR DESCRIPTION
## Summary

Implements V3 Phase F (docs/analytics-vision.md) — a new `/trends` page, account-wide (not per-fighter), honoring the global source/time-range filter (`useFilteredMatches`) like the other analytics pages.

- **Monthly performance**: win-rate bar chart per month (`getMonthlyRecords`), games-played shown in the tooltip, months with < 3 games rendered at reduced opacity with a caption calling out the small-sample cue. Compact table below (month, W-L, rate, games), most recent first.
- **Sessions & tilt**: session grouping via `getSessions` (default 3h gap) with a headline row (total sessions, avg games/session, best session by net wins, "worst tilt" = longest intra-session loss run with its date) plus a recent-sessions table; loss runs ≥ 3 highlighted with the `destructive` badge variant.
- **Setting comparison**: online/offline/unspecified stat blocks (`getOnlineOfflineSplit`) with a one-line takeaway ("You win X% more online than offline") gated on both online and offline samples being ≥ 10 games; otherwise a small-sample note.
- **Tournaments**: groups matches carrying `tournamentName` (name, event name(s), date range, W-L, rate, games; sorted most-recent-first). When **no** match has `tournamentName` (pre-enrichment synced data), renders the requested friendly hint instead of an empty table: "Tournament names attach on your next start.gg sync — head to Integrations and hit Sync now," linking to `/settings/integrations`.
- **Match-type mix over time**: included (not skipped) — a simple stacked bar of games/month split into tourney/friendly/quickplay/unspecified buckets, reusing the existing chart theme.

Nav entry "Trends" (TrendingUp icon) added immediately after "Match Data"; route `/trends` added to `AppRouter.tsx`, wrapped in `ProtectedRoute`.

## Test plan

- [x] `pnpm lint` — 0 errors (25 pre-existing-pattern `react-refresh/only-export-components` warnings, consistent with existing files like `LastMatchesChart.tsx` that export both a component and pure builders)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 297 passed (24 shared + 69 api + **204 web**, up from 162 before this branch: **42 new tests** across 6 new test files — pure builder math for monthly bucketing/opacity, session headline tie-breaks, setting takeaway thresholds, tournament grouping + the no-tournament-names hint, plus page-wrapper tests with `mockAuth`/`AnalyticsFilterProvider`/`api.matches.list` mocking)
- [x] `pnpm build` — succeeds
- [x] `pnpm format:check` — clean
- [x] Manual verification: since the Chrome MCP extension and the `preview_start` tool were both unavailable/misrouted in this sandboxed worktree (the launch config resolved to the sibling main checkout instead of this worktree), verification was done by running a local Vite dev server rooted in this worktree and confirming every new module + a temporary in-repo seeded harness (matches with and without `tournamentName`/`eventName`, small-sample months, a 3-loss tilt run) compiled and served without error, alongside the full automated test suite exercising every rendered state (empty states, resync hint, tilt highlight, takeaway gating). The harness was **fully reverted** before committing — `git diff` on `main.tsx` is empty and no extra files remain.

## Notes

- Only touched: new files under `apps/web/src/pages/Trends/**`, one nav entry in `apps/web/src/layouts/nav.ts`, one route in `apps/web/src/routes/AppRouter.tsx`. No changes to `stats.ts`, hooks, api, or other shared files.
- **Rebase heads-up**: if the `/opponents` page PR (Matchups → Match Data ordering: Matchups, **Opponents**, Match Data, **Trends**) lands first, this branch's rebase will likely hit a trivial adjacency conflict in `nav.ts`/`AppRouter.tsx` — resolve by keeping both entries (Opponents between Matchups and Match Data; Trends after Match Data).
- Do not merge — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)