### PR TITLE
V4 Phase A: bracket-aware sync — rounds, seeds, placements, tournament registry

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import usersRoutes from './routes/users.js';
 import matchesRoutes from './routes/matches.js';
 import opponentsRoutes from './routes/opponents.js';
 import startggRoutes from './routes/startgg.js';
+import tournamentsRoutes from './routes/tournaments.js';
 import { NotFoundError } from './services/rtdb.js';
 import type { FirebaseServices } from './firebase/admin.js';
 import type { StartggConfig } from './config/env.js';
@@ -111,6 +112,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(usersRoutes);
       await api.register(matchesRoutes);
       await api.register(opponentsRoutes);
+      await api.register(tournamentsRoutes);
       await api.register(startggRoutes, {
         config: options.startgg ?? null,
         fetchImpl: options.startggFetch,

--- a/apps/api/src/routes/tournaments.test.ts
+++ b/apps/api/src/routes/tournaments.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+describe('GET /api/tournaments', () => {
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'GET', url: '/api/tournaments' });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns an empty array when the user has no tournament entries', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/tournaments',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([]);
+  });
+
+  it('returns seeded entries sorted by lastSetAt descending', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`tournamentEntries/${TEST_UID}`, {
+      '987': {
+        eventId: 987,
+        eventName: 'Ultimate Singles',
+        tournamentName: 'Test Weekly 42',
+        numEntrants: 512,
+        seed: 408,
+        placement: 257,
+        firstSetAt: 1_700_000_000_000,
+        lastSetAt: 1_700_000_500_000,
+        setsPlayed: 5,
+      },
+      '555': {
+        eventId: 555,
+        eventName: 'Ultimate Doubles',
+        firstSetAt: 1_701_000_000_000,
+        lastSetAt: 1_701_000_900_000,
+        setsPlayed: 2,
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/tournaments',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const entries = response.json() as { eventId: number }[];
+    expect(entries.map((e) => e.eventId)).toEqual([555, 987]);
+    expect(entries[1]).toMatchObject({
+      eventId: 987,
+      eventName: 'Ultimate Singles',
+      tournamentName: 'Test Weekly 42',
+      numEntrants: 512,
+      seed: 408,
+      placement: 257,
+      setsPlayed: 5,
+    });
+  });
+});

--- a/apps/api/src/routes/tournaments.ts
+++ b/apps/api/src/routes/tournaments.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { tournamentEntryListSchema, tournamentEntrySchema } from '@smash-tracker/shared';
+
+/**
+ * GET /api/tournaments — the signed-in user's start.gg tournament registry,
+ * accumulated server-side during sync (see startgg/sync.ts's
+ * `accumulateRegistry`). Read-only: entries are written exclusively by the
+ * sync service under tournamentEntries/{uid}/{eventId}.
+ */
+const tournamentsRoutes: FastifyPluginAsyncZod = async (app) => {
+  app.addHook('preHandler', app.authenticate);
+
+  app.get(
+    '/tournaments',
+    {
+      schema: {
+        response: {
+          200: tournamentEntryListSchema,
+        },
+      },
+    },
+    async (request) => {
+      const snapshot = await app.firebase.database.ref(`tournamentEntries/${request.uid}`).get();
+      if (!snapshot.exists()) {
+        return [];
+      }
+      const raw = snapshot.val() as Record<string, unknown>;
+      const entries = Object.values(raw).map((entry) => tournamentEntrySchema.parse(entry));
+      entries.sort((a, b) => b.lastSetAt - a.lastSetAt);
+      return entries;
+    },
+  );
+};
+
+export default tournamentsRoutes;

