### PR TITLE
V5 Phase A: standings, slugs, and opponent event context in sync

### DIFF
--- a/apps/api/src/routes/startgg.ts
+++ b/apps/api/src/routes/startgg.ts
@@ -122,6 +122,7 @@ const startggRoutes: FastifyPluginAsyncZod<StartggRoutesOptions> = async (app, o
         link.playerId,
         config.apiToken,
         fetchImpl,
+        request.log,
       );
     },
   );

--- a/apps/api/src/routes/tournaments.test.ts
+++ b/apps/api/src/routes/tournaments.test.ts
@@ -65,4 +65,64 @@ describe('GET /api/tournaments', () => {
       setsPlayed: 5,
     });
   });
+
+  it('passes through slug, eventSlug, and topStandings when present', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`tournamentEntries/${TEST_UID}`, {
+      '987': {
+        eventId: 987,
+        eventName: 'Ultimate Singles',
+        firstSetAt: 1_700_000_000_000,
+        lastSetAt: 1_700_000_500_000,
+        setsPlayed: 5,
+        slug: 'tournament/the-box-juice-box-26',
+        eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+        topStandings: [
+          { placement: 1, name: 'Champ', gamerTag: 'Champ', userSlug: 'user/abc123' },
+          { placement: 2, name: 'RunnerUp' },
+        ],
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/tournaments',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const [entry] = response.json() as Record<string, unknown>[];
+    expect(entry).toMatchObject({
+      slug: 'tournament/the-box-juice-box-26',
+      eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+      topStandings: [
+        { placement: 1, name: 'Champ', gamerTag: 'Champ', userSlug: 'user/abc123' },
+        { placement: 2, name: 'RunnerUp' },
+      ],
+    });
+  });
+
+  it('omits slug/eventSlug/topStandings when absent from the stored entry', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`tournamentEntries/${TEST_UID}`, {
+      '555': {
+        eventId: 555,
+        eventName: 'Ultimate Doubles',
+        firstSetAt: 1_701_000_000_000,
+        lastSetAt: 1_701_000_900_000,
+        setsPlayed: 2,
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/tournaments',
+      headers: authHeader(),
+    });
+
+    const [entry] = response.json() as Record<string, unknown>[];
+    expect('slug' in entry!).toBe(false);
+    expect('eventSlug' in entry!).toBe(false);
+    expect('topStandings' in entry!).toBe(false);
+  });
 });

--- a/apps/api/src/startgg/client.test.ts
+++ b/apps/api/src/startgg/client.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { fetchEventDetails, StartggApiError } from './client.js';
+
+function gqlResponse(data: unknown) {
+  return new Response(JSON.stringify({ data }));
+}
+
+describe('fetchEventDetails', () => {
+  it('parses slug, tournament slug, and top standings', async () => {
+    const fetchMock = async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      expect(String(url)).toBe('https://api.start.gg/gql/alpha');
+      const body = JSON.parse(String(init?.body)) as { variables: Record<string, unknown> };
+      expect(body.variables).toEqual({ eventId: 123, perPage: 8 });
+      return gqlResponse({
+        event: {
+          slug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+          tournament: { name: 'The Box: Juice Box 26', slug: 'tournament/the-box-juice-box-26' },
+          standings: {
+            nodes: [
+              {
+                placement: 1,
+                entrant: {
+                  name: 'Team | Champ',
+                  participants: [
+                    { player: { id: 1, gamerTag: 'Champ' }, user: { slug: 'user/9fb774ae' } },
+                  ],
+                },
+              },
+              {
+                placement: 2,
+                entrant: {
+                  name: 'RunnerUp',
+                  participants: [{ player: { id: 2, gamerTag: null }, user: { slug: null } }],
+                },
+              },
+            ],
+          },
+        },
+      });
+    };
+
+    const details = await fetchEventDetails('server-token', 123, fetchMock as typeof fetch);
+
+    expect(details.slug).toBe('tournament/the-box-juice-box-26/event/ultimate-singles');
+    expect(details.tournamentSlug).toBe('tournament/the-box-juice-box-26');
+    expect(details.topStandings).toEqual([
+      { placement: 1, name: 'Team | Champ', gamerTag: 'Champ', userSlug: 'user/9fb774ae' },
+      { placement: 2, name: 'RunnerUp' },
+    ]);
+  });
+
+  it('tolerates a fully nullish event (no slug, no standings)', async () => {
+    const fetchMock = async () => gqlResponse({ event: null });
+
+    const details = await fetchEventDetails('server-token', 999, fetchMock as typeof fetch);
+
+    expect(details).toEqual({ topStandings: [] });
+  });
+
+  it('tolerates nullish tournament and empty standings nodes', async () => {
+    const fetchMock = async () =>
+      gqlResponse({
+        event: {
+          slug: 'tournament/x/event/y',
+          tournament: null,
+          standings: { nodes: [null, { placement: null, entrant: null }] },
+        },
+      });
+
+    const details = await fetchEventDetails('server-token', 42, fetchMock as typeof fetch);
+
+    expect(details.slug).toBe('tournament/x/event/y');
+    expect(details.tournamentSlug).toBeUndefined();
+    expect(details.topStandings).toEqual([]);
+  });
+
+  it('throws a StartggApiError on GraphQL errors', async () => {
+    const fetchMock = async () =>
+      new Response(JSON.stringify({ errors: [{ message: 'event not found' }] }));
+
+    await expect(
+      fetchEventDetails('server-token', 1, fetchMock as typeof fetch),
+    ).rejects.toBeInstanceOf(StartggApiError);
+  });
+});

