### PR TITLE
Silence chart.js canvas noise in web tests

### DIFF
--- a/apps/web/src/test/stubs/react-chartjs-2.tsx
+++ b/apps/web/src/test/stubs/react-chartjs-2.tsx
@@ -5,13 +5,8 @@
  * correctness is covered by each chart's exported pure builder functions;
  * component tests only need a stable placeholder to assert presence.
  */
-interface ChartStubProps {
-  data?: unknown;
-  options?: unknown;
-}
-
 function makeStub(type: string) {
-  return function ChartStub(_props: ChartStubProps) {
+  return function ChartStub() {
     return <div data-testid="chartjs-stub" data-chart-type={type} role="img" />;
   };
 }

--- a/apps/web/src/test/stubs/react-chartjs-2.tsx
+++ b/apps/web/src/test/stubs/react-chartjs-2.tsx
@@ -1,0 +1,24 @@
+/**
+ * Test stub for react-chartjs-2, aliased in vitest.config.ts. jsdom has no
+ * canvas implementation, so real chart components flood test output with
+ * "Not implemented: getContext" / "Failed to create chart" noise. Chart DATA
+ * correctness is covered by each chart's exported pure builder functions;
+ * component tests only need a stable placeholder to assert presence.
+ */
+interface ChartStubProps {
+  data?: unknown;
+  options?: unknown;
+}
+
+function makeStub(type: string) {
+  return function ChartStub(_props: ChartStubProps) {
+    return <div data-testid="chartjs-stub" data-chart-type={type} role="img" />;
+  };
+}
+
+export const Line = makeStub('line');
+export const Bar = makeStub('bar');
+export const Doughnut = makeStub('doughnut');
+export const Pie = makeStub('pie');
+export const Radar = makeStub('radar');
+export const Scatter = makeStub('scatter');

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,5 +13,14 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
+    alias: {
+      // jsdom has no canvas; the real chart components only produce
+      // "Not implemented: getContext" / "Failed to create chart" noise in
+      // test output. Chart math is covered by each chart's exported pure
+      // builder functions, so components render a stable placeholder.
+      'react-chartjs-2': fileURLToPath(
+        new URL('./src/test/stubs/react-chartjs-2.tsx', import.meta.url),
+      ),
+    },
   },
 });


### PR DESCRIPTION
Test output was flooded with jsdom canvas warnings from react-chartjs-2 (screenshot report from the user). Aliases the library to a stable stub inside vitest config only; chart math remains covered via the exported pure builders. Canvas noise lines in a full web test run: 100+ → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)