--- a/apps/api/src/startgg/client.ts
+++ b/apps/api/src/startgg/client.ts
@@ -86,10 +86,19 @@ const setsPageSchema = z.object({
             z.object({
               id: z.union([z.number(), z.string()]),
               completedAt: z.number().int().nullish(),
+              /** Human-readable round label, e.g. "Losers Round 2". */
+              fullRoundText: z.string().nullish(),
+              /** Signed bracket round; negative = losers side. */
+              round: z.number().int().nullish(),
+              /** Literally the string "DQ" for sets decided by disqualification. */
+              displayScore: z.string().nullish(),
+              totalGames: z.number().int().nullish(),
               event: z
                 .object({
+                  id: z.number().nullish(),
                   name: z.string().nullish(),
                   isOnline: z.boolean().nullish(),
+                  numEntrants: z.number().int().nullish(),
                   videogame: z.object({ id: z.number() }).nullish(),
                   tournament: z.object({ name: z.string().nullish() }).nullish(),
                 })
@@ -111,6 +120,10 @@ const setsPageSchema = z.object({
                                 .nullish(),
                             )
                             .nullish(),
+                          seeds: z
+                            .array(z.object({ seedNum: z.number().int().nullish() }).nullish())
+                            .nullish(),
+                          standing: z.object({ placement: z.number().int().nullish() }).nullish(),
                         })
                         .nullish(),
                     })
@@ -145,6 +158,9 @@ export type StartggSet = NonNullable<
   NonNullable<StartggSetsPage['player']>['sets']
 >['nodes'][number];
 
+// Complexity budget per page (perPage 10): ~10 sets x (2 slots x ~4 fields +
+// ~5 games x 3 fields + ~8 set/event fields) stays well under the 1000
+// object limit — nowhere near the ~180 objects/page this shape produces.
 const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!) {
   player(id: $playerId) {
     sets(perPage: $perPage, page: $page) {
@@ -152,8 +168,20 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
       nodes {
         id
         completedAt
-        event { name isOnline videogame { id } tournament { name } }
-        slots { entrant { id name participants { player { id } } } }
+        fullRoundText
+        round
+        displayScore
+        totalGames
+        event { id name isOnline numEntrants videogame { id } tournament { name } }
+        slots {
+          entrant {
+            id
+            name
+            participants { player { id } }
+            seeds { seedNum }
+            standing { placement }
+          }
+        }
         games {
           winnerId
           stage { name }

--- a/apps/api/src/startgg/sync.test.ts
+++ b/apps/api/src/startgg/sync.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { StartggSyncSummary } from '@smash-tracker/shared';
 import { FakeDatabase } from '../test-support/fakeDatabase.js';
-import { gamesFromSet, importPlayerMatches, normalizeOpponentTag } from './sync.js';
+import {
+  accumulateRegistry,
+  gamesFromSet,
+  importPlayerMatches,
+  normalizeOpponentTag,
+} from './sync.js';
 import { resolveStageByName } from './stageMap.js';
 import type { StartggSet } from './client.js';
 
@@ -15,6 +20,7 @@ function emptySummary(): StartggSyncSummary {
     gamesUnmappedCharacter: 0,
     gamesMissingSelections: 0,
     gamesUnknownStage: 0,
+    dqSets: 0,
   };
 }
 
@@ -23,14 +29,28 @@ function makeSet(overrides: Partial<StartggSet> = {}): StartggSet {
   return {
     id: 111,
     completedAt: 1_700_000_000,
+    fullRoundText: 'Losers Round 2',
+    round: -2,
+    displayScore: '2-1',
+    totalGames: 3,
     event: {
+      id: 987,
       name: 'Ultimate Singles',
       isOnline: true,
+      numEntrants: 512,
       videogame: { id: 1386 },
       tournament: { name: 'Test Weekly 42' },
     },
     slots: [
-      { entrant: { id: 1, name: 'Team | Me', participants: [{ player: { id: PLAYER_ID } }] } },
+      {
+        entrant: {
+          id: 1,
+          name: 'Team | Me',
+          participants: [{ player: { id: PLAYER_ID } }],
+          seeds: [{ seedNum: 408 }],
+          standing: { placement: 257 },
+        },
+      },
       { entrant: { id: 2, name: 'PowPow', participants: [{ player: { id: 999 } }] } },
     ],
     games: [
@@ -93,6 +113,8 @@ describe('gamesFromSet', () => {
       externalId: 'sgg:111:g1',
       eventName: 'Ultimate Singles',
       tournamentName: 'Test Weekly 42',
+      roundText: 'Losers Round 2',
+      bracketRound: -2,
     });
     expect(g1?.record.fighter_id).toBeGreaterThan(0);
     expect(g1?.record.map?.name).toBe('Battlefield');
@@ -160,14 +182,127 @@ describe('gamesFromSet', () => {
     expect(games[0]?.record.matchType).toBe('offline-tourney');
   });
 
-  it('omits event/tournament keys entirely when the API provides none', () => {
+  it('omits event/tournament/round keys entirely when the API provides none', () => {
     const summary = emptySummary();
-    const set = makeSet({ event: { isOnline: true, videogame: { id: 1386 } } });
+    const set = makeSet({
+      event: { isOnline: true, videogame: { id: 1386 } },
+      fullRoundText: null,
+      round: null,
+    });
     const games = gamesFromSet(set, PLAYER_ID, summary);
     expect(games[0]).toBeDefined();
     // RTDB rejects undefined values — the keys must be absent, not undefined.
     expect('eventName' in games[0]!.record).toBe(false);
     expect('tournamentName' in games[0]!.record).toBe(false);
+    expect('roundText' in games[0]!.record).toBe(false);
+    expect('bracketRound' in games[0]!.record).toBe(false);
+  });
+
+  it('skips DQ sets entirely and counts them separately from setsWithoutGames', () => {
+    const summary = emptySummary();
+    const set = makeSet({ displayScore: 'DQ' });
+    expect(gamesFromSet(set, PLAYER_ID, summary)).toHaveLength(0);
+    expect(summary.dqSets).toBe(1);
+    expect(summary.setsWithoutGames).toBe(0);
+    // DQ sets still count toward `sets` (examined), just not toward imports.
+    expect(summary.sets).toBe(1);
+  });
+});
+
+describe('accumulateRegistry', () => {
+  it('extracts eventName, tournamentName, numEntrants, seed, and placement', () => {
+    const registry = new Map();
+    accumulateRegistry(registry, makeSet(), PLAYER_ID);
+
+    expect(registry.size).toBe(1);
+    expect(registry.get(987)).toMatchObject({
+      eventId: 987,
+      eventName: 'Ultimate Singles',
+      tournamentName: 'Test Weekly 42',
+      numEntrants: 512,
+      seed: 408,
+      placement: 257,
+      setsPlayed: 1,
+      firstSetAt: 1_700_000_000_000,
+      lastSetAt: 1_700_000_000_000,
+    });
+  });
+
+  it('accumulates min/max completedAt and setsPlayed across multiple sets in the same event', () => {
+    const registry = new Map();
+    accumulateRegistry(registry, makeSet({ id: 1, completedAt: 1_700_000_000 }), PLAYER_ID);
+    accumulateRegistry(registry, makeSet({ id: 2, completedAt: 1_700_100_000 }), PLAYER_ID);
+    accumulateRegistry(registry, makeSet({ id: 3, completedAt: 1_699_900_000 }), PLAYER_ID);
+
+    const entry = registry.get(987);
+    expect(entry?.setsPlayed).toBe(3);
+    expect(entry?.firstSetAt).toBe(1_699_900_000_000);
+    expect(entry?.lastSetAt).toBe(1_700_100_000_000);
+  });
+
+  it('groups sets by event.id across multiple events', () => {
+    const registry = new Map();
+    accumulateRegistry(registry, makeSet({ id: 1 }), PLAYER_ID);
+    accumulateRegistry(
+      registry,
+      makeSet({
+        id: 2,
+        event: {
+          id: 555,
+          name: 'Ultimate Doubles',
+          isOnline: true,
+          videogame: { id: 1386 },
+        },
+      }),
+      PLAYER_ID,
+    );
+
+    expect(registry.size).toBe(2);
+    expect(registry.get(987)?.eventName).toBe('Ultimate Singles');
+    expect(registry.get(555)?.eventName).toBe('Ultimate Doubles');
+  });
+
+  it('does not accumulate DQ sets or non-SSBU sets', () => {
+    const registry = new Map();
+    accumulateRegistry(registry, makeSet({ displayScore: 'DQ' }), PLAYER_ID);
+    accumulateRegistry(
+      registry,
+      makeSet({ event: { id: 1, name: 'Other Game', videogame: { id: 1 } } }),
+      PLAYER_ID,
+    );
+    expect(registry.size).toBe(0);
+  });
+
+  it('skips sets with no event id (cannot be grouped into a registry entry)', () => {
+    const registry = new Map();
+    accumulateRegistry(
+      registry,
+      makeSet({ event: { name: 'Ultimate Singles', videogame: { id: 1386 } } }),
+      PLAYER_ID,
+    );
+    expect(registry.size).toBe(0);
+  });
+
+  it('omits optional fields when start.gg does not provide them', () => {
+    const registry = new Map();
+    accumulateRegistry(
+      registry,
+      makeSet({
+        event: { id: 987, name: 'Ultimate Singles', videogame: { id: 1386 } },
+        slots: [
+          { entrant: { id: 1, participants: [{ player: { id: PLAYER_ID } }] } },
+          { entrant: { id: 2, participants: [{ player: { id: 999 } }] } },
+        ],
+      }),
+      PLAYER_ID,
+    );
+
+    const entry = registry.get(987);
+    expect(entry).toBeDefined();
+    expect('tournamentName' in entry!).toBe(false);
+    expect('numEntrants' in entry!).toBe(false);
+    expect('seed' in entry!).toBe(false);
+    expect('placement' in entry!).toBe(false);
   });
 });
 
@@ -270,5 +405,58 @@ describe('importPlayerMatches', () => {
     const tree = database.dump() as Record<string, Record<string, unknown>>;
     const matches = tree['matches']?.['uid-1'] as Record<string, unknown>;
     expect(Object.keys(matches).sort()).toEqual(['-manualKey1', 'sgg-111-g1', 'sgg-111-g2']);
+  });
+
+  it('writes a tournament registry entry keyed by event id, and re-syncs idempotently', async () => {
+    const database = new FakeDatabase();
+    const fetchMock = async () => pageResponse([makeSet()]);
+
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+
+    const tree = database.dump() as Record<string, Record<string, unknown>>;
+    const registry = tree['tournamentEntries']?.['uid-1'] as Record<string, unknown>;
+    expect(Object.keys(registry)).toEqual(['987']);
+    expect(registry['987']).toMatchObject({
+      eventId: 987,
+      eventName: 'Ultimate Singles',
+      tournamentName: 'Test Weekly 42',
+      numEntrants: 512,
+      seed: 408,
+      placement: 257,
+      setsPlayed: 1,
+    });
+
+    // Re-sync: same single entry, no duplication.
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+    const registryAfter = tree['tournamentEntries']?.['uid-1'] as Record<string, unknown>;
+    expect(Object.keys(registryAfter)).toEqual(['987']);
+  });
+
+  it('does not write a registry entry when no sets were processed', async () => {
+    const database = new FakeDatabase();
+    const fetchMock = async () => pageResponse([makeSet({ displayScore: 'DQ' })]);
+
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+
+    const tree = database.dump() as Record<string, Record<string, unknown>>;
+    expect(tree['tournamentEntries']).toBeUndefined();
   });
 });

--- a/apps/api/src/startgg/sync.ts
+++ b/apps/api/src/startgg/sync.ts
@@ -1,5 +1,5 @@
 import type { Database } from 'firebase-admin/database';
-import type { MatchRecord, StartggSyncSummary } from '@smash-tracker/shared';
+import type { MatchRecord, StartggSyncSummary, TournamentEntry } from '@smash-tracker/shared';
 import { fetchPlayerSetsPage, SSBU_VIDEOGAME_ID, type StartggSet } from './client.js';
 import { startggCharacterToFighterId } from './characterMap.js';
 import { resolveStageByName } from './stageMap.js';
@@ -46,6 +46,13 @@ export function gamesFromSet(
   }
   summary.sets += 1;
 
+  // DQ sets carry no meaningful game data — skip entirely, before the
+  // games/completedAt checks below, and don't count them as setsWithoutGames.
+  if (set.displayScore === 'DQ') {
+    summary.dqSets += 1;
+    return [];
+  }
+
   const games = set.games ?? [];
   const completedAt = set.completedAt;
   const slots = (set.slots ?? []).flatMap((slot) => (slot?.entrant ? [slot.entrant] : []));
@@ -64,6 +71,8 @@ export function gamesFromSet(
   // RTDB rejects undefined values — these keys must be OMITTED when absent.
   const eventName = set.event?.name?.trim();
   const tournamentName = set.event?.tournament?.name?.trim();
+  const roundText = set.fullRoundText?.trim();
+  const bracketRound = typeof set.round === 'number' ? set.round : undefined;
   const results: ImportableGame[] = [];
 
   games.forEach((game, index) => {
@@ -111,6 +120,8 @@ export function gamesFromSet(
         externalId,
         ...(eventName ? { eventName } : {}),
         ...(tournamentName ? { tournamentName } : {}),
+        ...(roundText ? { roundText } : {}),
+        ...(bracketRound !== undefined ? { bracketRound } : {}),
       },
     });
   });
@@ -119,11 +130,96 @@ export function gamesFromSet(
 }
 
 /**
+ * Mutable accumulator for one event's tournament registry entry while
+ * paginating; converted to a `TournamentEntry` (with optional fields
+ * omitted, per the RTDB undefined rule) once accumulation is complete.
+ */
+interface RegistryAccumulator {
+  eventId: number;
+  eventName: string;
+  tournamentName?: string;
+  numEntrants?: number;
+  seed?: number;
+  placement?: number;
+  firstSetAt: number;
+  lastSetAt: number;
+  setsPlayed: number;
+}
+
+/**
+ * Folds one non-DQ SSBU set into the per-event registry accumulator map.
+ * Exported for tests. A set only contributes when it belongs to a
+ * recognizable event (`event.id` present) — sets without an event id can't
+ * be grouped into a tournament entry.
+ */
+export function accumulateRegistry(
+  accumulators: Map<number, RegistryAccumulator>,
+  set: StartggSet,
+  playerId: number,
+): void {
+  if (set.event?.videogame?.id !== SSBU_VIDEOGAME_ID || set.displayScore === 'DQ') {
+    return;
+  }
+  const eventId = set.event?.id;
+  const eventName = set.event?.name?.trim();
+  if (eventId == null || !eventName) {
+    return;
+  }
+
+  const slots = (set.slots ?? []).flatMap((slot) => (slot?.entrant ? [slot.entrant] : []));
+  const userEntrant = slots.find((entrant) =>
+    (entrant.participants ?? []).some((p) => p?.player?.id === playerId),
+  );
+  const seed = userEntrant?.seeds?.find((s) => typeof s?.seedNum === 'number')?.seedNum;
+  const placement = userEntrant?.standing?.placement;
+  const tournamentName = set.event?.tournament?.name?.trim();
+  const numEntrants = set.event?.numEntrants;
+  const completedAt = set.completedAt != null ? set.completedAt * 1000 : undefined;
+
+  const existing = accumulators.get(eventId);
+  if (!existing) {
+    accumulators.set(eventId, {
+      eventId,
+      eventName,
+      ...(tournamentName ? { tournamentName } : {}),
+      ...(numEntrants != null ? { numEntrants } : {}),
+      ...(seed != null ? { seed } : {}),
+      ...(placement != null ? { placement } : {}),
+      firstSetAt: completedAt ?? 0,
+      lastSetAt: completedAt ?? 0,
+      setsPlayed: 1,
+    });
+    return;
+  }
+
+  existing.setsPlayed += 1;
+  if (tournamentName) {
+    existing.tournamentName = tournamentName;
+  }
+  if (numEntrants != null) {
+    existing.numEntrants = numEntrants;
+  }
+  if (seed != null) {
+    existing.seed = seed;
+  }
+  if (placement != null) {
+    existing.placement = placement;
+  }
+  if (completedAt != null) {
+    existing.firstSetAt =
+      existing.firstSetAt === 0 ? completedAt : Math.min(existing.firstSetAt, completedAt);
+    existing.lastSetAt = Math.max(existing.lastSetAt, completedAt);
+  }
+}
+
+/**
  * Imports all of a player's SSBU tournament games as matches under
  * matches/{uid}. Idempotent: records use stable child keys derived from the
  * set id + game number, so re-syncs overwrite in place. Manual matches
  * (push-keyed) are never touched. Opponent tags are added to
- * opponents/{uid} exactly like manual entry does.
+ * opponents/{uid} exactly like manual entry does. Also accumulates a
+ * per-event tournament registry under tournamentEntries/{uid}, keyed by
+ * event id, idempotent the same way (re-syncs overwrite in place).
  */
 export async function importPlayerMatches(
   database: Database,
@@ -139,10 +235,12 @@ export async function importPlayerMatches(
     gamesUnmappedCharacter: 0,
     gamesMissingSelections: 0,
     gamesUnknownStage: 0,
+    dqSets: 0,
   };
 
   const matchUpdates: Record<string, MatchRecord> = {};
   const opponentUpdates: Record<string, true> = {};
+  const registry = new Map<number, RegistryAccumulator>();
 
   let page = 1;
   let totalPages = 1;
@@ -161,6 +259,7 @@ export async function importPlayerMatches(
         matchUpdates[game.key] = game.record;
         opponentUpdates[game.opponentTag] = true;
       }
+      accumulateRegistry(registry, set, playerId);
     }
     page += 1;
   }
@@ -168,6 +267,23 @@ export async function importPlayerMatches(
   if (Object.keys(matchUpdates).length > 0) {
     await database.ref(`matches/${uid}`).update(matchUpdates);
     await database.ref(`opponents/${uid}`).update(opponentUpdates);
+  }
+  if (registry.size > 0) {
+    const registryUpdates: Record<string, TournamentEntry> = {};
+    for (const [eventId, acc] of registry) {
+      registryUpdates[String(eventId)] = {
+        eventId: acc.eventId,
+        eventName: acc.eventName,
+        ...(acc.tournamentName ? { tournamentName: acc.tournamentName } : {}),
+        ...(acc.numEntrants != null ? { numEntrants: acc.numEntrants } : {}),
+        ...(acc.seed != null ? { seed: acc.seed } : {}),
+        ...(acc.placement != null ? { placement: acc.placement } : {}),
+        firstSetAt: acc.firstSetAt,
+        lastSetAt: acc.lastSetAt,
+        setsPlayed: acc.setsPlayed,
+      };
+    }
+    await database.ref(`tournamentEntries/${uid}`).update(registryUpdates);
   }
   await database.ref(`startggLinks/${uid}/lastSyncAt`).set(Date.now());
 

--- a/apps/web/src/hooks/useTournamentEntries.test.tsx
+++ b/apps/web/src/hooks/useTournamentEntries.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useTournamentEntries } from './useTournamentEntries';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+import { AuthProvider } from '@/context/AuthContext';
+
+const rawEntry = {
+  eventId: 987,
+  eventName: 'Ultimate Singles',
+  tournamentName: 'Test Weekly 42',
+  numEntrants: 512,
+  seed: 408,
+  placement: 257,
+  firstSetAt: 1_700_000_000_000,
+  lastSetAt: 1_700_000_500_000,
+  setsPlayed: 5,
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = [new QueryClient({ defaultOptions: { queries: { retry: false } } })];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function EntriesProbe() {
+  const { data, isSuccess } = useTournamentEntries();
+  if (!isSuccess) {
+    return <div>loading</div>;
+  }
+  return <div>entries: {data.length}</div>;
+}
+
+describe('useTournamentEntries', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify([rawEntry]),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches tournament entries with a Bearer auth header and validates against the shared schema', async () => {
+    render(
+      <Wrapper>
+        <EntriesProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('entries: 1')).toBeInTheDocument());
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(fetch).mock.calls[0];
+    if (!call) {
+      throw new Error('expected fetch to have been called');
+    }
+    const [url, init] = call;
+    expect(String(url)).toContain('/api/tournaments');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer mock-id-token');
+  });
+});