--- a/apps/api/src/startgg/client.ts
+++ b/apps/api/src/startgg/client.ts
@@ -115,7 +115,10 @@ const setsPageSchema = z.object({
                             .array(
                               z
                                 .object({
-                                  player: z.object({ id: z.number() }).nullish(),
+                                  player: z
+                                    .object({ id: z.number(), gamerTag: z.string().nullish() })
+                                    .nullish(),
+                                  user: z.object({ slug: z.string().nullish() }).nullish(),
                                 })
                                 .nullish(),
                             )
@@ -177,7 +180,7 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
           entrant {
             id
             name
-            participants { player { id } }
+            participants { player { id gamerTag } user { slug } }
             seeds { seedNum }
             standing { placement }
           }
@@ -209,4 +212,124 @@ export async function fetchPlayerSetsPage(
   );
   const sets = data.player?.sets;
   return { totalPages: sets?.pageInfo.totalPages ?? 0, sets: sets?.nodes ?? [] };
+}
+
+// ---- event details (slugs + standings, public data, server token) ----------
+
+const EVENT_STANDINGS_PER_PAGE = 8;
+
+const eventDetailsSchema = z.object({
+  event: z
+    .object({
+      slug: z.string().nullish(),
+      tournament: z.object({ name: z.string().nullish(), slug: z.string().nullish() }).nullish(),
+      standings: z
+        .object({
+          nodes: z
+            .array(
+              z
+                .object({
+                  placement: z.number().int().nullish(),
+                  entrant: z
+                    .object({
+                      name: z.string().nullish(),
+                      participants: z
+                        .array(
+                          z
+                            .object({
+                              player: z
+                                .object({
+                                  id: z.number().nullish(),
+                                  gamerTag: z.string().nullish(),
+                                })
+                                .nullish(),
+                              user: z.object({ slug: z.string().nullish() }).nullish(),
+                            })
+                            .nullish(),
+                        )
+                        .nullish(),
+                    })
+                    .nullish(),
+                })
+                .nullish(),
+            )
+            .nullish(),
+        })
+        .nullish(),
+    })
+    .nullish(),
+});
+
+const EVENT_DETAILS_QUERY = `query EventDetails($eventId: ID!, $perPage: Int!) {
+  event(id: $eventId) {
+    slug
+    tournament { name slug }
+    standings(query: { perPage: $perPage, page: 1 }) {
+      nodes {
+        placement
+        entrant {
+          name
+          participants { player { id gamerTag } user { slug } }
+        }
+      }
+    }
+  }
+}`;
+
+export interface StartggEventDetails {
+  /** Tournament slug, e.g. "tournament/the-box-juice-box-26". */
+  tournamentSlug?: string;
+  /** Event slug, e.g. "tournament/the-box-juice-box-26/event/ultimate-singles". */
+  slug?: string;
+  /** Top finishers of the event, per start.gg's default standings ordering. */
+  topStandings: {
+    placement: number;
+    name: string;
+    gamerTag?: string;
+    userSlug?: string;
+  }[];
+}
+
+/**
+ * Fetches an event's slug, parent tournament slug, and top standings
+ * (capped to `EVENT_STANDINGS_PER_PAGE`). Public data — usable with the
+ * server token. Nullish-tolerant throughout: start.gg omits fields freely,
+ * and callers (sync.ts) treat a fetch/parse failure for one event as
+ * non-fatal.
+ */
+export async function fetchEventDetails(
+  serverToken: string,
+  eventId: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<StartggEventDetails> {
+  const data = await gql(
+    serverToken,
+    EVENT_DETAILS_QUERY,
+    { eventId, perPage: EVENT_STANDINGS_PER_PAGE },
+    eventDetailsSchema,
+    fetchImpl,
+  );
+  const event = data.event;
+  const topStandings = (event?.standings?.nodes ?? []).flatMap((node) => {
+    if (!node || node.placement == null || !node.entrant?.name) {
+      return [];
+    }
+    const participant = node.entrant.participants?.find((p) => p != null);
+    const gamerTag = participant?.player?.gamerTag ?? undefined;
+    const userSlug = participant?.user?.slug ?? undefined;
+    return [
+      {
+        placement: node.placement,
+        name: node.entrant.name,
+        ...(gamerTag ? { gamerTag } : {}),
+        ...(userSlug ? { userSlug } : {}),
+      },
+    ];
+  });
+
+  return {
+    ...(event?.slug ? { slug: event.slug } : {}),
+    ...(event?.tournament?.slug ? { tournamentSlug: event.tournament.slug } : {}),
+    topStandings,
+  };
 }

--- a/apps/api/src/startgg/sync.test.ts
+++ b/apps/api/src/startgg/sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { StartggSyncSummary } from '@smash-tracker/shared';
 import { FakeDatabase } from '../test-support/fakeDatabase.js';
 import {
@@ -51,7 +51,17 @@ function makeSet(overrides: Partial<StartggSet> = {}): StartggSet {
           standing: { placement: 257 },
         },
       },
-      { entrant: { id: 2, name: 'PowPow', participants: [{ player: { id: 999 } }] } },
+      {
+        entrant: {
+          id: 2,
+          name: 'PowPow',
+          participants: [
+            { player: { id: 999, gamerTag: 'PowPow' }, user: { slug: 'user/9fb774ae' } },
+          ],
+          seeds: [{ seedNum: 12 }],
+          standing: { placement: 33 },
+        },
+      },
     ],
     games: [
       {
@@ -115,12 +125,36 @@ describe('gamesFromSet', () => {
       tournamentName: 'Test Weekly 42',
       roundText: 'Losers Round 2',
       bracketRound: -2,
+      opponentSeed: 12,
+      opponentPlacement: 33,
+      opponentUserSlug: 'user/9fb774ae',
     });
     expect(g1?.record.fighter_id).toBeGreaterThan(0);
     expect(g1?.record.map?.name).toBe('Battlefield');
     // Game 2: lost, accent-insensitive stage resolution
     expect(g2?.record.win).toBe(false);
     expect(g2?.record.map?.name).toContain('Stadium 2');
+  });
+
+  it('omits opponentSeed/opponentPlacement/opponentUserSlug when start.gg provides none', () => {
+    const summary = emptySummary();
+    const set = makeSet({
+      slots: [
+        {
+          entrant: {
+            id: 1,
+            name: 'Team | Me',
+            participants: [{ player: { id: PLAYER_ID } }],
+          },
+        },
+        { entrant: { id: 2, name: 'PowPow', participants: [{ player: { id: 999 } }] } },
+      ],
+    });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games[0]).toBeDefined();
+    expect('opponentSeed' in games[0]!.record).toBe(false);
+    expect('opponentPlacement' in games[0]!.record).toBe(false);
+    expect('opponentUserSlug' in games[0]!.record).toBe(false);
   });
 
   it('skips non-SSBU sets without counting them', () => {
@@ -367,11 +401,16 @@ describe('importPlayerMatches', () => {
     // occurrence across pages.
     const database = new FakeDatabase();
     const set = makeSet();
-    let call = 0;
-    const fetchMock = async () => {
-      call += 1;
-      // Same set delivered on both pages of a 2-page result.
-      return pageResponse([set], 2);
+    let setsPageCalls = 0;
+    const fetchMock = async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes('PlayerSets')) {
+        setsPageCalls += 1;
+        // Same set delivered on both pages of a 2-page result.
+        return pageResponse([set], 2);
+      }
+      // Event detail enrichment call — not under test here.
+      return new Response(JSON.stringify({ data: { event: null } }));
     };
 
     const summary = await importPlayerMatches(
@@ -382,7 +421,7 @@ describe('importPlayerMatches', () => {
       fetchMock as typeof fetch,
     );
 
-    expect(call).toBe(2);
+    expect(setsPageCalls).toBe(2);
     expect(summary.imported).toBe(2); // the set has 2 games, not 4
     const tree = database.dump() as Record<string, Record<string, unknown>>;
     const matches = tree['matches']?.['uid-1'] as Record<string, unknown>;
@@ -458,5 +497,147 @@ describe('importPlayerMatches', () => {
 
     const tree = database.dump() as Record<string, Record<string, unknown>>;
     expect(tree['tournamentEntries']).toBeUndefined();
+  });
+
+  function eventDetailsResponse(overrides: Record<string, unknown> = {}) {
+    return new Response(
+      JSON.stringify({
+        data: {
+          event: {
+            slug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+            tournament: { slug: 'tournament/the-box-juice-box-26' },
+            standings: {
+              nodes: [
+                {
+                  placement: 1,
+                  entrant: {
+                    name: 'Champ',
+                    participants: [
+                      { player: { id: 1, gamerTag: 'Champ' }, user: { slug: 'user/abc123' } },
+                    ],
+                  },
+                },
+              ],
+            },
+            ...overrides,
+          },
+        },
+      }),
+    );
+  }
+
+  /** Splits a combined fetch mock into sets-page vs event-detail calls by query text. */
+  function routedFetchMock(
+    onSetsPage: () => Promise<Response>,
+    onEventDetails: (eventId: number) => Promise<Response>,
+  ) {
+    return async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: Record<string, unknown>;
+      };
+      if (body.query.includes('PlayerSets')) {
+        return onSetsPage();
+      }
+      return onEventDetails(body.variables['eventId'] as number);
+    };
+  }
+
+  it('enriches the registry with slug/eventSlug/topStandings after pagination', async () => {
+    const database = new FakeDatabase();
+    let eventDetailCalls = 0;
+    const fetchMock = routedFetchMock(
+      async () => pageResponse([makeSet()]),
+      async () => {
+        eventDetailCalls += 1;
+        return eventDetailsResponse();
+      },
+    );
+
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+
+    expect(eventDetailCalls).toBe(1);
+    const tree = database.dump() as Record<string, Record<string, unknown>>;
+    const registry = tree['tournamentEntries']?.['uid-1'] as Record<string, unknown>;
+    expect(registry['987']).toMatchObject({
+      slug: 'tournament/the-box-juice-box-26',
+      eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+      topStandings: [{ placement: 1, name: 'Champ', gamerTag: 'Champ', userSlug: 'user/abc123' }],
+    });
+  });
+
+  it('logs and skips enrichment for an event whose detail fetch fails, without failing the sync', async () => {
+    const database = new FakeDatabase();
+    const fetchMock = routedFetchMock(
+      async () => pageResponse([makeSet()]),
+      async () => new Response('boom', { status: 500 }),
+    );
+    const logger = { warn: vi.fn() };
+
+    const summary = await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+      logger,
+    );
+
+    expect(summary.sets).toBe(1); // sync itself succeeded
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0]?.[0]).toMatchObject({ eventId: 987 });
+
+    const tree = database.dump() as Record<string, Record<string, unknown>>;
+    const registry = tree['tournamentEntries']?.['uid-1'] as Record<string, unknown>;
+    // Base registry fields are still present; enrichment fields are simply absent.
+    expect(registry['987']).toMatchObject({ eventId: 987, eventName: 'Ultimate Singles' });
+    expect('slug' in (registry['987'] as object)).toBe(false);
+    expect('eventSlug' in (registry['987'] as object)).toBe(false);
+    expect('topStandings' in (registry['987'] as object)).toBe(false);
+  });
+
+  it('caps event detail enrichment at 20 events, preferring the most recently active', async () => {
+    const database = new FakeDatabase();
+    // 25 distinct events, each with one set, with increasing completedAt so
+    // recency order is deterministic (event N+1 is more recent than N).
+    const sets = Array.from({ length: 25 }, (_, i) =>
+      makeSet({
+        id: i + 1,
+        completedAt: 1_700_000_000 + i,
+        event: {
+          id: 1000 + i,
+          name: `Event ${i}`,
+          isOnline: true,
+          videogame: { id: 1386 },
+        },
+      }),
+    );
+    const requestedEventIds: number[] = [];
+    const fetchMock = routedFetchMock(
+      async () => pageResponse(sets),
+      async (eventId) => {
+        requestedEventIds.push(eventId);
+        return eventDetailsResponse();
+      },
+    );
+
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+
+    expect(requestedEventIds).toHaveLength(20);
+    // Most-recent-first: events 1005..1024 (the last 20 by completedAt), not 1000..1004.
+    const expectedIds = Array.from({ length: 20 }, (_, i) => 1024 - i);
+    expect(requestedEventIds).toEqual(expectedIds);
   });
 });

