### PR TITLE
fix(deps): force uuid >=11.1.1 to resolve Dependabot alert 349

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: ^11.1.1
+
 importers:
 
   .:
@@ -3558,9 +3561,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vite@8.1.3:
@@ -6321,7 +6323,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7354,7 +7356,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7457,7 +7459,7 @@ snapshots:
   util-deprecate@1.0.2:
     optional: true
 
-  uuid@9.0.1:
+  uuid@11.1.1:
     optional: true
 
   vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+overrides:
+  uuid: ^11.1.1
 allowBuilds:
   '@firebase/util': true
   esbuild: true


### PR DESCRIPTION
## Summary
Resolves [Dependabot alert 349](https://github.com/bsmerbeck/smash-tracker/security/dependabot/349) — **GHSA-w5hq-g745-h8pq / CVE-2026-41907** (moderate): `uuid` <11.1.1 is missing a buffer bounds check in `v3`/`v5`/`v6` when a `buf` argument is provided.

## Why an override
The vulnerable `uuid@9.0.1` is a transitive dependency of `firebase-admin` in `apps/api`, pulled in via `@google-cloud/storage` → `gaxios@6` (`uuid ^9.0.1`) and `teeny-request@9` (`uuid ^9.0.0`). `firebase-admin` is already at the latest release (14.1.0), so no ordinary bump can reach the patched 11.1.1. This PR adds a pnpm `overrides` entry in `pnpm-workspace.yaml` (pnpm 11 no longer reads the `pnpm` field in `package.json`) forcing `uuid: ^11.1.1`. uuid@11 retains the CommonJS build and the `v4()` API those packages use, so the forced major bump is safe.

After the override, `pnpm why uuid -r` shows a single `uuid@11.1.1` across the workspace.

## Gate
- `pnpm lint` — 0 errors (31 pre-existing react-refresh warnings)
- `pnpm typecheck` — clean
- `pnpm test` — 605 passed (shared 37, api 91, web 477)
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)