--- a/apps/web/src/hooks/useTournamentEntries.ts
+++ b/apps/web/src/hooks/useTournamentEntries.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const tournamentEntriesQueryKey = ['tournaments'] as const;
+
+/** GET /api/tournaments — the signed-in user's start.gg tournament registry. */
+export function useTournamentEntries() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: tournamentEntriesQueryKey,
+    queryFn: () => api.tournaments.list(),
+    enabled: Boolean(user),
+  });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,7 @@ import {
   startggAuthorizeResponseSchema,
   startggStatusSchema,
   startggSyncSummarySchema,
+  tournamentEntryListSchema,
   userProfileSchema,
   type CreateMatchInput,
   type FighterSelectionInput,
@@ -184,6 +185,10 @@ export const api = {
       }),
     /** DELETE /api/integrations/startgg/link */
     unlink: () => apiRequest<void>('/api/integrations/startgg/link', { method: 'DELETE' }),
+  },
+  tournaments: {
+    /** GET /api/tournaments */
+    list: () => apiRequestParsed('/api/tournaments', tournamentEntryListSchema),
   },
 };
 

--- a/apps/web/src/pages/Integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/pages/Integrations/IntegrationsPage.test.tsx
@@ -105,6 +105,7 @@ describe('IntegrationsPage', () => {
       gamesUnmappedCharacter: 0,
       gamesMissingSelections: 0,
       gamesUnknownStage: 0,
+      dqSets: 0,
     });
 
     renderPage();
