### PR TITLE
V4 Phase D: scouting × tournament history

### DIFF
--- a/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@/lib/firebase', async () => {
 });
 
 const listMatches = vi.fn();
+const listTournaments = vi.fn();
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
 
 vi.mock('@/lib/api', () => ({
@@ -40,6 +41,9 @@ vi.mock('@/lib/api', () => ({
     },
     matches: {
       list: (...args: unknown[]) => listMatches(...args),
+    },
+    tournaments: {
+      list: (...args: unknown[]) => listTournaments(...args),
     },
   },
 }));
@@ -74,6 +78,7 @@ function renderOpponents() {
               <Route path="/opponents" element={<OpponentsPage />} />
               <Route path="/dashboard" element={<div>Dashboard page</div>} />
               <Route path="/settings/integrations" element={<div>Integrations page</div>} />
+              <Route path="/tournaments/:eventId" element={<div>Tournament detail page</div>} />
             </Routes>
           </AnalyticsFilterProvider>
         </AuthProvider>
@@ -88,6 +93,7 @@ describe('OpponentsPage', () => {
     vi.clearAllMocks();
     window.localStorage.clear();
     upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    listTournaments.mockResolvedValue([]);
     setMockUser(makeMockUser());
   });
 
@@ -274,6 +280,171 @@ describe('OpponentsPage', () => {
       expect(screen.getByText('Stages')).toBeInTheDocument();
       expect(screen.getAllByText('Final Destination').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Battlefield').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('tournament history', () => {
+    it('shows the empty state when no matches have an eventName', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+      ]);
+
+      renderOpponents();
+
+      expect(
+        await screen.findByText(
+          "No tournament sets vs this player yet — resync start.gg if you've played recently.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('groups sets into a tournament block with derived score, round labels, and a plain-text title when no registry entry matches', async () => {
+      listTournaments.mockResolvedValue([]);
+      listMatches.mockResolvedValue([
+        makeMatch({
+          id: 'm1',
+          time: 1,
+          opponent: 'rival',
+          win: true,
+          map: { id: 1, name: 'Battlefield' },
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          source: 'startgg',
+          externalId: 'sgg:100:g1',
+        }),
+        makeMatch({
+          id: 'm2',
+          time: 2,
+          opponent: 'rival',
+          win: false,
+          map: { id: 3, name: 'Final Destination' },
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          source: 'startgg',
+          externalId: 'sgg:100:g2',
+          roundText: 'Winners Semi-Final',
+          bracketRound: 3,
+        }),
+        makeMatch({
+          id: 'm3',
+          time: 3,
+          opponent: 'rival',
+          win: true,
+          map: { id: 1, name: 'Battlefield' },
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          source: 'startgg',
+          externalId: 'sgg:100:g3',
+          roundText: 'Winners Semi-Final',
+          bracketRound: 3,
+        }),
+      ]);
+
+      renderOpponents();
+
+      const historyCard = (await screen.findByText('Tournament History')).closest(
+        '[data-slot="card"]',
+      ) as HTMLElement;
+
+      const title = within(historyCard).getByText('The Big House 9');
+      expect(title.closest('a')).toBeNull();
+      expect(within(historyCard).getByText('2-1 vs them here')).toBeInTheDocument();
+      expect(within(historyCard).getByText('Winners Semi-Final')).toBeInTheDocument();
+    });
+
+    it('falls back to "Set N" round labels when no game in the set carries roundText', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({
+          id: 'm1',
+          time: 1,
+          opponent: 'rival',
+          win: true,
+          eventName: 'Ultimate Singles',
+          source: 'startgg',
+          externalId: 'sgg:100:g1',
+        }),
+        makeMatch({
+          id: 'm2',
+          time: 2,
+          opponent: 'rival',
+          win: true,
+          eventName: 'Ultimate Singles',
+          source: 'startgg',
+          externalId: 'sgg:200:g1',
+        }),
+      ]);
+
+      renderOpponents();
+
+      const historyCard = (await screen.findByText('Tournament History')).closest(
+        '[data-slot="card"]',
+      ) as HTMLElement;
+
+      expect(within(historyCard).getByText('Ultimate Singles')).toBeInTheDocument();
+      expect(within(historyCard).getByText('Set 1')).toBeInTheDocument();
+      expect(within(historyCard).getByText('Set 2')).toBeInTheDocument();
+    });
+
+    it('tints losers-side sets and links the block title to the tournament page when a registry entry matches', async () => {
+      listTournaments.mockResolvedValue([
+        {
+          eventId: 987,
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          firstSetAt: 0,
+          lastSetAt: 10,
+          setsPlayed: 2,
+        },
+      ]);
+      listMatches.mockResolvedValue([
+        makeMatch({
+          id: 'm1',
+          time: 5,
+          opponent: 'rival',
+          win: false,
+          eventName: 'Ultimate Singles',
+          tournamentName: 'The Big House 9',
+          source: 'startgg',
+          externalId: 'sgg:100:g1',
+          roundText: 'Losers Round 2',
+          bracketRound: -2,
+        }),
+      ]);
+
+      renderOpponents();
+
+      const link = await screen.findByRole('link', { name: 'The Big House 9' });
+      expect(link).toHaveAttribute('href', '/tournaments/987');
+      expect(screen.getByText('Losers')).toBeInTheDocument();
+    });
+
+    it('shows the encounter context line summarizing tournament count and date span', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({
+          id: 'm1',
+          time: Date.parse('2021-01-15T00:00:00Z'),
+          opponent: 'rival',
+          win: true,
+          eventName: 'Ultimate Singles',
+          source: 'startgg',
+          externalId: 'sgg:100:g1',
+        }),
+        makeMatch({
+          id: 'm2',
+          time: Date.parse('2021-03-20T00:00:00Z'),
+          opponent: 'rival',
+          win: false,
+          eventName: 'Ultimate Doubles',
+          source: 'startgg',
+          externalId: 'sgg:200:g1',
+        }),
+      ]);
+
+      renderOpponents();
+
+      expect(
+        await screen.findByText('Met at 2 tournaments between Jan 2021 and Mar 2021'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/Opponents/OpponentsPage.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { useFilteredMatches } from '@/hooks/useFilteredMatches';
+import { useTournamentEntries } from '@/hooks/useTournamentEntries';
 import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
 import { getOpponentProfile, getOpponentRecords } from '@/lib/stats';
 import { OpponentList } from './components/OpponentList';
@@ -10,6 +11,8 @@ import { WhatTheyPlayTable } from './components/WhatTheyPlayTable';
 import { ScoutingStagesCard } from './components/ScoutingStagesCard';
 import { ScoutingTrendChart } from './components/ScoutingTrendChart';
 import { RecentEncounters } from './components/RecentEncounters';
+import { TournamentHistory } from './components/TournamentHistory';
+import { groupTournamentBlocks, getEncounterContext } from './tournamentHistory';
 
 /**
  * Phase E (docs/analytics-vision.md): scouting reports per human opponent —
@@ -18,6 +21,7 @@ import { RecentEncounters } from './components/RecentEncounters';
  */
 export function OpponentsPage() {
   const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
+  const { data: tournamentEntries } = useTournamentEntries();
 
   const opponentRecords = useMemo(() => getOpponentRecords(matches), [matches]);
 
@@ -43,6 +47,15 @@ export function OpponentsPage() {
     }
     return getOpponentProfile(matches, selected);
   }, [matches, selected]);
+
+  const opponentMatches = useMemo(
+    () => (profile ? matches.filter((m) => m.opponent === profile.opponent) : []),
+    [matches, profile],
+  );
+
+  const tournamentBlocks = useMemo(() => groupTournamentBlocks(opponentMatches), [opponentMatches]);
+
+  const encounterContext = useMemo(() => getEncounterContext(tournamentBlocks), [tournamentBlocks]);
 
   if (isLoading) {
     return <div className="text-muted-foreground">Loading scouting reports...</div>;
@@ -94,13 +107,17 @@ export function OpponentsPage() {
 
         {profile ? (
           <div key={profile.opponent} className="flex flex-col gap-4">
-            <ScoutingHeader profile={profile} />
+            <ScoutingHeader profile={profile} encounterContext={encounterContext} />
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <WhatTheyPlayTable byTheirFighter={profile.byTheirFighter} />
               <ScoutingStagesCard byStage={profile.byStage} />
             </div>
-            <ScoutingTrendChart matches={matches.filter((m) => m.opponent === profile.opponent)} />
+            <ScoutingTrendChart matches={opponentMatches} />
             <RecentEncounters matches={profile.recent} />
+            <TournamentHistory
+              blocks={tournamentBlocks}
+              tournamentEntries={tournamentEntries ?? []}
+            />
           </div>
         ) : (
           <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">

--- a/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
@@ -1,13 +1,41 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WinLossPips } from '@/components/WinLossPips';
 import type { OpponentProfile } from '@/lib/stats';
+import type { EncounterContext } from '../tournamentHistory';
+
+function formatEncounterContext(context: EncounterContext): string | null {
+  if (context.tournamentCount === 0 || !context.span) {
+    return null;
+  }
+  const count = context.tournamentCount;
+  const start = new Date(context.span.start).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+  const end = new Date(context.span.end).toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+  const tournamentWord = count === 1 ? 'tournament' : 'tournaments';
+  const span = start === end ? start : `${start} and ${end}`;
+  return `Met at ${count} ${tournamentWord} between ${span}`;
+}
 
 /**
  * Scouting report header: opponent tag, overall H2H record + rate + sample
- * size, first/last played dates, and last-10 form pips vs this opponent.
+ * size, first/last played dates, last-10 form pips vs this opponent, and (when
+ * tournament-tagged encounters exist) an encounter context line summarizing
+ * how many tournaments and over what date span you've met them.
  */
-export function ScoutingHeader({ profile }: { profile: OpponentProfile }) {
+export function ScoutingHeader({
+  profile,
+  encounterContext,
+}: {
+  profile: OpponentProfile;
+  encounterContext: EncounterContext;
+}) {
   const { record } = profile;
+  const encounterLine = formatEncounterContext(encounterContext);
 
   return (
     <Card>
@@ -18,6 +46,7 @@ export function ScoutingHeader({ profile }: { profile: OpponentProfile }) {
             First played {new Date(profile.firstPlayedAt).toLocaleDateString()} · Last played{' '}
             {new Date(profile.lastPlayedAt).toLocaleDateString()}
           </p>
+          {encounterLine && <p className="mt-1 text-sm text-muted-foreground">{encounterLine}</p>}
         </div>
         <div className="text-right">
           <p className="text-2xl font-semibold">

--- a/apps/web/src/pages/Opponents/components/TournamentHistory.tsx
+++ b/apps/web/src/pages/Opponents/components/TournamentHistory.tsx
@@ -1,0 +1,153 @@
+import { Link } from 'react-router';
+import type { TournamentEntry } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  resolveTournamentEntry,
+  type TournamentBlock,
+  type TournamentSet,
+} from '../tournamentHistory';
+
+function formatDate(time: number): string {
+  return new Date(time).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatDateRange(startTime: number, endTime: number): string {
+  const start = formatDate(startTime);
+  const end = formatDate(endTime);
+  return start === end ? start : `${start} – ${end}`;
+}
+
+/**
+ * Every game in a set as a small chip: stage abbreviation, win/loss tint,
+ * and a tooltip (native `title`) with the full stage name + date + result.
+ */
+function GameChips({ games }: { games: TournamentSet['games'] }) {
+  return (
+    <div className="flex flex-wrap gap-1" aria-label="Games">
+      {games.map((game) => (
+        <span
+          key={game.match.id}
+          title={`${game.stageName} — ${game.win ? 'Win' : 'Loss'} — ${new Date(
+            game.match.time,
+          ).toLocaleDateString()}`}
+          className={`inline-flex size-7 items-center justify-center rounded text-[10px] font-semibold ${
+            game.win
+              ? 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400'
+              : 'bg-destructive/15 text-destructive'
+          }`}
+        >
+          {game.stageAbbr}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function SetRow({ set }: { set: TournamentSet }) {
+  return (
+    <li
+      className={`flex flex-wrap items-center justify-between gap-3 rounded-md border p-2 ${
+        set.isLosersSide ? 'border-destructive/40 bg-destructive/5' : ''
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <span className="w-36 shrink-0 text-sm font-medium">
+          {set.roundLabel}
+          {set.isLosersSide && (
+            <Badge variant="destructive" className="ml-2 align-middle">
+              Losers
+            </Badge>
+          )}
+        </span>
+        <GameChips games={set.games} />
+      </div>
+      <span className="text-sm font-semibold">
+        {set.wins}-{set.losses}
+      </span>
+    </li>
+  );
+}
+
+function TournamentBlockCard({
+  block,
+  registryEntry,
+}: {
+  block: TournamentBlock;
+  registryEntry: TournamentEntry | null;
+}) {
+  const title = block.displayName;
+  return (
+    <div className="rounded-lg border">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b p-3">
+        <div>
+          {registryEntry ? (
+            <Link
+              to={`/tournaments/${registryEntry.eventId}`}
+              className="font-semibold text-primary underline-offset-2 hover:underline"
+            >
+              {title}
+            </Link>
+          ) : (
+            <span className="font-semibold">{title}</span>
+          )}
+          <p className="text-xs text-muted-foreground">
+            {formatDateRange(block.startTime, block.endTime)}
+          </p>
+        </div>
+        <span className="text-sm font-semibold">
+          {block.wins}-{block.losses} vs them here
+        </span>
+      </div>
+      <ul className="flex flex-col gap-2 p-3" aria-label={`Sets vs them at ${title}`}>
+        {block.sets.map((set) => (
+          <SetRow key={set.setId} set={set} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Phase D (docs/analytics-vision.md): tournament history block for the
+ * scouting report — every start.gg-imported set played against this
+ * opponent, grouped by tournament, with per-set score and per-game stage
+ * chips. Grouping/scoring/resolution logic lives in `../tournamentHistory`
+ * (pure, unit-tested); this component only renders the resulting structures.
+ */
+export function TournamentHistory({
+  blocks,
+  tournamentEntries,
+}: {
+  blocks: TournamentBlock[];
+  tournamentEntries: TournamentEntry[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tournament History</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {blocks.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No tournament sets vs this player yet — resync start.gg if you&apos;ve played recently.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {blocks.map((block) => (
+              <TournamentBlockCard
+                key={`${block.displayName}-${block.startTime}`}
+                block={block}
+                registryEntry={resolveTournamentEntry(block, tournamentEntries)}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Opponents/tournamentHistory.test.ts
+++ b/apps/web/src/pages/Opponents/tournamentHistory.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from 'vitest';
+import type { Match, TournamentEntry } from '@smash-tracker/shared';
+import {
+  abbreviateStageName,
+  getEncounterContext,
+  groupIntoSets,
+  groupTournamentBlocks,
+  parseSetId,
+  resolveTournamentEntry,
+  TOURNAMENT_PROXIMITY_WINDOW_MS,
+} from './tournamentHistory';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 1, name: 'Battlefield' },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'offline-tourney',
+    source: 'startgg',
+    ...overrides,
+  };
+}
+
+describe('parseSetId', () => {
+  it('extracts the set id from a well-formed externalId', () => {
+    expect(parseSetId('sgg:12345:g1')).toBe('12345');
+    expect(parseSetId('sgg:12345:g2')).toBe('12345');
+  });
+
+  it('handles set ids that themselves contain colons', () => {
+    expect(parseSetId('sgg:abc:def:g3')).toBe('abc:def');
+  });
+
+  it('returns null for undefined or malformed ids', () => {
+    expect(parseSetId(undefined)).toBeNull();
+    expect(parseSetId('not-a-startgg-id')).toBeNull();
+    expect(parseSetId('sgg:12345')).toBeNull();
+  });
+});
+
+describe('abbreviateStageName', () => {
+  it('takes initials for multi-word names, skipping "the"/"of"', () => {
+    expect(abbreviateStageName('Battlefield')).toBe('BAT');
+    expect(abbreviateStageName('Final Destination')).toBe('FD');
+    expect(abbreviateStageName("Peach's Castle")).toBe('PC');
+    expect(abbreviateStageName('Kingdom of the Winds')).toBe('KW');
+  });
+
+  it('returns an empty string for an empty name', () => {
+    expect(abbreviateStageName('')).toBe('');
+  });
+});
+
+describe('groupIntoSets', () => {
+  it('groups games by parsed setId and derives the score from game wins/losses', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 1, win: true, externalId: 'sgg:100:g1' }),
+      makeMatch({ id: 'g2', time: 2, win: false, externalId: 'sgg:100:g2' }),
+      makeMatch({ id: 'g3', time: 3, win: true, externalId: 'sgg:100:g3' }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets).toHaveLength(1);
+    expect(sets[0]!.setId).toBe('100');
+    expect(sets[0]!.wins).toBe(2);
+    expect(sets[0]!.losses).toBe(1);
+    expect(sets[0]!.games).toHaveLength(3);
+  });
+
+  it('splits distinct set ids into separate sets and orders sets chronologically', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 10, win: true, externalId: 'sgg:200:g1' }),
+      makeMatch({ id: 'g2', time: 1, win: true, externalId: 'sgg:100:g1' }),
+      makeMatch({ id: 'g3', time: 2, win: false, externalId: 'sgg:100:g2' }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets.map((s) => s.setId)).toEqual(['100', '200']);
+  });
+
+  it('ignores games without a parseable externalId', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 1, win: true, externalId: 'sgg:100:g1' }),
+      makeMatch({ id: 'g2', time: 2, win: true, source: undefined, externalId: undefined }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets).toHaveLength(1);
+    expect(sets[0]!.games).toHaveLength(1);
+  });
+
+  it('uses roundText when present on any game in the set', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 1,
+        win: true,
+        externalId: 'sgg:100:g1',
+        roundText: 'Winners Semi-Final',
+        bracketRound: 3,
+      }),
+      makeMatch({ id: 'g2', time: 2, win: false, externalId: 'sgg:100:g2' }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets[0]!.roundLabel).toBe('Winners Semi-Final');
+    expect(sets[0]!.bracketRound).toBe(3);
+    expect(sets[0]!.isLosersSide).toBe(false);
+  });
+
+  it('falls back to "Set N" (1-based, chronological) when no game carries roundText', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 1, win: true, externalId: 'sgg:100:g1' }),
+      makeMatch({ id: 'g2', time: 10, win: true, externalId: 'sgg:200:g1' }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets[0]!.roundLabel).toBe('Set 1');
+    expect(sets[1]!.roundLabel).toBe('Set 2');
+  });
+
+  it('marks a set as losers-side when bracketRound is negative', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 1,
+        win: false,
+        externalId: 'sgg:100:g1',
+        roundText: 'Losers Round 2',
+        bracketRound: -2,
+      }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets[0]!.isLosersSide).toBe(true);
+  });
+
+  it('derives stage abbreviation and falls back to "unknown" for the no-stage sentinel', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 1,
+        win: true,
+        externalId: 'sgg:100:g1',
+        map: { id: 3, name: 'Final Destination' },
+      }),
+      makeMatch({
+        id: 'g2',
+        time: 2,
+        win: false,
+        externalId: 'sgg:100:g2',
+        map: { id: 0, name: 'unknown' },
+      }),
+    ];
+
+    const sets = groupIntoSets(matches);
+
+    expect(sets[0]!.games[0]!.stageAbbr).toBe('FD');
+    expect(sets[0]!.games[1]!.stageName).toBe('unknown');
+  });
+});
+
+describe('groupTournamentBlocks', () => {
+  it('excludes matches without an eventName', () => {
+    const matches = [makeMatch({ id: 'g1', time: 1, win: true, eventName: undefined })];
+    expect(groupTournamentBlocks(matches)).toEqual([]);
+  });
+
+  it('groups by tournamentName falling back to eventName, and computes the block record', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 1,
+        win: true,
+        eventName: 'Ultimate Singles',
+        tournamentName: 'The Big House 9',
+        externalId: 'sgg:100:g1',
+      }),
+      makeMatch({
+        id: 'g2',
+        time: 2,
+        win: false,
+        eventName: 'Ultimate Singles',
+        tournamentName: 'The Big House 9',
+        externalId: 'sgg:200:g1',
+      }),
+      makeMatch({
+        id: 'g3',
+        time: 3,
+        win: true,
+        eventName: 'Ultimate Doubles',
+        externalId: 'sgg:300:g1',
+      }),
+    ];
+
+    const blocks = groupTournamentBlocks(matches);
+
+    expect(blocks).toHaveLength(2);
+    const tbh = blocks.find((b) => b.displayName === 'The Big House 9')!;
+    expect(tbh.wins).toBe(1);
+    expect(tbh.losses).toBe(1);
+    expect(tbh.sets).toHaveLength(2);
+    const doubles = blocks.find((b) => b.displayName === 'Ultimate Doubles')!;
+    expect(doubles.wins).toBe(1);
+  });
+
+  it('splits same-named groups into separate blocks when sets are further apart than the proximity window', () => {
+    const base = Date.parse('2021-01-01T00:00:00Z');
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: base,
+        win: true,
+        eventName: 'Weekly',
+        externalId: 'sgg:100:g1',
+      }),
+      makeMatch({
+        id: 'g2',
+        time: base + TOURNAMENT_PROXIMITY_WINDOW_MS + 1,
+        win: false,
+        eventName: 'Weekly',
+        externalId: 'sgg:200:g1',
+      }),
+    ];
+
+    const blocks = groupTournamentBlocks(matches);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks.every((b) => b.displayName === 'Weekly')).toBe(true);
+  });
+
+  it('keeps same-named sets within the proximity window in a single block', () => {
+    const base = Date.parse('2021-01-01T00:00:00Z');
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: base,
+        win: true,
+        eventName: 'Weekly',
+        externalId: 'sgg:100:g1',
+      }),
+      makeMatch({
+        id: 'g2',
+        time: base + TOURNAMENT_PROXIMITY_WINDOW_MS - 1,
+        win: false,
+        eventName: 'Weekly',
+        externalId: 'sgg:200:g1',
+      }),
+    ];
+
+    const blocks = groupTournamentBlocks(matches);
+
+    expect(blocks).toHaveLength(1);
+  });
+
+  it('sorts blocks by endTime descending (most recent first)', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 1,
+        win: true,
+        eventName: 'Older Event',
+        externalId: 'sgg:100:g1',
+      }),
+      makeMatch({
+        id: 'g2',
+        time: 1000,
+        win: true,
+        eventName: 'Newer Event',
+        externalId: 'sgg:200:g1',
+      }),
+    ];
+
+    const blocks = groupTournamentBlocks(matches);
+
+    expect(blocks.map((b) => b.displayName)).toEqual(['Newer Event', 'Older Event']);
+  });
+});
+
+describe('resolveTournamentEntry', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const BASE = Date.parse('2021-01-01T00:00:00Z');
+
+  function makeEntry(overrides: Partial<TournamentEntry> = {}): TournamentEntry {
+    return {
+      eventId: 987,
+      eventName: 'Ultimate Singles',
+      firstSetAt: BASE,
+      lastSetAt: BASE + DAY_MS,
+      setsPlayed: 5,
+      ...overrides,
+    };
+  }
+
+  it('matches an entry by eventName when the block falls within its time window', () => {
+    const block = {
+      displayName: 'The Big House 9',
+      eventName: 'Ultimate Singles',
+      tournamentName: 'The Big House 9',
+      sets: [],
+      startTime: BASE + 1000,
+      endTime: BASE + DAY_MS - 1000,
+      wins: 2,
+      losses: 1,
+    };
+    const entries = [makeEntry()];
+
+    expect(resolveTournamentEntry(block, entries)).toEqual(entries[0]);
+  });
+
+  it('returns null when eventName does not match any entry', () => {
+    const block = {
+      displayName: 'X',
+      eventName: 'Ultimate Doubles',
+      sets: [],
+      startTime: BASE + 1000,
+      endTime: BASE + DAY_MS - 1000,
+      wins: 0,
+      losses: 0,
+    };
+    expect(resolveTournamentEntry(block, [makeEntry()])).toBeNull();
+  });
+
+  it('returns null when the eventName matches but the time window does not', () => {
+    const block = {
+      displayName: 'X',
+      eventName: 'Ultimate Singles',
+      sets: [],
+      startTime: BASE + 30 * DAY_MS,
+      endTime: BASE + 31 * DAY_MS,
+      wins: 0,
+      losses: 0,
+    };
+    expect(resolveTournamentEntry(block, [makeEntry()])).toBeNull();
+  });
+
+  it('picks the matching entry among several candidates with the same eventName', () => {
+    const block = {
+      displayName: 'X',
+      eventName: 'Ultimate Singles',
+      sets: [],
+      startTime: BASE + 10 * DAY_MS + 1000,
+      endTime: BASE + 10 * DAY_MS + 2000,
+      wins: 0,
+      losses: 0,
+    };
+    const entries = [
+      makeEntry({ eventId: 1, firstSetAt: BASE, lastSetAt: BASE + DAY_MS }),
+      makeEntry({ eventId: 2, firstSetAt: BASE + 10 * DAY_MS, lastSetAt: BASE + 11 * DAY_MS }),
+    ];
+
+    expect(resolveTournamentEntry(block, entries)?.eventId).toBe(2);
+  });
+});
+
+describe('getEncounterContext', () => {
+  it('reports zero tournaments and a null span when there are no blocks', () => {
+    expect(getEncounterContext([])).toEqual({ tournamentCount: 0, span: null });
+  });
+
+  it('reports the count and overall span across blocks', () => {
+    const blocks = [
+      {
+        displayName: 'A',
+        eventName: 'A',
+        sets: [],
+        startTime: 100,
+        endTime: 200,
+        wins: 1,
+        losses: 0,
+      },
+      {
+        displayName: 'B',
+        eventName: 'B',
+        sets: [],
+        startTime: 500,
+        endTime: 900,
+        wins: 0,
+        losses: 1,
+      },
+    ];
+
+    expect(getEncounterContext(blocks)).toEqual({
+      tournamentCount: 2,
+      span: { start: 100, end: 900 },
+    });
+  });
+});

--- a/apps/web/src/pages/Opponents/tournamentHistory.ts
+++ b/apps/web/src/pages/Opponents/tournamentHistory.ts
@@ -1,0 +1,283 @@
+import type { Match, TournamentEntry } from '@smash-tracker/shared';
+import { stagesById } from '@/data/stages';
+
+/**
+ * Phase D (docs/analytics-vision.md): tournament history inside a scouting
+ * report — every start.gg-imported set played against the selected opponent,
+ * grouped into per-tournament blocks with per-set score/round detail. All
+ * grouping/derivation logic here is pure (no React) so it's unit-testable in
+ * isolation; the UI (`TournamentHistory.tsx`) only renders these structures.
+ */
+
+// ---------------------------------------------------------------------------
+// Set grouping
+// ---------------------------------------------------------------------------
+
+export interface TournamentSetGame {
+  match: Match;
+  /** Stage abbreviation, e.g. "BF", "FD", or "?" when the stage id is the no-selection sentinel (0). */
+  stageAbbr: string;
+  /** Full stage name, or "unknown" for the no-selection sentinel. */
+  stageName: string;
+  win: boolean;
+}
+
+export interface TournamentSet {
+  /** The start.gg set id parsed from `externalId` ('sgg:{setId}:g{n}'). */
+  setId: string;
+  games: TournamentSetGame[];
+  /** Games won by the tracked user within this set. */
+  wins: number;
+  /** Games won by the opponent within this set. */
+  losses: number;
+  /** `roundText` from the first game that has one, else `"Set {n}"` (n = 1-based position within the tournament block, chronological). */
+  roundLabel: string;
+  /** `bracketRound` from the first game that has one, when present. */
+  bracketRound?: number;
+  /** True when this set was on the losers side (`bracketRound < 0`). */
+  isLosersSide: boolean;
+  /** Epoch ms of the set's first game — used to order sets within a block. */
+  time: number;
+}
+
+/** Parses the start.gg set id out of an imported game's `externalId` ('sgg:{setId}:g{n}'). Returns null for non-start.gg or malformed ids. */
+export function parseSetId(externalId: string | undefined): string | null {
+  if (!externalId) {
+    return null;
+  }
+  const match = /^sgg:(.+):g\d+$/.exec(externalId);
+  return match ? match[1]! : null;
+}
+
+/** Short (<=3 char) abbreviation for a stage name: initials of significant words, or the first letters of a single word. */
+export function abbreviateStageName(name: string): string {
+  const words = name
+    .replace(/['’]/g, '')
+    .split(/[\s-]+/)
+    .filter((w) => w.length > 0 && w.toLowerCase() !== 'the' && w.toLowerCase() !== 'of');
+  if (words.length === 0) {
+    return '';
+  }
+  if (words.length === 1) {
+    return words[0]!.slice(0, 3).toUpperCase();
+  }
+  return words
+    .slice(0, 3)
+    .map((w) => w[0]!.toUpperCase())
+    .join('');
+}
+
+function stageInfoFor(match: Match): { stageAbbr: string; stageName: string } {
+  if (!match.map || match.map.id === 0) {
+    return { stageAbbr: '?', stageName: 'unknown' };
+  }
+  const stageName = stagesById.get(match.map.id)?.name ?? match.map.name;
+  return { stageAbbr: abbreviateStageName(stageName), stageName };
+}
+
+/**
+ * Groups games belonging to the same start.gg set (same parsed `setId`) into
+ * a `TournamentSet`, deriving the score from game wins/losses. Games are
+ * grouped in the order they first appear per set, but each set's own games
+ * are additionally sorted by `time` to keep the per-game chip order stable.
+ * `roundLabel` falls back to `"Set {n}"` (n = 1-based, by chronological
+ * position among the sets returned) when no game in the set carries
+ * `roundText` — this is the pre-resync case called out in Phase D.
+ */
+export function groupIntoSets(matches: Match[]): TournamentSet[] {
+  const bySet = new Map<string, Match[]>();
+  for (const match of matches) {
+    const setId = parseSetId(match.externalId);
+    if (setId === null) {
+      continue;
+    }
+    const group = bySet.get(setId);
+    if (group) {
+      group.push(match);
+    } else {
+      bySet.set(setId, [match]);
+    }
+  }
+
+  const sets = [...bySet.entries()].map(([setId, games]) => {
+    const sortedGames = [...games].sort((a, b) => a.time - b.time);
+    const wins = sortedGames.filter((m) => m.win).length;
+    const losses = sortedGames.filter((m) => !m.win).length;
+    const roundTextGame = sortedGames.find((m) => m.roundText);
+    const bracketRoundGame = sortedGames.find((m) => m.bracketRound !== undefined);
+    const bracketRound = bracketRoundGame?.bracketRound;
+
+    return {
+      setId,
+      games: sortedGames.map((match) => {
+        const { stageAbbr, stageName } = stageInfoFor(match);
+        return { match, stageAbbr, stageName, win: match.win };
+      }),
+      wins,
+      losses,
+      roundLabel: roundTextGame?.roundText ?? '',
+      bracketRound,
+      isLosersSide: bracketRound !== undefined && bracketRound < 0,
+      time: sortedGames[0]!.time,
+    };
+  });
+
+  sets.sort((a, b) => a.time - b.time);
+
+  let setCounter = 0;
+  return sets.map((set) => {
+    if (set.roundLabel) {
+      return set;
+    }
+    setCounter += 1;
+    return { ...set, roundLabel: `Set ${setCounter}` };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tournament block grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Two same-named tournament groups (e.g. a recurring weekly) more than this
+ * far apart in time are treated as separate blocks — chosen generously (4
+ * days) to keep multi-day majors as one block without merging distinct
+ * occurrences of a weekly series that shares a name.
+ */
+export const TOURNAMENT_PROXIMITY_WINDOW_MS = 4 * 24 * 60 * 60 * 1000;
+
+export interface TournamentBlock {
+  /** `tournamentName ?? eventName` for every match in this block. */
+  displayName: string;
+  eventName: string;
+  tournamentName?: string;
+  sets: TournamentSet[];
+  startTime: number;
+  endTime: number;
+  wins: number;
+  losses: number;
+}
+
+/**
+ * Groups the opponent's start.gg-imported matches into per-tournament
+ * blocks: first by `tournamentName ?? eventName`, then split into separate
+ * blocks whenever consecutive sets (by time) exceed
+ * `TOURNAMENT_PROXIMITY_WINDOW_MS` apart — so a recurring weekly with the
+ * same name doesn't merge distant occurrences into one block. Matches
+ * without `eventName` (never synced, or pre-Phase-B import) are excluded;
+ * callers use an empty result to show the "no tournament sets" empty state.
+ */
+export function groupTournamentBlocks(
+  matches: Match[],
+  proximityWindowMs = TOURNAMENT_PROXIMITY_WINDOW_MS,
+): TournamentBlock[] {
+  const withEvent = matches.filter(
+    (m): m is Match & { eventName: string } => m.eventName != null && m.eventName !== '',
+  );
+
+  const byName = new Map<string, (Match & { eventName: string })[]>();
+  for (const match of withEvent) {
+    const key = match.tournamentName ?? match.eventName;
+    const group = byName.get(key);
+    if (group) {
+      group.push(match);
+    } else {
+      byName.set(key, [match]);
+    }
+  }
+
+  const blocks: TournamentBlock[] = [];
+  for (const [, group] of byName) {
+    const sorted = [...group].sort((a, b) => a.time - b.time);
+    let current: (Match & { eventName: string })[] = [];
+    for (const match of sorted) {
+      const previous = current[current.length - 1];
+      if (previous && match.time - previous.time > proximityWindowMs) {
+        blocks.push(buildBlock(current));
+        current = [match];
+      } else {
+        current.push(match);
+      }
+    }
+    if (current.length > 0) {
+      blocks.push(buildBlock(current));
+    }
+  }
+
+  return blocks.sort((a, b) => b.endTime - a.endTime);
+}
+
+function buildBlock(matches: (Match & { eventName: string })[]): TournamentBlock {
+  const sets = groupIntoSets(matches);
+  const wins = matches.filter((m) => m.win).length;
+  const losses = matches.filter((m) => !m.win).length;
+  const first = matches[0]!;
+  return {
+    displayName: first.tournamentName ?? first.eventName,
+    eventName: first.eventName,
+    tournamentName: first.tournamentName,
+    sets,
+    startTime: Math.min(...matches.map((m) => m.time)),
+    endTime: Math.max(...matches.map((m) => m.time)),
+    wins,
+    losses,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tournament registry resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Slack added around a block's [startTime, endTime] span when matching
+ * against a registry entry's [firstSetAt, lastSetAt] — the two are derived
+ * from the same underlying start.gg sets so they should already align
+ * closely, but a little slack absorbs any rounding/timezone edge cases.
+ */
+const REGISTRY_MATCH_SLACK_MS = 60 * 60 * 1000;
+
+/**
+ * Resolves a tournament block to a registry entry (for linking to
+ * `/tournaments/:eventId`) by matching `eventName` and requiring the block's
+ * time span to fall within the registry entry's [firstSetAt, lastSetAt]
+ * window (plus slack). Returns null when no entry matches — the block title
+ * then renders as plain text instead of a link. Pure + exported for tests.
+ */
+export function resolveTournamentEntry(
+  block: TournamentBlock,
+  entries: TournamentEntry[],
+): TournamentEntry | null {
+  const candidates = entries.filter((e) => e.eventName === block.eventName);
+  for (const entry of candidates) {
+    const withinWindow =
+      block.startTime >= entry.firstSetAt - REGISTRY_MATCH_SLACK_MS &&
+      block.endTime <= entry.lastSetAt + REGISTRY_MATCH_SLACK_MS;
+    if (withinWindow) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Encounter context summary
+// ---------------------------------------------------------------------------
+
+export interface EncounterContext {
+  tournamentCount: number;
+  /** Epoch ms span across all blocks, or null when there are no blocks. */
+  span: { start: number; end: number } | null;
+}
+
+/** Summarizes tournament blocks into the header's "met at N tournaments between X and Y" context line. */
+export function getEncounterContext(blocks: TournamentBlock[]): EncounterContext {
+  if (blocks.length === 0) {
+    return { tournamentCount: 0, span: null };
+  }
+  const starts = blocks.map((b) => b.startTime);
+  const ends = blocks.map((b) => b.endTime);
+  return {
+    tournamentCount: blocks.length,
+    span: { start: Math.min(...starts), end: Math.max(...ends) },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a **Tournament History** section to the per-opponent scouting report (`apps/web/src/pages/Opponents/`):

- Groups the selected opponent's start.gg-imported matches into per-tournament blocks: keyed by `tournamentName ?? eventName`, split into separate blocks when same-named groups are more than 4 days apart (so a recurring weekly doesn't merge distant occurrences).
- Within each block, groups games into sets by parsing the start.gg set id out of `externalId` (`sgg:{setId}:g{n}`), deriving the set score from game wins/losses.
- Each set's round label uses `roundText` when present, falling back to `"Set N"` (1-based, chronological) for matches synced before the bracket-round enrichment (Phase A) — handles the pre-resync case gracefully.
- Losers-side sets (`bracketRound < 0`) get a red tint + "Losers" badge.
- Per-game chips show a derived stage abbreviation with win/loss tinting and a tooltip (stage name, result, date).
- Block titles link to `/tournaments/:eventId` when a tournament-registry entry (`useTournamentEntries`) resolves by `eventName` + time-window match; otherwise renders as plain text (that route is owned by a concurrent PR — links will resolve once it merges).
- Empty state: "No tournament sets vs this player yet — resync start.gg if you've played recently."
- Scouting header now shows an **encounter context line**: "Met at N tournaments between Mon YYYY and Mon YYYY" when the opponent has any tournament-tagged encounters.

All grouping/scoring/resolution logic is implemented as pure, exported builders in the new `apps/web/src/pages/Opponents/tournamentHistory.ts` (`groupIntoSets`, `groupTournamentBlocks`, `resolveTournamentEntry`, `getEncounterContext`, plus `parseSetId`/`abbreviateStageName` helpers) — the UI components (`TournamentHistory.tsx`, updated `ScoutingHeader.tsx`) only render the resulting structures.

## Test plan

- [x] `apps/web/src/pages/Opponents/tournamentHistory.test.ts` — 23 new tests: set-id parsing, stage abbreviation, set grouping + score derivation, roundText fallback, losers-side detection, tournament block grouping (proximity window split/merge, sort order), registry resolution (match/no-match/time-window/multi-candidate), encounter context summary.
- [x] `apps/web/src/pages/Opponents/OpponentsPage.test.tsx` — updated to mock `api.tournaments.list` and added a `/tournaments/:eventId` test route; 13 tests total including 5 new ones covering the empty state, set/round rendering, "Set N" fallback, losers tint + registry link, and the encounter context line.
- [x] `pnpm lint` — 0 errors (26 pre-existing warnings, unrelated to this change)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all packages passing (shared 24, api 81, web 378)
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean

Scope: changes are confined to `apps/web/src/pages/Opponents/**`, per this phase's ownership boundary (Tournaments/Trends pages and match-form/api are owned by concurrent agents). Synced from `origin/master` (includes merged PR #86 bracket sync, plus later Phase B/C/E merges via rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)