--- a/apps/api/src/startgg/sync.ts
+++ b/apps/api/src/startgg/sync.ts
@@ -1,11 +1,23 @@
 import type { Database } from 'firebase-admin/database';
 import type { MatchRecord, StartggSyncSummary, TournamentEntry } from '@smash-tracker/shared';
-import { fetchPlayerSetsPage, SSBU_VIDEOGAME_ID, type StartggSet } from './client.js';
+import {
+  fetchEventDetails,
+  fetchPlayerSetsPage,
+  SSBU_VIDEOGAME_ID,
+  type StartggSet,
+} from './client.js';
 import { startggCharacterToFighterId } from './characterMap.js';
 import { resolveStageByName } from './stageMap.js';
 
 /** Hard cap on pages per sync — 40 pages x 10 sets stays well inside the 80 req/60s rate limit. */
 const MAX_PAGES = 40;
+
+/**
+ * Hard cap on per-event detail fetches (slug + standings) per sync. Combined
+ * with `MAX_PAGES` sets pages, worst case is 40 + 20 = 60 requests — still
+ * comfortably under the 80 req/60s start.gg rate limit.
+ */
+const MAX_EVENT_DETAIL_FETCHES = 20;
 
 // eslint-disable-next-line no-control-regex -- control chars are exactly what RTDB keys forbid
 const RTDB_ILLEGAL = /[.#$[\]/\u0000-\u001f]/g;
@@ -73,6 +85,12 @@ export function gamesFromSet(
   const tournamentName = set.event?.tournament?.name?.trim();
   const roundText = set.fullRoundText?.trim();
   const bracketRound = typeof set.round === 'number' ? set.round : undefined;
+  // Per-event facts about the human opponent, duplicated per game by design
+  // (RTDB read simplicity beats normalization here).
+  const opponentSeed = opponentEntrant.seeds?.find((s) => typeof s?.seedNum === 'number')?.seedNum;
+  const opponentPlacement = opponentEntrant.standing?.placement ?? undefined;
+  const opponentUserSlug = (opponentEntrant.participants ?? []).find((p) => p?.user?.slug != null)
+    ?.user?.slug;
   const results: ImportableGame[] = [];
 
   games.forEach((game, index) => {
@@ -122,6 +140,9 @@ export function gamesFromSet(
         ...(tournamentName ? { tournamentName } : {}),
         ...(roundText ? { roundText } : {}),
         ...(bracketRound !== undefined ? { bracketRound } : {}),
+        ...(opponentSeed != null ? { opponentSeed } : {}),
+        ...(opponentPlacement != null ? { opponentPlacement } : {}),
+        ...(opponentUserSlug ? { opponentUserSlug } : {}),
       },
     });
   });
