### PR TITLE
V5 Phase C: opponent source badges + alias merge

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,7 @@ import authPlugin from './plugins/auth.js';
 import usersRoutes from './routes/users.js';
 import matchesRoutes from './routes/matches.js';
 import opponentsRoutes from './routes/opponents.js';
+import opponentAliasesRoutes from './routes/opponentAliases.js';
 import startggRoutes from './routes/startgg.js';
 import tournamentsRoutes from './routes/tournaments.js';
 import { NotFoundError } from './services/rtdb.js';
@@ -112,6 +113,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(usersRoutes);
       await api.register(matchesRoutes);
       await api.register(opponentsRoutes);
+      await api.register(opponentAliasesRoutes);
       await api.register(tournamentsRoutes);
       await api.register(startggRoutes, {
         config: options.startgg ?? null,

--- a/apps/api/src/routes/opponentAliases.test.ts
+++ b/apps/api/src/routes/opponentAliases.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+describe('GET /api/opponents/aliases', () => {
+  it('returns an empty map when no aliases exist', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/opponents/aliases',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({});
+  });
+
+  it('returns the flat alias map', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`opponentAliases/${TEST_UID}`, { rivl: 'rival', riv: 'rival' });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/opponents/aliases',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ rivl: 'rival', riv: 'rival' });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'GET', url: '/api/opponents/aliases' });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/opponents/aliases/:alias', () => {
+  it('writes a new alias -> canonical mapping and returns the updated map', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/rivl',
+      headers: authHeader(),
+      payload: { canonical: 'rival' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ rivl: 'rival' });
+    expect(database.dump()).toMatchObject({
+      opponentAliases: { [TEST_UID]: { rivl: 'rival' } },
+    });
+  });
+
+  it('normalizes both the alias (params) and canonical (body) name', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/opponents/aliases/${encodeURIComponent('  Rivl  ')}`,
+      headers: authHeader(),
+      payload: { canonical: '  Rival  ' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ rivl: 'rival' });
+  });
+
+  it('rejects a direct self-merge (alias === canonical)', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/rival',
+      headers: authHeader(),
+      payload: { canonical: 'rival' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().message).toMatch(/cannot be merged into itself/i);
+  });
+
+  it('rejects a self-merge that only becomes apparent after transitive resolution', async () => {
+    const { app, database } = buildTestApp();
+    // "rivl" already resolves to "rival". Writing rival -> rivl should
+    // resolve rivl -> rival first, discover the target IS rival, and reject.
+    database.seed(`opponentAliases/${TEST_UID}`, { rivl: 'rival' });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/rival',
+      headers: authHeader(),
+      payload: { canonical: 'rivl' },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('resolves the canonical transitively when the target is itself an alias, keeping the map flat', async () => {
+    const { app, database } = buildTestApp();
+    // "riv" -> "rivl" already exists. Merging "rivl" -> "rival" should NOT
+    // create a chain; instead "riv" continues to resolve correctly because
+    // "rivl" becomes a terminal alias pointing at "rival", and a fresh write
+    // of another alias into "rivl" resolves through it.
+    database.seed(`opponentAliases/${TEST_UID}`, { riv: 'rivl' });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/newalias',
+      headers: authHeader(),
+      payload: { canonical: 'riv' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // "riv" resolves (through the existing map) to "rivl" — the final
+    // non-aliased name — so "newalias" is written pointing at "rivl", not "riv".
+    expect(response.json()).toEqual({ riv: 'rivl', newalias: 'rivl' });
+  });
+
+  it('rejects an invalid canonical name (blank)', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/rivl',
+      headers: authHeader(),
+      payload: { canonical: '' },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects an alias param containing RTDB-reserved characters', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/opponents/aliases/${encodeURIComponent('a/b')}`,
+      headers: authHeader(),
+      payload: { canonical: 'rival' },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/opponents/aliases/rivl',
+      payload: { canonical: 'rival' },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('DELETE /api/opponents/aliases/:alias', () => {
+  it('removes an existing alias', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`opponentAliases/${TEST_UID}`, { rivl: 'rival' });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/opponents/aliases/rivl',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(database.dump()).not.toMatchObject({
+      opponentAliases: { [TEST_UID]: { rivl: 'rival' } },
+    });
+  });
+
+  it('returns 404 for a non-existent alias', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/opponents/aliases/nope',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/opponents/aliases/rivl',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/apps/api/src/routes/opponentAliases.ts
+++ b/apps/api/src/routes/opponentAliases.ts
@@ -1,0 +1,95 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  errorResponseSchema,
+  opponentAliasMapSchema,
+  opponentNameInputSchema,
+  upsertOpponentAliasInputSchema,
+} from '@smash-tracker/shared';
+import { RtdbService, ValidationError } from '../services/rtdb.js';
+
+const aliasParamsSchema = z.object({
+  alias: opponentNameInputSchema,
+});
+
+/**
+ * V5 Phase C: opponent identity. `opponentAliases/{uid}` is a flat map from
+ * an alias opponent name to the canonical name it should display/aggregate
+ * as (see packages/shared/src/opponent.ts for the full write-time
+ * resolution + cycle-rejection rules). Web's `useFilteredMatches` is the
+ * single choke point that applies this map to rewrite `match.opponent`
+ * before any downstream consumer (scouting, tables, dashboards) sees it.
+ */
+const opponentAliasesRoutes: FastifyPluginAsyncZod = async (app) => {
+  const rtdb = new RtdbService(app.firebase.database);
+
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/opponents/aliases
+  app.get(
+    '/opponents/aliases',
+    {
+      schema: {
+        response: {
+          200: opponentAliasMapSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.listOpponentAliases(request.uid);
+    },
+  );
+
+  // PUT /api/opponents/aliases/:alias
+  app.put(
+    '/opponents/aliases/:alias',
+    {
+      schema: {
+        params: aliasParamsSchema,
+        body: upsertOpponentAliasInputSchema,
+        response: {
+          200: opponentAliasMapSchema,
+          400: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        return await rtdb.setOpponentAlias(
+          request.uid,
+          request.params.alias,
+          request.body.canonical,
+        );
+      } catch (err) {
+        if (err instanceof ValidationError) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: err.message,
+            statusCode: 400,
+          });
+        }
+        throw err;
+      }
+    },
+  );
+
+  // DELETE /api/opponents/aliases/:alias — NotFoundError from the service
+  // bubbles up to the global error handler, which maps it to a 404.
+  app.delete(
+    '/opponents/aliases/:alias',
+    {
+      schema: {
+        params: aliasParamsSchema,
+        response: {
+          204: z.undefined(),
+        },
+      },
+    },
+    async (request, reply) => {
+      await rtdb.deleteOpponentAlias(request.uid, request.params.alias);
+      return reply.code(204).send();
+    },
+  );
+};
+
+export default opponentAliasesRoutes;

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -1,12 +1,14 @@
 import type { Database } from 'firebase-admin/database';
 import {
   matchRecordSchema,
+  opponentAliasMapSchema,
   opponentMapSchema,
   userSchema,
   type CreateMatchInput,
   type FighterSelectionInput,
   type Match,
   type MatchRecord,
+  type OpponentAliasMap,
   type UpdateMatchInput,
   type User,
 } from '@smash-tracker/shared';
@@ -15,6 +17,14 @@ export class NotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'NotFoundError';
+  }
+}
+
+/** Thrown for a 400-worthy alias write: self-merge (alias === canonical after resolution). */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
   }
 }
 
