### PR TITLE
Stage art polish: selected-stage preview + table thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage
 # firebase
 .firebase/
 .firebaserc
+.claude/worktrees/

--- a/apps/web/src/components/match-form/MatchForm.tsx
+++ b/apps/web/src/components/match-form/MatchForm.tsx
@@ -46,6 +46,27 @@ export const alphaSpriteList = [...SpriteList].sort((a, b) => a.name.localeCompa
 
 export { stageOptions };
 
+/**
+ * Legacy-style banner preview of the currently selected stage's artwork,
+ * shown under the stage select. Renders nothing for the no-selection
+ * sentinel or stages without art.
+ */
+function StageArtPreview({ stageId }: { stageId: number }) {
+  const stage = stageOptions.find((s) => s.id === stageId);
+  // The no-selection sentinel has no `url` property at all; art-less stages
+  // have an empty one — render nothing for either.
+  if (!stage || !('url' in stage) || !stage.url) {
+    return null;
+  }
+  return (
+    <img
+      src={stage.url}
+      alt={stage.name}
+      className="mt-2 aspect-video max-h-32 w-full rounded-md border object-cover"
+    />
+  );
+}
+
 const MATCH_TYPE_LABELS: Record<(typeof matchTypeValues)[number], string> = {
   none: 'None',
   quickplay: 'QuickPlay',
@@ -246,6 +267,7 @@ export function MatchFormFields({
                   </SelectGroup>
                 </SelectContent>
               </Select>
+              <StageArtPreview stageId={field.value} />
               <FormMessage />
             </FormItem>
           )}

--- a/apps/web/src/pages/Matchups/components/MatchupStageTable.tsx
+++ b/apps/web/src/pages/Matchups/components/MatchupStageTable.tsx
@@ -9,7 +9,8 @@ import {
 } from '@/components/ui/table';
 import type { Match } from '@smash-tracker/shared';
 import { getStageRecords } from '@/lib/stats';
-import { stagesById } from '@/data/stages';
+import { stagesById, UNKNOWN_STAGE } from '@/data/stages';
+import { StageOption } from '@/components/StageOption';
 
 /**
  * Per-stage records for the selected matchup, sorted by sample size. The
@@ -44,9 +45,17 @@ export function MatchupStageTable({ matchupMatches }: { matchupMatches: Match[] 
               {records.map((record) => (
                 <TableRow key={record.stageId}>
                   <TableCell>
-                    {record.stageId === 0
-                      ? 'unknown'
-                      : (stagesById.get(record.stageId)?.name ?? 'Unknown')}
+                    <StageOption
+                      stage={
+                        record.stageId === 0
+                          ? { ...UNKNOWN_STAGE, url: '' }
+                          : (stagesById.get(record.stageId) ?? {
+                              id: record.stageId,
+                              name: 'Unknown',
+                              url: '',
+                            })
+                      }
+                    />
                   </TableCell>
                   <TableCell>
                     {record.wins}-{record.losses}

--- a/packages/shared/src/stageData.ts
+++ b/packages/shared/src/stageData.ts
@@ -78,7 +78,7 @@ export const StageList: Stage[] = [
   { id: 58, name: 'Pokémon Stadium', url: '' },
   { id: 59, name: 'Pokémon Stadium 2', url: '/assets/stages/40-pokemon-stadium-2.jpg' },
   { id: 60, name: 'Spear Pillar', url: '' },
-  { id: 61, name: 'Unova Pokémon League', url: '' },
+  { id: 61, name: 'Unova Pokémon League', url: '/assets/stages/62-unova-pokemon-league.jpg' },
   { id: 62, name: 'Prism Tower', url: '' },
   { id: 63, name: 'Kalos Pokémon League', url: '/assets/stages/79-kalos-pokemon-league.jpg' },
   { id: 64, name: 'Big Blue', url: '' },


### PR DESCRIPTION
User request: bring stage pictures forward. All nine competitively-played stages already had wired art; this makes it more present:

- Legacy-style banner preview of the selected stage under the match form's stage picker
- Art thumbnails in the Matchup Lab stage breakdown table
- Fixes the Unova Pokémon League entry whose asset existed on disk but was never referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)