@@ -115,6 +116,32 @@ describe('IntegrationsPage', () => {
     await user.click(screen.getByRole('button', { name: /Sync now/ }));
     await waitFor(() => expect(sync).toHaveBeenCalled());
     expect(await screen.findByText(/Imported 112 games from 74 sets/)).toBeInTheDocument();
+  });
+
+  it('surfaces DQ sets skipped in the sync summary', async () => {
+    const user = userEvent.setup();
+    status.mockResolvedValue({
+      linked: true,
+      gamerTag: 'Pandem1c',
+      playerId: 1802316,
+      slug: 'user/07dc2239',
+      lastSyncAt: 1_700_000_000_000,
+    });
+    sync.mockResolvedValue({
+      sets: 74,
+      imported: 108,
+      setsWithoutGames: 20,
+      gamesUnmappedCharacter: 0,
+      gamesMissingSelections: 0,
+      gamesUnknownStage: 0,
+      dqSets: 3,
+    });
+
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: /Sync now/ }));
+    await waitFor(() => expect(sync).toHaveBeenCalled());
+    expect(await screen.findByText(/3 DQs skipped/)).toBeInTheDocument();
   });
 
   it('unlinks after confirmation', async () => {

--- a/apps/web/src/pages/Integrations/IntegrationsPage.tsx
+++ b/apps/web/src/pages/Integrations/IntegrationsPage.tsx
@@ -33,6 +33,9 @@ function describeSummary(summary: StartggSyncSummary): string {
   if (summary.gamesUnknownStage > 0) {
     parts.push(`${summary.gamesUnknownStage} with unrecognized stages`);
   }
+  if (summary.dqSets > 0) {
+    parts.push(`${summary.dqSets} DQs skipped`);
+  }
   return parts.join(' · ');
 }
 

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -77,6 +77,18 @@ export const matchRecordSchema = z.object({
   eventName: z.string().optional(),
   /** Tournament name for imported matches (e.g. "The Big House 9"). Server-set. */
   tournamentName: z.string().optional(),
+  /**
+   * start.gg's human-readable round label for the set this game belonged to
+   * (e.g. "Losers Round 2", "Winners Semi-Final"). Server-set, imported
+   * matches only.
+   */
+  roundText: z.string().optional(),
+  /**
+   * start.gg's `set.round` — a signed integer where negative values mean the
+   * losers side of a double-elimination bracket (e.g. -2 = Losers Round 2).
+   * Server-set, imported matches only.
+   */
+  bracketRound: z.number().int().optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 

--- a/packages/shared/src/startgg.ts
+++ b/packages/shared/src/startgg.ts
@@ -44,6 +44,8 @@ export const startggSyncSummarySchema = z.object({
   gamesMissingSelections: z.number().int().nonnegative(),
   /** Games whose stage didn't match the stage list (imported with the unknown sentinel). */
   gamesUnknownStage: z.number().int().nonnegative(),
+  /** Sets skipped outright because start.gg reported them as a DQ (`displayScore === 'DQ'`). */
+  dqSets: z.number().int().nonnegative(),
 });
 export type StartggSyncSummary = z.infer<typeof startggSyncSummarySchema>;
 
@@ -51,3 +53,36 @@ export type StartggSyncSummary = z.infer<typeof startggSyncSummarySchema>;
 export const startggAuthorizeResponseSchema = z.object({
   url: z.string().min(1),
 });
+
+/**
+ * `tournamentEntries/{uid}/{eventId}` — one entry per start.gg event the
+ * user has processed sets for, accumulated during sync. Server-only write;
+ * exposed read-only via GET /api/tournaments. Optional fields are omitted
+ * (not `undefined`) when start.gg doesn't provide them, per the RTDB
+ * undefined-rejection rule matches already follow.
+ */
+export const tournamentEntrySchema = z.object({
+  /** start.gg event id — the key this record is stored under (as a string). */
+  eventId: z.number().int().positive(),
+  /** Event name, e.g. "Ultimate Singles". */
+  eventName: z.string().min(1),
+  /** Tournament name, e.g. "The Big House 9", when start.gg provides one. */
+  tournamentName: z.string().optional(),
+  /** Total entrants in the event, when start.gg provides it. */
+  numEntrants: z.number().int().positive().optional(),
+  /** The user's seed in this event, when start.gg provides it. */
+  seed: z.number().int().positive().optional(),
+  /** The user's final placement in this event, when start.gg provides it. */
+  placement: z.number().int().positive().optional(),
+  /** Epoch ms of the earliest processed set for this event. */
+  firstSetAt: z.number().int().nonnegative(),
+  /** Epoch ms of the latest processed set for this event. */
+  lastSetAt: z.number().int().nonnegative(),
+  /** Count of non-DQ sets processed for this event. */
+  setsPlayed: z.number().int().nonnegative(),
+});
+export type TournamentEntry = z.infer<typeof tournamentEntrySchema>;
+
+/** GET /api/tournaments response — the user's tournament registry, newest first. */
+export const tournamentEntryListSchema = z.array(tournamentEntrySchema);
+export type TournamentEntryList = z.infer<typeof tournamentEntryListSchema>;


### PR DESCRIPTION
## Summary
- Adds bracket-round context to imported match records: `roundText` (e.g. "Losers Round 2") and `bracketRound` (signed int; negative = losers side), server-set and omitted (not `undefined`) when start.gg doesn't provide them.
- DQ sets (`set.displayScore === 'DQ'`) are now skipped entirely during sync and counted in a new `dqSets` summary field, separate from `setsWithoutGames`.
- New tournament registry: `tournamentEntries/{uid}/{eventId}` accumulated during sync — event name, tournament name, entrant count, the user's seed and final placement, first/last set timestamps, and sets-played count. Idempotent like matches (re-sync overwrites in place); only events with at least one processed (non-DQ) set are included.
- New `GET /api/tournaments` (Bearer auth) returns the user's registry sorted by `lastSetAt` descending; empty array when none.
- start.gg GraphQL query extended with `fullRoundText`, `round`, `displayScore`, `totalGames`, `event.id`, `event.numEntrants`, `slots.entrant.seeds.seedNum`, `slots.entrant.standing.placement` — all nullish-tolerant, `perPage` unchanged at 10 (complexity stays well under the 1000-object limit).
- Minimal web plumbing: `api.tournaments.list()`, new `useTournamentEntries` hook (TanStack Query, gated on auth), and `IntegrationsPage`'s `describeSummary` appends `· N DQs skipped` when applicable. No tournament UI pages in this phase — that's a separate phase per the plan.

## Design notes
- `gamesFromSet` (per-game transform) and `accumulateRegistry` (per-event registry fold) are separate pure functions sharing the same DQ/SSBU/user-entrant-lookup logic, so registry accumulation doesn't depend on a set having importable game detail — a "processed" set just needs to be non-DQ and SSBU.
- Registry entries only form when `event.id` and `event.name` are both present (can't group a set into a tournament entry without an event id); optional fields (`tournamentName`, `numEntrants`, `seed`, `placement`) are carried forward across sets in an event, updated whenever a later set provides a fresher non-null value.

## Test plan
- [x] `packages/shared`: 24/24 tests passing (existing suite; new fields are additive/optional so no regressions).
- [x] `apps/api`: 81/81 tests passing, including:
  - `sync.test.ts` (27 tests): DQ skip + counter, roundText/bracketRound present/omitted, `accumulateRegistry` (seed/placement/numEntrants extraction, min/max date accumulation, multi-event grouping, DQ/non-SSBU exclusion, missing-event-id exclusion, optional-field omission), `importPlayerMatches` registry write + idempotent re-sync + no-write-when-nothing-processed.
  - `routes/tournaments.test.ts` (3 tests): 401 unauthenticated, empty array, seeded + sorted by `lastSetAt` desc.
- [x] `apps/web`: 254/254 tests passing, including updated `IntegrationsPage.test.tsx` (dqSets summary line) and new `useTournamentEntries.test.tsx`.
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated to this change).
- [x] `pnpm typecheck` — clean across all workspaces.
- [x] `pnpm build` — clean across all workspaces.
- [x] `pnpm format:check` — clean.

## Deviations from the brief
- None of substance. Registry write path lives in `sync.ts` alongside `gamesFromSet` (not a separate module) since it shares the DQ/SSBU checks and the per-set user-entrant lookup; the new route lives in its own `routes/tournaments.ts` file (the brief left this as "your call").

🤖 Generated with [Claude Code](https://claude.com/claude-code)