@@ -157,5 +167,63 @@ export class RtdbService {
 
   private async addOpponent(uid: string, name: string): Promise<void> {
     await this.database.ref(`opponents/${uid}/${name}`).set(true);
+  }
+
+  // ---- opponentAliases/{uid}/{alias} -------------------------------------
+
+  async listOpponentAliases(uid: string): Promise<OpponentAliasMap> {
+    const snapshot = await this.database.ref(`opponentAliases/${uid}`).get();
+    if (!snapshot.exists()) {
+      return {};
+    }
+    return opponentAliasMapSchema.parse(snapshot.val());
+  }
+
+  /**
+   * Writes `alias -> canonical`. To keep the map flat (no chains, so every
+   * value is always itself a terminal/non-aliased name), the requested
+   * `canonical` is first resolved through the existing map — if `canonical`
+   * is itself currently an alias for some other name, the alias is pointed
+   * at that final name instead. After resolution, `alias === canonical`
+   * (a self-merge) is rejected with `ValidationError` (maps to 400).
+   *
+   * Note this does NOT re-point other aliases that already targeted `alias`
+   * itself (i.e. if `alias` was previously used as someone's canonical
+   * value) — per the locked design, resolution happens at write time on the
+   * new edge only; a name being merged away while other aliases still point
+   * at it is expected to be rare and is surfaced via the "Merged names" UI
+   * card so the user can review before merging further.
+   */
+  async setOpponentAlias(uid: string, alias: string, canonical: string): Promise<OpponentAliasMap> {
+    const map = await this.listOpponentAliases(uid);
+    const resolved = this.resolveCanonical(map, canonical);
+
+    if (alias === resolved) {
+      throw new ValidationError('An opponent cannot be merged into itself');
+    }
+
+    const next = { ...map, [alias]: resolved };
+    await this.database.ref(`opponentAliases/${uid}/${alias}`).set(resolved);
+    return next;
+  }
+
+  async deleteOpponentAlias(uid: string, alias: string): Promise<void> {
+    const ref = this.database.ref(`opponentAliases/${uid}/${alias}`);
+    const existing = await ref.get();
+    if (!existing.exists()) {
+      throw new NotFoundError(`Alias ${alias} not found`);
+    }
+    await ref.remove();
+  }
+
+  /** Follows `map` from `name` until reaching a name that isn't itself an alias key. */
+  private resolveCanonical(map: OpponentAliasMap, name: string): string {
+    const seen = new Set<string>();
+    let current = name;
+    while (Object.prototype.hasOwnProperty.call(map, current) && !seen.has(current)) {
+      seen.add(current);
+      current = map[current]!;
+    }
+    return current;
   }
 }

--- a/apps/web/src/hooks/useFilteredMatches.test.ts
+++ b/apps/web/src/hooks/useFilteredMatches.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { Match } from '@smash-tracker/shared';
-import { filterBySource, filterByRange } from './useFilteredMatches';
+import {
+  applyOpponentAliases,
+  filterBySource,
+  filterByRange,
+  getOpponentSources,
+} from './useFilteredMatches';
 
 const manual = { id: 'm1', fighter_id: 1, opponent_id: 2, time: 1, win: true } as Match;
 const imported = {
@@ -64,5 +69,80 @@ describe('filterByRange', () => {
     const tooOld = matchAt('too-old', now - 400 * DAY_MS);
     expect(filterByRange([at6m, at12m, tooOld], '6m', now)).toEqual([at6m]);
     expect(filterByRange([at6m, at12m, tooOld], '12m', now)).toEqual([at6m, at12m]);
+  });
+});
+
+function withOpponent(id: string, opponent: string | undefined, source?: 'startgg'): Match {
+  return {
+    id,
+    fighter_id: 1,
+    opponent_id: 2,
+    time: 1,
+    win: true,
+    ...(opponent !== undefined ? { opponent } : {}),
+    ...(source ? { source } : {}),
+  } as Match;
+}
+
+describe('applyOpponentAliases', () => {
+  it('returns the same array reference when the alias map is empty', () => {
+    const matches = [withOpponent('m1', 'rival')];
+    expect(applyOpponentAliases(matches, {})).toBe(matches);
+  });
+
+  it('rewrites match.opponent to the canonical name', () => {
+    const matches = [withOpponent('m1', 'rivl')];
+    const result = applyOpponentAliases(matches, { rivl: 'rival' });
+    expect(result[0]!.opponent).toBe('rival');
+  });
+
+  it('leaves matches without an opponent untouched', () => {
+    const matches = [withOpponent('m1', undefined)];
+    const result = applyOpponentAliases(matches, { rivl: 'rival' });
+    expect(result[0]).toBe(matches[0]);
+  });
+
+  it('leaves matches whose opponent is not an alias key untouched (same reference)', () => {
+    const matches = [withOpponent('m1', 'someoneelse')];
+    const result = applyOpponentAliases(matches, { rivl: 'rival' });
+    expect(result[0]).toBe(matches[0]);
+  });
+
+  it('applies a chain of aliases pointing at different names independently', () => {
+    const matches = [withOpponent('m1', 'rivl'), withOpponent('m2', 'riv')];
+    const result = applyOpponentAliases(matches, { rivl: 'rival', riv: 'rival' });
+    expect(result.map((m) => m.opponent)).toEqual(['rival', 'rival']);
+  });
+});
+
+describe('getOpponentSources', () => {
+  it('classifies an opponent with only imported matches as startgg', () => {
+    const matches = [
+      withOpponent('m1', 'rival', 'startgg'),
+      withOpponent('m2', 'rival', 'startgg'),
+    ];
+    expect(getOpponentSources(matches).get('rival')).toBe('startgg');
+  });
+
+  it('classifies an opponent with only manual matches as manual', () => {
+    const matches = [withOpponent('m1', 'rival'), withOpponent('m2', 'rival')];
+    expect(getOpponentSources(matches).get('rival')).toBe('manual');
+  });
+
+  it('classifies an opponent with both as mixed', () => {
+    const matches = [withOpponent('m1', 'rival', 'startgg'), withOpponent('m2', 'rival')];
+    expect(getOpponentSources(matches).get('rival')).toBe('mixed');
+  });
+
+  it('ignores matches with no opponent name', () => {
+    const matches = [withOpponent('m1', undefined)];
+    expect(getOpponentSources(matches).size).toBe(0);
+  });
+
+  it('tracks multiple opponents independently', () => {
+    const matches = [withOpponent('m1', 'rival', 'startgg'), withOpponent('m2', 'zeta')];
+    const sources = getOpponentSources(matches);
+    expect(sources.get('rival')).toBe('startgg');
+    expect(sources.get('zeta')).toBe('manual');
   });
 });

--- a/apps/web/src/hooks/useFilteredMatches.ts
+++ b/apps/web/src/hooks/useFilteredMatches.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
-import type { Match } from '@smash-tracker/shared';
+import type { Match, OpponentAliasMap } from '@smash-tracker/shared';
 import { useMatches } from '@/hooks/useMatches';
 import { useAnalyticsFilter } from '@/hooks/useAnalyticsFilter';
+import { useOpponentAliases } from '@/hooks/useOpponentAliases';
 import type { AnalyticsRangeFilter, AnalyticsSourceFilter } from '@/context/AnalyticsFilterContext';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -41,6 +42,65 @@ export function filterByRange(
   return matches.filter((m) => m.time >= cutoff);
 }
 