@@ -220,6 +241,12 @@ export function accumulateRegistry(
  * opponents/{uid} exactly like manual entry does. Also accumulates a
  * per-event tournament registry under tournamentEntries/{uid}, keyed by
  * event id, idempotent the same way (re-syncs overwrite in place).
+ *
+ * After pagination, the most-recently-active events (capped at
+ * `MAX_EVENT_DETAIL_FETCHES`) are enriched with their start.gg slug and top
+ * standings via one `fetchEventDetails` call each. Enrichment failures are
+ * logged (via the optional `logger`) and skipped per-event — they never
+ * fail the sync as a whole.
  */
 export async function importPlayerMatches(
   database: Database,
@@ -227,6 +254,7 @@ export async function importPlayerMatches(
   playerId: number,
   serverToken: string,
   fetchImpl: typeof fetch = fetch,
+  logger?: { warn: (obj: unknown, msg?: string) => void },
 ): Promise<StartggSyncSummary> {
   const summary: StartggSyncSummary = {
     sets: 0,
@@ -283,6 +311,37 @@ export async function importPlayerMatches(
         setsPlayed: acc.setsPlayed,
       };
     }
+
+    // Enrich with slug/standings, most-recently-active events first, capped
+    // at MAX_EVENT_DETAIL_FETCHES to respect the rate limit. A per-event
+    // fetch/parse failure is logged and skipped — it must never fail the
+    // whole sync, since the registry write above already succeeded.
+    const eventIdsByRecency = [...registry.values()]
+      .sort((a, b) => b.lastSetAt - a.lastSetAt)
+      .slice(0, MAX_EVENT_DETAIL_FETCHES)
+      .map((acc) => acc.eventId);
+
+    for (const eventId of eventIdsByRecency) {
+      try {
+        const details = await fetchEventDetails(serverToken, eventId, fetchImpl);
+        const entry = registryUpdates[String(eventId)];
+        if (!entry) {
+          continue;
+        }
+        registryUpdates[String(eventId)] = {
+          ...entry,
+          ...(details.slug ? { eventSlug: details.slug } : {}),
+          ...(details.tournamentSlug ? { slug: details.tournamentSlug } : {}),
+          ...(details.topStandings.length > 0 ? { topStandings: details.topStandings } : {}),
+        };
+      } catch (err) {
+        logger?.warn(
+          { err, eventId },
+          'start.gg event detail enrichment failed; skipping for this event',
+        );
+      }
+    }
+
     await database.ref(`tournamentEntries/${uid}`).update(registryUpdates);
   }
   await database.ref(`startggLinks/${uid}/lastSyncAt`).set(Date.now());

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   opponentListSchema,
   opponentMapSchema,
   stageSchema,
+  tournamentEntrySchema,
   updateMatchInputSchema,
   userProfileSchema,
   userSchema,
@@ -170,6 +171,53 @@ describe('matchRecordSchema', () => {
         time: 1700000000000,
         win: true,
         stocksLeft: 1.5,
+      }),
+    ).toThrow();
+  });
+
+  it('parses opponentSeed/opponentPlacement/opponentUserSlug when start.gg provides them', () => {
+    const record = {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: true,
+      opponentSeed: 12,
+      opponentPlacement: 33,
+      opponentUserSlug: 'user/9fb774ae',
+    };
+    expect(matchRecordSchema.parse(record)).toEqual(record);
+  });
+
+  it('omits opponentSeed/opponentPlacement/opponentUserSlug when absent', () => {
+    const record = {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: true,
+    };
+    const parsed = matchRecordSchema.parse(record);
+    expect('opponentSeed' in parsed).toBe(false);
+    expect('opponentPlacement' in parsed).toBe(false);
+    expect('opponentUserSlug' in parsed).toBe(false);
+  });
+
+  it('rejects a non-positive opponentSeed or opponentPlacement', () => {
+    expect(() =>
+      matchRecordSchema.parse({
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1700000000000,
+        win: true,
+        opponentSeed: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      matchRecordSchema.parse({
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1700000000000,
+        win: true,
+        opponentPlacement: -1,
       }),
     ).toThrow();
   });
@@ -357,5 +405,49 @@ describe('opponent schemas', () => {
 
   it('parses an opponent list', () => {
     expect(opponentListSchema.parse(['someplayer', 'other'])).toEqual(['someplayer', 'other']);
+  });
+});
+
+describe('tournamentEntrySchema', () => {
+  const base = {
+    eventId: 987,
+    eventName: 'Ultimate Singles',
+    firstSetAt: 1_700_000_000_000,
+    lastSetAt: 1_700_000_500_000,
+    setsPlayed: 5,
+  };
+
+  it('parses the base shape without slug/eventSlug/topStandings', () => {
+    expect(tournamentEntrySchema.parse(base)).toEqual(base);
+  });
+
+  it('parses slug, eventSlug, and topStandings when present', () => {
+    const entry = {
+      ...base,
+      slug: 'tournament/the-box-juice-box-26',
+      eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+      topStandings: [
+        { placement: 1, name: 'Champ', gamerTag: 'Champ', userSlug: 'user/abc123' },
+        { placement: 2, name: 'RunnerUp' },
+      ],
+    };
+    expect(tournamentEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it('rejects a topStandings array longer than 8', () => {
+    const topStandings = Array.from({ length: 9 }, (_, i) => ({
+      placement: i + 1,
+      name: `Player ${i + 1}`,
+    }));
+    expect(() => tournamentEntrySchema.parse({ ...base, topStandings })).toThrow();
+  });
+
+  it('rejects a topStandings entry missing a placement or name', () => {
+    expect(() =>
+      tournamentEntrySchema.parse({ ...base, topStandings: [{ name: 'NoPlacement' }] }),
+    ).toThrow();
+    expect(() =>
+      tournamentEntrySchema.parse({ ...base, topStandings: [{ placement: 1 }] }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -95,6 +95,25 @@ export const matchRecordSchema = z.object({
    * Server-set, imported matches only.
    */
   bracketRound: z.number().int().optional(),
+  /**
+   * The human opponent's seed in the event this match belonged to, when
+   * start.gg provides it. Per-event fact about the opponent, intentionally
+   * duplicated across every game/match row from that event (RTDB read
+   * simplicity beats normalization here). Server-set, imported matches only.
+   */
+  opponentSeed: z.number().int().positive().optional(),
+  /**
+   * The human opponent's final placement in the event this match belonged
+   * to, when start.gg provides it. Same per-event duplication rationale as
+   * `opponentSeed`. Server-set, imported matches only.
+   */
+  opponentPlacement: z.number().int().positive().optional(),
+  /**
+   * The human opponent's start.gg profile slug (e.g. "user/9fb774ae"), when
+   * start.gg provides it. Same per-event duplication rationale as
+   * `opponentSeed`. Server-set, imported matches only.
+   */
+  opponentUserSlug: z.string().optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 

--- a/packages/shared/src/startgg.ts
+++ b/packages/shared/src/startgg.ts
@@ -55,6 +55,24 @@ export const startggAuthorizeResponseSchema = z.object({
 });
 
 /**
+ * One entrant's placement in `topStandings` (see `tournamentEntrySchema`).
+ * Mirrors the shape of `event.standings.nodes` from start.gg's API — not
+ * necessarily the tracked user; this is the public leaderboard context for
+ * the event, capped to a handful of top finishers.
+ */
+export const eventStandingSchema = z.object({
+  /** The entrant's placement in the event (1 = winner). */
+  placement: z.number().int().positive(),
+  /** Entrant display name as start.gg renders it (may include a sponsor prefix). */
+  name: z.string().min(1),
+  /** The player's gamer tag, when start.gg provides it. */
+  gamerTag: z.string().optional(),
+  /** The player's start.gg profile slug (e.g. "user/9fb774ae"), when start.gg provides it. */
+  userSlug: z.string().optional(),
+});
+export type EventStanding = z.infer<typeof eventStandingSchema>;
+
+/**
  * `tournamentEntries/{uid}/{eventId}` — one entry per start.gg event the
  * user has processed sets for, accumulated during sync. Server-only write;
  * exposed read-only via GET /api/tournaments. Optional fields are omitted
@@ -80,6 +98,12 @@ export const tournamentEntrySchema = z.object({
   lastSetAt: z.number().int().nonnegative(),
   /** Count of non-DQ sets processed for this event. */
   setsPlayed: z.number().int().nonnegative(),
+  /** Tournament slug (e.g. "tournament/the-box-juice-box-26"), fetched post-sync. */
+  slug: z.string().optional(),
+  /** Event slug (e.g. "tournament/the-box-juice-box-26/event/ultimate-singles"), fetched post-sync. */
+  eventSlug: z.string().optional(),
+  /** Top finishers of the event (capped, ~8), fetched post-sync. */
+  topStandings: z.array(eventStandingSchema).max(8).optional(),
 });
 export type TournamentEntry = z.infer<typeof tournamentEntrySchema>;
 


### PR DESCRIPTION
## Summary

- **Client** (`apps/api/src/startgg/client.ts`): `SETS_QUERY` now requests `participants { player { id gamerTag } user { slug } }` on each slot entrant (nullish-tolerant). New `fetchEventDetails(serverToken, eventId, fetchImpl)` calls the probe-verified `event(id) { slug tournament { slug } standings(query: {perPage: 8, page: 1}) { nodes { placement entrant { name participants { player { gamerTag } user { slug } } } } } }` query and returns `{ slug?, tournamentSlug?, topStandings[] }`, fully nullish-tolerant.
- **Sync** (`apps/api/src/startgg/sync.ts`): `gamesFromSet` now captures the *opponent* entrant's `seeds[0].seedNum`, `standing.placement`, and `participants[].user.slug` onto every imported game record as `opponentSeed` / `opponentPlacement` / `opponentUserSlug` (conditional spreads — omitted, never `undefined`, per the RTDB rule). After pagination, `importPlayerMatches` enriches the tournament registry: the most-recently-active events (sorted by `lastSetAt` desc, capped at `MAX_EVENT_DETAIL_FETCHES = 20`) each get one `fetchEventDetails` call, attaching `slug` / `eventSlug` / `topStandings` to their `tournamentEntries/{uid}/{eventId}` record. A per-event fetch/parse failure is logged via an optional `logger` param (wired from `request.log` in the sync route) and skipped — it never fails the sync as a whole.
- **Shared schemas**: `tournamentEntrySchema` gains optional `slug`, `eventSlug`, `topStandings` (new `eventStandingSchema`, max 8 entries: `placement`, `name`, optional `gamerTag`/`userSlug`). `matchRecordSchema` gains optional `opponentSeed`, `opponentPlacement`, `opponentUserSlug` — per-event facts about the human opponent, intentionally duplicated per match/game row (RTDB read simplicity over normalization).
- **Route** (`apps/api/src/routes/tournaments.ts`): no code change needed — it already parses each entry with `tournamentEntrySchema` and the Fastify zod serializer passes the new optional fields straight through. Added passthrough + omission tests to confirm.

## Rate limit handling

Sets pagination is capped at `MAX_PAGES = 40`; event-detail enrichment is capped at `MAX_EVENT_DETAIL_FETCHES = 20`. Worst case per sync: 40 + 20 = 60 requests, comfortably under start.gg's 80 req/60s limit.

## Test plan

- [x] `packages/shared` — 44 tests passing (added: `matchRecordSchema` opponent-context optionals present/absent/validation; new `tournamentEntrySchema` describe block covering base shape, slug/eventSlug/topStandings present, `topStandings` max-8 rejection, and missing placement/name rejection).
- [x] `apps/api` — 101 tests passing (added: `client.test.ts` for `fetchEventDetails` — happy path, fully-nullish event, nullish tournament/empty standings nodes, GraphQL error → `StartggApiError`; `sync.test.ts` additions for opponent seed/placement/slug capture + omission, registry enrichment happy path, failure-tolerance with logger assertion, and the 20-event recency cap with 25 synthetic events).
- [x] `apps/web` — 477 tests passing, unchanged (no `apps/web` files touched, per scope).
- [x] `pnpm lint` — 0 errors (31 pre-existing warnings in untouched `apps/web` files).
- [x] `pnpm typecheck` — clean across all packages.
- [x] `pnpm build` — clean across all packages.
- [x] `pnpm format:check` — clean.

## Deviations

- `importPlayerMatches` gained an optional trailing `logger` parameter (`{ warn: (obj, msg?) => void }`) to report per-event enrichment failures without throwing; the sync route (`apps/api/src/routes/startgg.ts`) passes `request.log`. This wasn't explicitly specified but was needed to satisfy "tolerate per-event fetch failure: log, skip enrichment for that event, never fail the sync."
- Scope respected: no changes outside `packages/shared/src/{match.ts,startgg.ts}`, `apps/api/src/startgg/**`, `apps/api/src/routes/{startgg.ts,tournaments.ts}`, and their tests. `packages/shared/src/opponent.ts` and all of `apps/web` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)