+/**
+ * Rewrites `match.opponent` to its canonical name per `aliasMap` (alias ->
+ * canonical). Matches with no `opponent` set, or whose opponent isn't a key
+ * in the map, are returned unchanged (same object reference — no unnecessary
+ * re-renders downstream). This is the SINGLE CHOKE POINT for opponent
+ * identity merging: every consumer that reads `match.opponent` should go
+ * through `useFilteredMatches` (which applies this) rather than raw
+ * `useMatches`, so scouting/tables/dashboards all see merged identities
+ * automatically without each needing alias-awareness of their own.
+ */
+export function applyOpponentAliases(matches: Match[], aliasMap: OpponentAliasMap): Match[] {
+  if (Object.keys(aliasMap).length === 0) {
+    return matches;
+  }
+  return matches.map((match) => {
+    if (!match.opponent || !Object.prototype.hasOwnProperty.call(aliasMap, match.opponent)) {
+      return match;
+    }
+    return { ...match, opponent: aliasMap[match.opponent]! };
+  });
+}
+
+export type OpponentSource = 'startgg' | 'manual' | 'mixed';
+
+/**
+ * Per canonical opponent name (post-alias-merge — call after
+ * `applyOpponentAliases`), classifies where their matches came from:
+ * 'startgg' when every match for that name was imported, 'manual' when none
+ * were, 'mixed' otherwise. Powers the source badges on the scouting list +
+ * report header. Matches without an opponent name are ignored.
+ */
+export function getOpponentSources(matches: Match[]): Map<string, OpponentSource> {
+  const flags = new Map<string, { hasStartgg: boolean; hasManual: boolean }>();
+  for (const match of matches) {
+    if (!match.opponent) {
+      continue;
+    }
+    const entry = flags.get(match.opponent) ?? { hasStartgg: false, hasManual: false };
+    if (match.source === 'startgg') {
+      entry.hasStartgg = true;
+    } else {
+      entry.hasManual = true;
+    }
+    flags.set(match.opponent, entry);
+  }
+
+  const sources = new Map<string, OpponentSource>();
+  for (const [opponent, { hasStartgg, hasManual }] of flags) {
+    if (hasStartgg && hasManual) {
+      sources.set(opponent, 'mixed');
+    } else if (hasStartgg) {
+      sources.set(opponent, 'startgg');
+    } else {
+      sources.set(opponent, 'manual');
+    }
+  }
+  return sources;
+}
+
 export interface UseFilteredMatchesResult {
   /** Matches after applying the global source + time-range filter. */
   matches: Match[];
@@ -58,10 +118,25 @@ export interface UseFilteredMatchesResult {
   filterActive: boolean;
 }
 
-/** Wraps `useMatches` with the global analytics filter (source + time range) applied. */
+/**
+ * Wraps `useMatches` with opponent-alias canonicalization + the global
+ * analytics filter (source + time range) applied, in that order — aliases
+ * are resolved first so every downstream filter/consumer already sees
+ * merged identities (the single choke point; see `applyOpponentAliases`).
+ *
+ * The alias query is enabled only when authed (same gate as `useMatches`);
+ * while it's loading (or absent), an empty map is used rather than gating
+ * render on it, per the locked design — no loading flicker for pages that
+ * just want to show opponent names quickly and re-render once aliases land.
+ */
 export function useFilteredMatches(): UseFilteredMatchesResult {
-  const { data: allMatches = [], isLoading } = useMatches();
+  const { data: rawMatches = [], isLoading } = useMatches();
+  const { data: aliasMap } = useOpponentAliases();
   const { source, range } = useAnalyticsFilter();
+
+  const allMatches = useMemo(() => {
+    return applyOpponentAliases(rawMatches, aliasMap ?? {});
+  }, [rawMatches, aliasMap]);
 
   const timeFilteredMatches = useMemo(() => {
     return filterByRange(allMatches, range);

--- a/apps/web/src/hooks/useOpponentAliases.ts
+++ b/apps/web/src/hooks/useOpponentAliases.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UpsertOpponentAliasInput } from '@smash-tracker/shared';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const opponentAliasesQueryKey = ['opponentAliases'] as const;
+
+/**
+ * GET /api/opponents/aliases — the signed-in user's alias -> canonical map.
+ * Feeds `useFilteredMatches`'s `applyOpponentAliases` choke point. Per the
+ * locked design, when this is loading (or the user isn't authed yet) the
+ * caller should treat it as an empty map rather than gating rendering — no
+ * loading flicker on every page that shows opponent names.
+ */
+export function useOpponentAliases() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: opponentAliasesQueryKey,
+    queryFn: () => api.opponents.aliases.list(),
+    enabled: Boolean(user),
+  });
+}
+
+/** PUT /api/opponents/aliases/:alias. Invalidates the alias map + opponents list. */
+export function useUpsertOpponentAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ alias, input }: { alias: string; input: UpsertOpponentAliasInput }) =>
+      api.opponents.aliases.upsert(alias, input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: opponentAliasesQueryKey });
+    },
+  });
+}
+
+/** DELETE /api/opponents/aliases/:alias (un-merge). Invalidates the alias map. */
+export function useDeleteOpponentAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (alias: string) => api.opponents.aliases.remove(alias),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: opponentAliasesQueryKey });
+    },
+  });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import {
   errorResponseSchema,
   fighterSelectionSchema,
   matchSchema,
+  opponentAliasMapSchema,
   opponentListSchema,
   startggAuthorizeResponseSchema,
   startggStatusSchema,
@@ -13,6 +14,7 @@ import {
   type FighterSelectionInput,
   type Match,
   type UpdateMatchInput,
+  type UpsertOpponentAliasInput,
 } from '@smash-tracker/shared';
 import { getFirebaseAuth } from './firebase';
 
@@ -171,6 +173,22 @@ export const api = {
   opponents: {
     /** GET /api/opponents */
     list: () => apiRequestParsed('/api/opponents', opponentListSchema),
+    aliases: {
+      /** GET /api/opponents/aliases */
+      list: () => apiRequestParsed('/api/opponents/aliases', opponentAliasMapSchema),
+      /** PUT /api/opponents/aliases/:alias */
+      upsert: (alias: string, input: UpsertOpponentAliasInput) =>
+        apiRequestParsed(
+          `/api/opponents/aliases/${encodeURIComponent(alias)}`,
+          opponentAliasMapSchema,
+          { method: 'PUT', body: input },
+        ),
+      /** DELETE /api/opponents/aliases/:alias */
+      remove: (alias: string) =>
+        apiRequest<void>(`/api/opponents/aliases/${encodeURIComponent(alias)}`, {
+          method: 'DELETE',
+        }),
+    },
   },
   startgg: {
     /** GET /api/integrations/startgg/status */

--- a/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.test.tsx
@@ -33,6 +33,9 @@ vi.mock('@/lib/firebase', async () => {
 const listMatches = vi.fn();
 const listTournaments = vi.fn();
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+const listAliases = vi.fn();
+const upsertAlias = vi.fn();
+const removeAlias = vi.fn();
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -44,6 +47,13 @@ vi.mock('@/lib/api', () => ({
     },
     tournaments: {
       list: (...args: unknown[]) => listTournaments(...args),
+    },
+    opponents: {
+      aliases: {
+        list: (...args: unknown[]) => listAliases(...args),
+        upsert: (...args: unknown[]) => upsertAlias(...args),
+        remove: (...args: unknown[]) => removeAlias(...args),
+      },
     },
   },
 }));
@@ -94,6 +104,9 @@ describe('OpponentsPage', () => {
     window.localStorage.clear();
     upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
     listTournaments.mockResolvedValue([]);
+    listAliases.mockResolvedValue({});
+    upsertAlias.mockResolvedValue({});
+    removeAlias.mockResolvedValue(undefined);
     setMockUser(makeMockUser());
   });
 
@@ -199,7 +212,9 @@ describe('OpponentsPage', () => {
       renderOpponents();
 
       await screen.findByText('2 opponents faced');
-      await user.click(screen.getByRole('button', { name: /zeta/ }));
+      // Scoped to the row's selection button (has aria-pressed) — the row's
+      // kebab menu button ("Actions for zeta") also matches /zeta/ by name.
+      await user.click(screen.getByRole('button', { name: /zeta/, pressed: false }));
 
       // The scouting report card title switches to "zeta".
       await waitFor(() => {
@@ -445,6 +460,150 @@ describe('OpponentsPage', () => {
       expect(
         await screen.findByText('Met at 2 tournaments between Jan 2021 and Mar 2021'),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('source badges', () => {
+    it('shows a start.gg-verified badge for an opponent whose matches are all imported', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true, source: 'startgg' }),
+      ]);
+
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+      expect(screen.getAllByLabelText('start.gg-verified').length).toBeGreaterThan(0);
+    });
+
+    it('shows a manual badge for an opponent whose matches are all manual', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+      ]);
+
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+      expect(screen.getAllByLabelText('manually entered').length).toBeGreaterThan(0);
+    });
+
+    it('shows a mixed badge for an opponent with both manual and imported matches', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true, source: 'startgg' }),
+        makeMatch({ id: 'm2', time: 2, opponent: 'rival', win: false }),
+      ]);
+
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+      expect(screen.getAllByLabelText('mixed sources').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('merge flow', () => {
+    beforeEach(() => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+        makeMatch({ id: 'm2', time: 2, opponent: 'rival', win: true }),
+        makeMatch({ id: 'm3', time: 3, opponent: 'zeta', win: true }),
+      ]);
+    });
+
+    it('opens the merge dialog, selects a target, and calls PUT with the resolved alias', async () => {
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await screen.findByText('2 opponents faced');
+
+      await user.click(screen.getByRole('button', { name: 'Actions for zeta' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Merge into...' }));
+
+      expect(await screen.findByText('Merge "zeta" into...')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('option', { name: 'rival' }));
+      await user.click(screen.getByRole('button', { name: 'Merge' }));
+
+      await waitFor(() => expect(upsertAlias).toHaveBeenCalledWith('zeta', { canonical: 'rival' }));
+    });
+
+    it('warns and defaults to the reversed direction when merging a start.gg-verified name into a manual one', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true, source: 'startgg' }),
+        makeMatch({ id: 'm2', time: 2, opponent: 'zeta', win: true }),
+      ]);
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await screen.findByText('2 opponents faced');
+
+      await user.click(screen.getByRole('button', { name: 'Actions for rival' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Merge into...' }));
+
+      await user.click(screen.getByRole('option', { name: 'zeta' }));
+
+      expect(
+        await screen.findByText(/start\.gg-verified and "zeta" is manual-only/),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Merge' }));
+
+      // Default direction reverses so the start.gg tag stays canonical:
+      // "zeta" becomes the alias, "rival" stays canonical.
+      await waitFor(() => expect(upsertAlias).toHaveBeenCalledWith('zeta', { canonical: 'rival' }));
+    });
+
+    it('allows overriding the recommended direction via the warning link', async () => {
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true, source: 'startgg' }),
+        makeMatch({ id: 'm2', time: 2, opponent: 'zeta', win: true }),
+      ]);
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await screen.findByText('2 opponents faced');
+
+      await user.click(screen.getByRole('button', { name: 'Actions for rival' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Merge into...' }));
+      await user.click(screen.getByRole('option', { name: 'zeta' }));
+
+      await screen.findByText(/start\.gg-verified and "zeta" is manual-only/);
+      await user.click(screen.getByRole('button', { name: 'Merge "rival" into "zeta" anyway' }));
+      await user.click(screen.getByRole('button', { name: 'Merge' }));
+
+      await waitFor(() => expect(upsertAlias).toHaveBeenCalledWith('rival', { canonical: 'zeta' }));
+    });
+  });
+
+  describe('merged names card + un-merge', () => {
+    it('shows merged aliases pointing at the selected opponent and un-merges on click', async () => {
+      listAliases.mockResolvedValue({ rivl: 'rival' });
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+      ]);
+      const user = userEvent.setup();
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+
+      const mergedCard = (await screen.findByText('Merged names')).closest(
+        '[data-slot="card"]',
+      ) as HTMLElement;
+      expect(within(mergedCard).getByText('rivl')).toBeInTheDocument();
+
+      await user.click(within(mergedCard).getByRole('button', { name: 'Un-merge' }));
+
+      await waitFor(() => expect(removeAlias).toHaveBeenCalledWith('rivl'));
+    });
+
+    it('does not show the merged names card when no aliases point at the selected opponent', async () => {
+      listAliases.mockResolvedValue({});
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, opponent: 'rival', win: true }),
+      ]);
+
+      renderOpponents();
+
+      await waitFor(() => expect(screen.getByText('Last 10 (newest first)')).toBeInTheDocument());
+      expect(screen.queryByText('Merged names')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/Opponents/OpponentsPage.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
-import { useFilteredMatches } from '@/hooks/useFilteredMatches';
+import { getOpponentSources, useFilteredMatches } from '@/hooks/useFilteredMatches';
 import { useTournamentEntries } from '@/hooks/useTournamentEntries';
+import { useOpponentAliases } from '@/hooks/useOpponentAliases';
 import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
 import { getOpponentProfile, getOpponentRecords } from '@/lib/stats';
 import { OpponentList } from './components/OpponentList';
@@ -12,6 +13,8 @@ import { ScoutingStagesCard } from './components/ScoutingStagesCard';
 import { ScoutingTrendChart } from './components/ScoutingTrendChart';
 import { RecentEncounters } from './components/RecentEncounters';
 import { TournamentHistory } from './components/TournamentHistory';
+import { MergeOpponentDialog } from './components/MergeOpponentDialog';
+import { MergedNamesCard } from './components/MergedNamesCard';
 import { groupTournamentBlocks, getEncounterContext } from './tournamentHistory';
 
 /**
@@ -22,8 +25,10 @@ import { groupTournamentBlocks, getEncounterContext } from './tournamentHistory'
 export function OpponentsPage() {
   const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
   const { data: tournamentEntries } = useTournamentEntries();
+  const { data: aliasMap } = useOpponentAliases();
 
   const opponentRecords = useMemo(() => getOpponentRecords(matches), [matches]);
+  const sources = useMemo(() => getOpponentSources(matches), [matches]);
 
   const mostPlayed = useMemo(() => {
     return [...opponentRecords].sort((a, b) => b.total - a.total)[0]?.opponent ?? null;
@@ -35,6 +40,10 @@ export function OpponentsPage() {
   // derived during render like Dashboard's fighter selection, no effect
   // needed to seed state from data that just loaded.
   const [selectedOpponent, setSelectedOpponent] = useState<string | null>(null);
+
+  // The opponent name currently open in the "Merge into..." dialog, or null
+  // when the dialog is closed.
+  const [mergeCandidate, setMergeCandidate] = useState<string | null>(null);
 
   const selected =
     selectedOpponent && opponentRecords.some((o) => o.opponent === selectedOpponent)
@@ -56,6 +65,17 @@ export function OpponentsPage() {
   const tournamentBlocks = useMemo(() => groupTournamentBlocks(opponentMatches), [opponentMatches]);
 
   const encounterContext = useMemo(() => getEncounterContext(tournamentBlocks), [tournamentBlocks]);
+
+  // Alias names that currently resolve to the selected opponent (for the
+  // "Merged names" management card).
+  const mergedAliasesForSelected = useMemo(() => {
+    if (!selected || !aliasMap) {
+      return [];
+    }
+    return Object.entries(aliasMap)
+      .filter(([, canonical]) => canonical === selected)
+      .map(([alias]) => alias);
+  }, [aliasMap, selected]);
 
   if (isLoading) {
     return <div className="text-muted-foreground">Loading scouting reports...</div>;
@@ -103,11 +123,20 @@ export function OpponentsPage() {
       {filterActive && matches.length === 0 && <FilteredEmptyNotice />}
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[320px_1fr]">
-        <OpponentList matches={matches} selected={selected} onSelect={setSelectedOpponent} />
+        <OpponentList
+          matches={matches}
+          selected={selected}
+          onSelect={setSelectedOpponent}
+          onRequestMerge={setMergeCandidate}
+        />
 
         {profile ? (
           <div key={profile.opponent} className="flex flex-col gap-4">
-            <ScoutingHeader profile={profile} encounterContext={encounterContext} />
+            <ScoutingHeader
+              profile={profile}
+              encounterContext={encounterContext}
+              source={sources.get(profile.opponent) ?? 'manual'}
+            />
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <WhatTheyPlayTable byTheirFighter={profile.byTheirFighter} />
               <ScoutingStagesCard byStage={profile.byStage} />
@@ -118,6 +147,7 @@ export function OpponentsPage() {
               blocks={tournamentBlocks}
               tournamentEntries={tournamentEntries ?? []}
             />
+            <MergedNamesCard canonical={profile.opponent} aliases={mergedAliasesForSelected} />
           </div>
         ) : (
           <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
@@ -125,6 +155,23 @@ export function OpponentsPage() {
           </div>
         )}
       </div>
+
+      {mergeCandidate && (
+        <MergeOpponentDialog
+          open={mergeCandidate != null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setMergeCandidate(null);
+            }
+          }}
+          opponent={mergeCandidate}
+          candidates={opponentRecords
+            .map((o) => o.opponent)
+            .filter((name) => name !== mergeCandidate)}
+          sources={sources}
+          onMerged={() => setMergeCandidate(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/Opponents/components/MergeOpponentDialog.tsx
+++ b/apps/web/src/pages/Opponents/components/MergeOpponentDialog.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import type { OpponentSource } from '@/hooks/useFilteredMatches';
+import { useUpsertOpponentAlias } from '@/hooks/useOpponentAliases';
+import { rankMergeSuggestions } from '../mergeSuggestions';
+
+export interface MergeOpponentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The opponent name being merged away (will become an alias). */
+  opponent: string;
+  /** Every other known opponent name, for the searchable target list. */
+  candidates: string[];
+  /** Source classification per opponent name, for the start.gg-tag-preservation warning. */
+  sources: Map<string, OpponentSource>;
+  onMerged?: () => void;
+}
+
+/**
+ * "Merge into..." dialog: pick another opponent name that `opponent` should
+ * be folded into. Confirming writes alias `opponent` -> `target` (target
+ * becomes canonical). If `opponent` is start.gg-verified and `target` is
+ * manual-only, warns that merging this direction would lose the start.gg
+ * tag as canonical and offers the reversed direction instead (still
+ * overridable — the user can proceed with their original choice).
+ */
+export function MergeOpponentDialog({
+  open,
+  onOpenChange,
+  opponent,
+  candidates,
+  sources,
+  onMerged,
+}: MergeOpponentDialogProps) {
+  const [target, setTarget] = useState<string | null>(null);
+  const [confirmedDespiteWarning, setConfirmedDespiteWarning] = useState(false);
+  const upsertAlias = useUpsertOpponentAlias();
+
+  const ranked = useMemo(() => rankMergeSuggestions(opponent, candidates), [opponent, candidates]);
+
+  const wouldLoseStartggTag =
+    target != null && sources.get(opponent) === 'startgg' && sources.get(target) === 'manual';
+
+  function reset() {
+    setTarget(null);
+    setConfirmedDespiteWarning(false);
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      reset();
+    }
+    onOpenChange(next);
+  }
+
+  function commitMerge(alias: string, canonical: string) {
+    upsertAlias.mutate(
+      { alias, input: { canonical } },
+      {
+        onSuccess: () => {
+          reset();
+          onOpenChange(false);
+          onMerged?.();
+        },
+      },
+    );
+  }
+
+  function handleConfirm() {
+    if (!target) {
+      return;
+    }
+    if (wouldLoseStartggTag && !confirmedDespiteWarning) {
+      // Recommended direction: keep the start.gg-verified name canonical by
+      // reversing the merge (target becomes the alias instead).
+      commitMerge(target, opponent);
+      return;
+    }
+    commitMerge(opponent, target);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Merge &quot;{opponent}&quot; into...</DialogTitle>
+          <DialogDescription>
+            Choose the opponent name that should be treated as the same person. Their matches will
+            be combined everywhere.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Command className="rounded-md border">
+          <CommandInput placeholder="Search opponents..." />
+          <CommandList>
+            <CommandEmpty>No matching opponents.</CommandEmpty>
+            <CommandGroup>
+              {ranked.map((name) => (
+                <CommandItem
+                  key={name}
+                  value={name}
+                  onSelect={() => {
+                    setTarget(name);
+                    setConfirmedDespiteWarning(false);
+                  }}
+                  aria-selected={target === name}
+                  data-selected={target === name || undefined}
+                >
+                  {name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+
+        {target && wouldLoseStartggTag && !confirmedDespiteWarning && (
+          <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
+            <p>
+              &quot;{opponent}&quot; is start.gg-verified and &quot;{target}&quot; is manual-only.
+              To keep the start.gg tag as canonical, we&apos;ll merge &quot;{target}&quot; into
+              &quot;{opponent}&quot; instead.
+            </p>
+            <Button
+              type="button"
+              variant="link"
+              className="mt-1 h-auto p-0 text-sm"
+              onClick={() => setConfirmedDespiteWarning(true)}
+            >
+              Merge &quot;{opponent}&quot; into &quot;{target}&quot; anyway
+            </Button>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" disabled={!target || upsertAlias.isPending} onClick={handleConfirm}>
+            {upsertAlias.isPending ? 'Merging...' : 'Merge'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/MergedNamesCard.tsx
+++ b/apps/web/src/pages/Opponents/components/MergedNamesCard.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useDeleteOpponentAlias } from '@/hooks/useOpponentAliases';
+
+export interface MergedNamesCardProps {
+  /** Canonical opponent name currently selected in the scouting report. */
+  canonical: string;
+  /** Alias names currently pointing at `canonical` (already filtered by the caller). */
+  aliases: string[];
+}
+
+/**
+ * "Merged names" management card: shown in the scouting report when at
+ * least one alias currently resolves to the selected opponent. Each row
+ * offers an "Un-merge" action (DELETE the alias), splitting that name back
+ * out into its own separate scouting identity.
+ */
+export function MergedNamesCard({ canonical, aliases }: MergedNamesCardProps) {
+  const deleteAlias = useDeleteOpponentAlias();
+
+  if (aliases.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Merged names</CardTitle>
+        <CardDescription>
+          These names are folded into &quot;{canonical}&quot;. Un-merge to track them separately
+          again.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="flex flex-col gap-2" role="list" aria-label="Merged names">
+          {aliases.map((alias) => (
+            <li key={alias} className="flex items-center justify-between gap-2 text-sm">
+              <span className="min-w-0 flex-1 truncate">{alias}</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={deleteAlias.isPending}
+                onClick={() => deleteAlias.mutate(alias)}
+              >
+                Un-merge
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/OpponentList.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentList.tsx
@@ -1,27 +1,42 @@
 import { useMemo, useState } from 'react';
-import { Search } from 'lucide-react';
+import { MoreVertical, Search } from 'lucide-react';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { getOpponentRecords, type OpponentRecord } from '@/lib/stats';
+import { getOpponentSources, type OpponentSource } from '@/hooks/useFilteredMatches';
+import { OpponentSourceBadge } from './OpponentSourceBadge';
 
 export interface OpponentListProps {
   matches: Match[];
   selected: string | null;
   onSelect: (opponent: string) => void;
+  /** Opens the "Merge into..." dialog for the given opponent name. */
+  onRequestMerge: (opponent: string) => void;
 }
 
 /**
  * Left-column opponent list for the Scouting page: every human opponent
  * faced (`getOpponentRecords`), ranked by games played descending, with a
- * substring search filter. Selecting a row calls `onSelect`.
+ * substring search filter. Selecting a row calls `onSelect`. Each row shows
+ * a source badge (start.gg-verified / manual / mixed) and a kebab menu with
+ * a "Merge into..." action.
  */
-export function OpponentList({ matches, selected, onSelect }: OpponentListProps) {
+export function OpponentList({ matches, selected, onSelect, onRequestMerge }: OpponentListProps) {
   const [query, setQuery] = useState('');
 
   const opponents = useMemo(() => {
     return [...getOpponentRecords(matches)].sort((a, b) => b.total - a.total);
   }, [matches]);
+
+  const sources = useMemo(() => getOpponentSources(matches), [matches]);
 
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -63,7 +78,9 @@ export function OpponentList({ matches, selected, onSelect }: OpponentListProps)
                 key={opponent.opponent}
                 opponent={opponent}
                 selected={opponent.opponent === selected}
+                source={sources.get(opponent.opponent) ?? 'manual'}
                 onSelect={onSelect}
+                onRequestMerge={onRequestMerge}
               />
             ))}
           </ul>
@@ -76,25 +93,30 @@ export function OpponentList({ matches, selected, onSelect }: OpponentListProps)
 function OpponentRow({
   opponent,
   selected,
+  source,
   onSelect,
+  onRequestMerge,
 }: {
   opponent: OpponentRecord;
   selected: boolean;
+  source: OpponentSource;
   onSelect: (opponent: string) => void;
+  onRequestMerge: (opponent: string) => void;
 }) {
   return (
-    <li>
+    <li
+      className={`flex items-center gap-1 rounded-md border px-1 transition-colors ${
+        selected ? 'border-primary bg-primary/10' : 'border-transparent hover:bg-accent'
+      }`}
+    >
       <button
         type="button"
         onClick={() => onSelect(opponent.opponent)}
         aria-pressed={selected}
-        className={`flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
-          selected
-            ? 'border-primary bg-primary/10'
-            : 'border-transparent hover:bg-accent hover:text-accent-foreground'
-        }`}
+        className="flex min-w-0 flex-1 items-center gap-2 py-2 text-left text-sm"
       >
         <span className="min-w-0 flex-1 truncate font-medium">{opponent.opponent}</span>
+        <OpponentSourceBadge source={source} />
         <span className="text-muted-foreground">
           {opponent.wins}-{opponent.losses}
         </span>
@@ -103,6 +125,23 @@ function OpponentRow({
           {opponent.total} game{opponent.total === 1 ? '' : 's'}
         </span>
       </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${opponent.opponent}`}
+          >
+            <MoreVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => onRequestMerge(opponent.opponent)}>
+            Merge into...
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </li>
   );
 }

--- a/apps/web/src/pages/Opponents/components/OpponentSourceBadge.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentSourceBadge.tsx
@@ -1,0 +1,39 @@
+import { Check } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { OpponentSource } from '@/hooks/useFilteredMatches';
+
+/**
+ * Tasteful, non-shouty source indicator for an opponent identity: a
+ * start.gg-verified check badge when every recorded match against them was
+ * imported, an outline "manual" badge when none were, or both badges
+ * together (labeled via aria) when the identity is a merge of manual +
+ * imported matches.
+ */
+export function OpponentSourceBadge({ source }: { source: OpponentSource }) {
+  if (source === 'mixed') {
+    return (
+      <span className="inline-flex items-center gap-1" aria-label="mixed sources">
+        <Badge variant="success" className="gap-0.5">
+          <Check className="size-3" />
+          start.gg
+        </Badge>
+        <Badge variant="outline">manual</Badge>
+      </span>
+    );
+  }
+
+  if (source === 'startgg') {
+    return (
+      <Badge variant="success" className="gap-0.5" aria-label="start.gg-verified">
+        <Check className="size-3" />
+        start.gg
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="outline" aria-label="manually entered">
+      manual
+    </Badge>
+  );
+}

--- a/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
@@ -1,7 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WinLossPips } from '@/components/WinLossPips';
 import type { OpponentProfile } from '@/lib/stats';
+import type { OpponentSource } from '@/hooks/useFilteredMatches';
 import type { EncounterContext } from '../tournamentHistory';
+import { OpponentSourceBadge } from './OpponentSourceBadge';
 
 function formatEncounterContext(context: EncounterContext): string | null {
   if (context.tournamentCount === 0 || !context.span) {
@@ -30,9 +32,11 @@ function formatEncounterContext(context: EncounterContext): string | null {
 export function ScoutingHeader({
   profile,
   encounterContext,
+  source,
 }: {
   profile: OpponentProfile;
   encounterContext: EncounterContext;
+  source: OpponentSource;
 }) {
   const { record } = profile;
   const encounterLine = formatEncounterContext(encounterContext);
@@ -41,7 +45,10 @@ export function ScoutingHeader({
     <Card>
       <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-4">
         <div>
-          <CardTitle className="text-2xl">{profile.opponent}</CardTitle>
+          <div className="flex flex-wrap items-center gap-2">
+            <CardTitle className="text-2xl">{profile.opponent}</CardTitle>
+            <OpponentSourceBadge source={source} />
+          </div>
           <p className="mt-1 text-sm text-muted-foreground">
             First played {new Date(profile.firstPlayedAt).toLocaleDateString()} · Last played{' '}
             {new Date(profile.lastPlayedAt).toLocaleDateString()}

--- a/apps/web/src/pages/Opponents/mergeSuggestions.test.ts
+++ b/apps/web/src/pages/Opponents/mergeSuggestions.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isNearMissSuggestion,
+  isPrefixRelation,
+  levenshteinDistance,
+  rankMergeSuggestions,
+} from './mergeSuggestions';
+
+describe('levenshteinDistance', () => {
+  it('is 0 for identical strings', () => {
+    expect(levenshteinDistance('rival', 'rival')).toBe(0);
+  });
+
+  it('handles an empty string', () => {
+    expect(levenshteinDistance('', 'abc')).toBe(3);
+    expect(levenshteinDistance('abc', '')).toBe(3);
+  });
+
+  it('counts a single substitution', () => {
+    expect(levenshteinDistance('rival', 'rivbl')).toBe(1);
+  });
+
+  it('counts a single insertion/deletion', () => {
+    expect(levenshteinDistance('rival', 'rivals')).toBe(1);
+    expect(levenshteinDistance('rivals', 'rival')).toBe(1);
+  });
+
+  it('computes a larger distance for dissimilar strings', () => {
+    expect(levenshteinDistance('rival', 'zzzzz')).toBe(5);
+  });
+});
+
+describe('isPrefixRelation', () => {
+  it('is true when one name is a prefix of the other', () => {
+    expect(isPrefixRelation('riv', 'rival')).toBe(true);
+    expect(isPrefixRelation('rival', 'riv')).toBe(true);
+  });
+
+  it('is false for unrelated names', () => {
+    expect(isPrefixRelation('rival', 'zeta')).toBe(false);
+  });
+
+  it('is false for empty strings', () => {
+    expect(isPrefixRelation('', 'rival')).toBe(false);
+    expect(isPrefixRelation('rival', '')).toBe(false);
+  });
+});
+
+describe('isNearMissSuggestion', () => {
+  it('is true within edit distance 2', () => {
+    expect(isNearMissSuggestion('rival', 'rivals')).toBe(true); // distance 1
+    expect(isNearMissSuggestion('rival', 'rivvle')).toBe(true); // distance 2
+  });
+
+  it('is true for a prefix relation even with a large edit distance', () => {
+    expect(isNearMissSuggestion('riv', 'rivalofsomekind')).toBe(true);
+  });
+
+  it('is false for unrelated names', () => {
+    expect(isNearMissSuggestion('rival', 'completelydifferentname')).toBe(false);
+  });
+
+  it('is false comparing a name to itself', () => {
+    expect(isNearMissSuggestion('rival', 'rival')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isNearMissSuggestion('Rival', 'rival')).toBe(false); // same after lowering
+    expect(isNearMissSuggestion('RIVAL', 'rivals')).toBe(true);
+  });
+});
+
+describe('rankMergeSuggestions', () => {
+  it('puts near-miss candidates first, ordered by ascending distance', () => {
+    const result = rankMergeSuggestions('rival', ['zeta', 'rivals', 'rival2', 'unrelated']);
+    // rivals: distance 1; rival2: distance 1 (substitution) -- alphabetical tiebreak
+    expect(result.slice(0, 2).sort()).toEqual(['rival2', 'rivals'].sort());
+    expect(result).toContain('zeta');
+    expect(result).toContain('unrelated');
+  });
+
+  it('excludes the name itself from the candidate list', () => {
+    const result = rankMergeSuggestions('rival', ['rival', 'zeta']);
+    expect(result).not.toContain('rival');
+  });
+
+  it('preserves original relative order for non-suggestions', () => {
+    const result = rankMergeSuggestions('rival', ['bravo', 'alpha', 'charlie']);
+    expect(result).toEqual(['bravo', 'alpha', 'charlie']);
+  });
+
+  it('returns an empty array when there are no other candidates', () => {
+    expect(rankMergeSuggestions('rival', [])).toEqual([]);
+    expect(rankMergeSuggestions('rival', ['rival'])).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Opponents/mergeSuggestions.ts
+++ b/apps/web/src/pages/Opponents/mergeSuggestions.ts
@@ -1,0 +1,92 @@
+/**
+ * "Merge into..." suggestion ranking for the Scouting page. Given the
+ * opponent name being merged away and the full candidate list (every other
+ * opponent name), ranks near-miss names first: a small Levenshtein edit
+ * distance (<= 2) or a prefix relationship (either name is a prefix of the
+ * other) to the selected name. Remaining candidates keep their original
+ * relative order (stable), appended after the suggestions.
+ */
+
+/** Classic iterative Levenshtein edit distance (single-row DP, case-sensitive). */
+export function levenshteinDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+
+  let previousRow = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    const currentRow = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      currentRow.push(
+        Math.min(
+          previousRow[j]! + 1, // deletion
+          currentRow[j - 1]! + 1, // insertion
+          previousRow[j - 1]! + substitutionCost, // substitution
+        ),
+      );
+    }
+    previousRow = currentRow;
+  }
+
+  return previousRow[b.length]!;
+}
+
+/** True when `a` and `b` are in a prefix relationship (either is a prefix of the other), both non-empty. */
+export function isPrefixRelation(a: string, b: string): boolean {
+  if (a.length === 0 || b.length === 0) {
+    return false;
+  }
+  return a.startsWith(b) || b.startsWith(a);
+}
+
+const SUGGESTION_MAX_DISTANCE = 2;
+
+/**
+ * Whether `candidate` is a "near-miss" of `name` worth suggesting first:
+ * Levenshtein distance <= 2, or a prefix relationship. Names are compared
+ * case-insensitively (opponent names are already lowercased in practice,
+ * but this stays defensive) and a candidate is never suggested against
+ * itself.
+ */
+export function isNearMissSuggestion(name: string, candidate: string): boolean {
+  const a = name.toLowerCase();
+  const b = candidate.toLowerCase();
+  if (a === b) {
+    return false;
+  }
+  return levenshteinDistance(a, b) <= SUGGESTION_MAX_DISTANCE || isPrefixRelation(a, b);
+}
+
+/**
+ * Orders `candidates` (every other opponent name) for the merge-target
+ * picker: near-miss suggestions first (sorted by ascending edit distance,
+ * ties broken alphabetically for determinism), then the rest in their
+ * original order. `name` itself is excluded if present in `candidates`.
+ */
+export function rankMergeSuggestions(name: string, candidates: string[]): string[] {
+  const others = candidates.filter((c) => c !== name);
+
+  const withDistance = others.map((candidate) => ({
+    candidate,
+    distance: levenshteinDistance(name.toLowerCase(), candidate.toLowerCase()),
+    isNearMiss: isNearMissSuggestion(name, candidate),
+  }));
+
+  const suggestions = withDistance
+    .filter((c) => c.isNearMiss)
+    .sort((x, y) => x.distance - y.distance || x.candidate.localeCompare(y.candidate))
+    .map((c) => c.candidate);
+
+  const suggestionSet = new Set(suggestions);
+  const rest = others.filter((c) => !suggestionSet.has(c));
+
+  return [...suggestions, ...rest];
+}

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -8,10 +8,13 @@ import {
   matchRecordSchema,
   matchSchema,
   matchTypeSchema,
+  opponentAliasMapSchema,
   opponentListSchema,
   opponentMapSchema,
+  opponentNameInputSchema,
   stageSchema,
   updateMatchInputSchema,
+  upsertOpponentAliasInputSchema,
   userProfileSchema,
   userSchema,
 } from './index.js';
@@ -357,5 +360,48 @@ describe('opponent schemas', () => {
 
   it('parses an opponent list', () => {
     expect(opponentListSchema.parse(['someplayer', 'other'])).toEqual(['someplayer', 'other']);
+  });
+});
+
+describe('opponentNameInputSchema', () => {
+  it('trims and lowercases', () => {
+    expect(opponentNameInputSchema.parse('  SomePlayer  ')).toBe('someplayer');
+  });
+
+  it('rejects a blank name', () => {
+    expect(() => opponentNameInputSchema.parse('   ')).toThrow();
+  });
+
+  it('rejects RTDB-reserved characters', () => {
+    for (const badName of ['a.b', 'a#b', 'a$b', 'a[b', 'a]b', 'a/b']) {
+      expect(() => opponentNameInputSchema.parse(badName)).toThrow();
+    }
+  });
+
+  it('allows spaces', () => {
+    expect(opponentNameInputSchema.parse('team mate')).toBe('team mate');
+  });
+});
+
+describe('opponentAliasMapSchema', () => {
+  it('parses a flat alias -> canonical map', () => {
+    const map = { rivl: 'rival', riv: 'rival' };
+    expect(opponentAliasMapSchema.parse(map)).toEqual(map);
+  });
+
+  it('parses an empty map', () => {
+    expect(opponentAliasMapSchema.parse({})).toEqual({});
+  });
+});
+
+describe('upsertOpponentAliasInputSchema', () => {
+  it('normalizes the canonical name', () => {
+    expect(upsertOpponentAliasInputSchema.parse({ canonical: '  Rival  ' })).toEqual({
+      canonical: 'rival',
+    });
+  });
+
+  it('rejects a blank canonical name', () => {
+    expect(() => upsertOpponentAliasInputSchema.parse({ canonical: '' })).toThrow();
   });
 });

--- a/packages/shared/src/opponent.ts
+++ b/packages/shared/src/opponent.ts
@@ -12,3 +12,69 @@ export type OpponentMap = z.infer<typeof opponentMapSchema>;
 /** GET /api/opponents response: the flat list of known opponent names. */
 export const opponentListSchema = z.array(z.string());
 export type OpponentList = z.infer<typeof opponentListSchema>;
+
+/**
+ * `opponents/{uid}/{opponentName}` (and now `opponentAliases/{uid}/{alias}`)
+ * both use the free-text opponent name as the literal RTDB key, so it can't
+ * contain the characters RTDB reserves for paths (`.`, `#`, `$`, `[`, `]`,
+ * `/`) or ASCII control characters. This mirrors match.ts's
+ * `opponentNameInputSchema` exactly (trim + lowercase + reject illegal
+ * chars) — duplicated here (rather than imported from match.ts) to avoid a
+ * cross-file dependency between the two concurrently-owned modules; kept
+ * byte-for-byte identical intentionally.
+ */
+const RTDB_RESERVED_KEY_CHARS = ['.', '#', '$', '[', ']', '/'];
+
+function containsRtdbIllegalChar(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const codePoint = value.codePointAt(i);
+    if (codePoint !== undefined && codePoint <= 0x1f) {
+      return true;
+    }
+  }
+  return RTDB_RESERVED_KEY_CHARS.some((char) => value.includes(char));
+}
+
+/**
+ * Normalizes a free-text opponent name into its canonical RTDB-safe form:
+ * trim, lowercase, and reject characters RTDB reserves for path segments.
+ * Reused anywhere an opponent name is read from user input outside of
+ * match.ts's own schema (e.g. the alias endpoints below) so both places
+ * apply byte-for-byte the same rule that already unifies manual + imported
+ * matches (exact lowercased name equality).
+ */
+export const opponentNameInputSchema = z
+  .string()
+  .trim()
+  .min(1, 'Opponent name is required')
+  .transform((value) => value.toLowerCase())
+  .refine((value) => !containsRtdbIllegalChar(value), {
+    message: 'Opponent name cannot contain . # $ [ ] / or control characters',
+  });
+
+/**
+ * `opponentAliases/{uid}` — a flat map from an alias opponent name to the
+ * canonical opponent name it should be merged into for display/aggregation
+ * purposes. Both keys and values are pre-normalized (trimmed/lowercased,
+ * RTDB-safe) opponent names, same shape as `opponents/{uid}` keys.
+ *
+ * Invariant: no alias key may equal its own canonical value (a direct
+ * self-cycle) — enforced at write time by the API, not by this schema
+ * (schema-level cross-field refinement isn't practical for a `z.record`).
+ * Longer cycles are prevented procedurally: writes resolve the requested
+ * target through the existing map first (see rtdb.ts's `resolveCanonical`),
+ * so a chain can never form — every value in the map is always itself a
+ * terminal (non-aliased) name.
+ */
+export const opponentAliasMapSchema = z.record(z.string(), z.string());
+export type OpponentAliasMap = z.infer<typeof opponentAliasMapSchema>;
+
+/**
+ * PUT /api/opponents/aliases/:alias body. `canonical` is validated through
+ * the same normalizer as the alias itself; the API additionally rejects
+ * `alias === canonical` (self-merge) after normalization.
+ */
+export const upsertOpponentAliasInputSchema = z.object({
+  canonical: opponentNameInputSchema,
+});
+export type UpsertOpponentAliasInput = z.infer<typeof upsertOpponentAliasInputSchema>;


### PR DESCRIPTION
## Summary

- **Source badges**: pure `getOpponentSources(matches)` classifies each canonical opponent name as `startgg` (every match imported), `manual` (none were), or `mixed` — surfaced as a small badge (start.gg-verified check / outline "manual" / both) on the Scouting opponent list rows and the scouting report header.
- **Alias merge**: `opponentAliases/{uid}` is a flat `alias -> canonical` map in RTDB. Writes resolve the target through the existing map first (so the map never chains — every value is always a terminal, non-aliased name) and reject a direct or transitively-discovered self-merge with 400. New endpoints: `GET/PUT/DELETE /api/opponents/aliases[/:alias]`, Bearer-authed.
- **Single choke point**: `useFilteredMatches` now applies `applyOpponentAliases` (pure, exported) before any filtering, so every downstream consumer (scouting, tables, dashboards) sees merged identities automatically without individual alias-awareness. The alias query is enabled only when authed; while loading, an empty map is used — no loading-flicker gate.
- **Merge UI**: a per-opponent "Merge into..." action opens a searchable dialog (suggestions ranked first by Levenshtein distance ≤2 or a prefix relationship — pure `rankMergeSuggestions`, exported + tested). Confirming writes the alias. If the selected name is start.gg-verified and the target is manual-only, the dialog warns and defaults to the reversed direction (target becomes the alias) so the start.gg tag stays canonical — still overridable via an explicit "anyway" link. A "Merged names" card in the scouting report lists aliases pointing at the selected opponent with un-merge (DELETE) buttons.

## Test plan

- [x] `packages/shared`: 45 tests passing (opponent name normalizer reuse, alias map schema, upsert input validation).
- [x] `apps/api`: 105 tests passing, including new `opponentAliases.test.ts` (auth, validation, direct self-merge rejection, transitive-resolution self-merge rejection, flat-map-preserving transitive canonical resolution, 404 un-merge, RTDB-illegal-character rejection).
- [x] `apps/web`: 512 tests passing — `applyOpponentAliases`/`getOpponentSources` pure-function tests, `mergeSuggestions.ts` (Levenshtein/prefix/ranking) tests, and expanded `OpponentsPage.test.tsx` covering badge rendering (all three source states), the full merge dialog flow (PUT called with the resolved alias), the start.gg-tag-preservation warning + override, and the merged-names card + un-merge (DELETE called).
- [x] Full gate: `pnpm lint` (0 errors, 31 pre-existing warnings unrelated to this change), `pnpm typecheck`, `pnpm test` (662 total passing), `pnpm build`, `pnpm format:check` — all green.

**Note:** `apps/api/src/app.ts` gains exactly one import line + one registration line (`opponentAliasesRoutes`) to wire up the new route — flagged per the coordination plan since a concurrent agent/PR also touches `app.ts`/`apps/api/src/startgg/**`. This is a minimal, isolated two-line diff; possible trivial merge conflict with that PR, easy to resolve by keeping both registration lines.

Do not merge — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)