### PR TITLE
V5 Phase B: event results + start.gg deep links

### DIFF
--- a/apps/web/src/pages/Tournaments/TournamentDetailPage.test.tsx
+++ b/apps/web/src/pages/Tournaments/TournamentDetailPage.test.tsx
@@ -141,6 +141,10 @@ describe('TournamentDetailPage', () => {
     expect(screen.getByText('Outperformed seed: 408 → 257')).toBeInTheDocument();
     expect(screen.getByText('512 entrants')).toBeInTheDocument();
 
+    // Event Results: resync hint when topStandings hasn't synced.
+    expect(screen.getByText('Event Results')).toBeInTheDocument();
+    expect(screen.getByText('Full results attach on your next start.gg sync.')).toBeInTheDocument();
+
     // Set timeline: the single set's round label and result.
     expect(screen.getByText('Set Timeline')).toBeInTheDocument();
     expect(screen.getAllByText('Winners Round 1').length).toBeGreaterThan(0);
@@ -169,5 +173,32 @@ describe('TournamentDetailPage', () => {
     expect(screen.queryByText(/Outperformed seed/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Underperformed seed/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Matched seed/)).not.toBeInTheDocument();
+  });
+
+  it('renders Event Results with a winner callout and start.gg deep link when synced', async () => {
+    listTournaments.mockResolvedValue([
+      makeEntry({
+        eventId: 42,
+        slug: 'tournament/the-box-juice-box-26',
+        eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+        topStandings: [
+          { placement: 1, name: 'Champ', gamerTag: 'Champ' },
+          { placement: 2, name: 'RunnerUp', gamerTag: 'RunnerUp' },
+        ],
+      }),
+    ]);
+    listMatches.mockResolvedValue([]);
+
+    renderPage('42');
+
+    await screen.findByText('Event Results');
+    expect(screen.getByText('Champ won this event')).toBeInTheDocument();
+    expect(screen.getByText('RunnerUp')).toBeInTheDocument();
+
+    const startggLink = screen.getByRole('link', { name: /View on start\.gg/ });
+    expect(startggLink).toHaveAttribute(
+      'href',
+      'https://start.gg/tournament/the-box-juice-box-26/event/ultimate-singles',
+    );
   });
 });

--- a/apps/web/src/pages/Tournaments/TournamentDetailPage.tsx
+++ b/apps/web/src/pages/Tournaments/TournamentDetailPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useTournamentEntries } from '@/hooks/useTournamentEntries';
 import { useMatches } from '@/hooks/useMatches';
 import { TournamentHeader } from './components/TournamentHeader';
+import { EventResults } from './components/EventResults';
 import { SetTimeline } from './components/SetTimeline';
 import { CharactersAndStages } from './components/CharactersAndStages';
 import { AdvisorRetrospective } from './components/AdvisorRetrospective';
@@ -27,11 +28,13 @@ function NotFoundState() {
 }
 
 /**
- * V4 Phase B: tournament detail page — header (with seed->placement badge),
- * set-by-set timeline, characters/stages summary, and the Advisor
- * Retrospective. Reached by clicking a tournament row in Trends, or by
- * direct URL (`/tournaments/:eventId`); an unknown/foreign eventId renders a
- * friendly not-found state rather than crashing on a missing entry.
+ * V4 Phase B / V5 Phase B: tournament detail page — header (with
+ * seed->placement badge + start.gg deep link), Event Results (top-8
+ * standings), set-by-set timeline, characters/stages summary, and the
+ * Advisor Retrospective. Reached by clicking a tournament row in Trends, or
+ * by direct URL (`/tournaments/:eventId`); an unknown/foreign eventId
+ * renders a friendly not-found state rather than crashing on a missing
+ * entry.
  */
 export function TournamentDetailPage() {
   const { eventId } = useParams<{ eventId: string }>();
@@ -73,6 +76,7 @@ export function TournamentDetailPage() {
   return (
     <div className="flex flex-col gap-6">
       <TournamentHeader entry={entry} />
+      <EventResults entry={entry} entryMatches={entryMatches} />
       <SetTimeline sets={timeline.sets} otherMatches={timeline.otherMatches} />
       <CharactersAndStages matches={entryMatches} />
       {retrospective && <AdvisorRetrospective retrospective={retrospective} />}

--- a/apps/web/src/pages/Tournaments/components/EventResults.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/EventResults.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match, TournamentEntry } from '@smash-tracker/shared';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { EventResults } from './EventResults';
+
+function makeEntry(overrides: Partial<TournamentEntry> = {}): TournamentEntry {
+  return {
+    eventId: 1,
+    eventName: 'Ultimate Singles',
+    firstSetAt: Date.UTC(2021, 0, 1),
+    lastSetAt: Date.UTC(2021, 0, 1),
+    setsPlayed: 3,
+    ...overrides,
+  };
+}
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 1, name: 'Battlefield' },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'offline-tourney',
+    ...overrides,
+  };
+}
+
+function renderResults(entry: TournamentEntry, entryMatches: Match[] = []) {
+  return render(
+    <TooltipProvider>
+      <EventResults entry={entry} entryMatches={entryMatches} />
+    </TooltipProvider>,
+  );
+}
+
+describe('EventResults', () => {
+  it('shows the resync hint when topStandings is absent', () => {
+    renderResults(makeEntry({ topStandings: undefined }));
+    expect(screen.getByText('Full results attach on your next start.gg sync.')).toBeInTheDocument();
+  });
+
+  it('shows a winner callout for placement 1', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 1, name: 'Champ', gamerTag: 'Champ' }],
+      }),
+    );
+    expect(screen.getByText('Champ won this event')).toBeInTheDocument();
+  });
+
+  it('renders a top-8 table with placement and entrant name', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [
+          { placement: 1, name: 'Champ' },
+          { placement: 2, name: 'RunnerUp' },
+        ],
+      }),
+    );
+    expect(screen.getByText('Champ')).toBeInTheDocument();
+    expect(screen.getByText('RunnerUp')).toBeInTheDocument();
+  });
+
+  it('shows the gamerTag alongside the raw name when they differ', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 1, name: 'Sponsor | Rival', gamerTag: 'Rival' }],
+      }),
+    );
+    expect(screen.getByText('Rival')).toBeInTheDocument();
+    expect(screen.getByText('(Sponsor | Rival)')).toBeInTheDocument();
+  });
+
+  it('links out to start.gg for rows with a userSlug', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 2, name: 'Champ', userSlug: 'user/abc123' }],
+      }),
+    );
+    const link = screen.getByRole('link', { name: 'View Champ on start.gg' });
+    expect(link).toHaveAttribute('href', 'https://start.gg/user/abc123');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('shows the profile link both in the winner callout and the table row for the placement-1 winner', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 1, name: 'Champ', userSlug: 'user/abc123' }],
+      }),
+    );
+    const links = screen.getAllByRole('link', { name: 'View Champ on start.gg' });
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://start.gg/user/abc123');
+    }
+  });
+
+  it('omits the profile link for rows without a userSlug', () => {
+    renderResults(makeEntry({ topStandings: [{ placement: 1, name: 'Champ' }] }));
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('tints and tooltips rows whose gamerTag matches an opponent played at this event', () => {
+    const matches = [makeMatch({ id: 'm1', time: 100, win: true, opponent: 'rival' })];
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 3, name: 'Sponsor | Rival', gamerTag: 'Rival' }],
+      }),
+      matches,
+    );
+    const row = screen.getByText('Rival').closest('tr');
+    expect(row?.className).toContain('bg-primary/5');
+  });
+
+  it('does not tint rows that were not played at this event', () => {
+    renderResults(
+      makeEntry({
+        topStandings: [{ placement: 3, name: 'Stranger' }],
+      }),
+      [],
+    );
+    const row = screen.getByText('Stranger').closest('tr');
+    expect(row?.className ?? '').not.toContain('bg-primary/5');
+  });
+});

--- a/apps/web/src/pages/Tournaments/components/EventResults.tsx
+++ b/apps/web/src/pages/Tournaments/components/EventResults.tsx
@@ -1,0 +1,125 @@
+import { ExternalLink, Trophy } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import type { Match, TournamentEntry } from '@smash-tracker/shared';
+import { buildEventResultRows, type EventResultRow } from '../lib/eventResults';
+
+function ProfileLink({ row }: { row: EventResultRow }) {
+  if (!row.profileUrl) {
+    return null;
+  }
+  return (
+    <a
+      href={row.profileUrl}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={`View ${row.displayName} on start.gg`}
+      className="inline-flex text-muted-foreground hover:text-foreground"
+    >
+      <ExternalLink className="size-3.5" />
+    </a>
+  );
+}
+
+function ResultRow({ row }: { row: EventResultRow }) {
+  const nameCell = (
+    <span className="inline-flex items-center gap-2">
+      {row.standing.placement === 1 && <Trophy className="size-4 text-amber-500" />}
+      <span>
+        {row.displayName}
+        {row.subLabel && (
+          <span className="ml-1 text-xs text-muted-foreground">({row.subLabel})</span>
+        )}
+      </span>
+      <ProfileLink row={row} />
+    </span>
+  );
+
+  return (
+    <TableRow className={cn(row.playedAtEvent && 'bg-primary/5')}>
+      <TableCell className="font-medium">{row.standing.placement}</TableCell>
+      <TableCell>
+        {row.playedAtEvent ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-default underline decoration-dotted underline-offset-4">
+                {nameCell}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>You played them at this event</TooltipContent>
+          </Tooltip>
+        ) : (
+          nameCell
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Winner callout + top-8 standings table, sourced from
+ * `entry.topStandings` (populated post-sync, capped to ~8 by the API — see
+ * `packages/shared/src/startgg.ts`). Rows whose name/gamerTag match an
+ * opponent the user actually played at this event (via `entryMatches`) get a
+ * subtle tint + tooltip; rows with a `userSlug` link out to the entrant's
+ * start.gg profile. Renders a resync hint instead of an empty table when
+ * `topStandings` hasn't synced yet (pre-Phase-A data, or synced before this
+ * field existed).
+ */
+export function EventResults({
+  entry,
+  entryMatches,
+}: {
+  entry: TournamentEntry;
+  entryMatches: Match[];
+}) {
+  const rows = buildEventResultRows(entry, entryMatches);
+  const winner = rows.find((row) => row.standing.placement === 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Event Results</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Full results attach on your next start.gg sync.
+          </p>
+        ) : (
+          <>
+            {winner && (
+              <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+                <Trophy className="size-5 text-amber-500" />
+                <span className="text-sm font-medium">{winner.displayName} won this event</span>
+                <ProfileLink row={winner} />
+              </div>
+            )}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16">Place</TableHead>
+                  <TableHead>Entrant</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <ResultRow key={row.standing.placement} row={row} />
+                ))}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
@@ -107,4 +107,62 @@ describe('SetTimeline', () => {
     const otherList = screen.getByRole('list', { name: 'Other matches during this event' });
     expect(within(otherList).getAllByRole('listitem')).toHaveLength(1);
   });
+
+  it('shows the opponent tag for a set', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', opponent: 'rival' }),
+    ];
+    renderTimeline(matches);
+    expect(screen.getByText(/vs rival/)).toBeInTheDocument();
+  });
+
+  it('links the opponent tag to their start.gg profile when opponentUserSlug is present', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 100,
+        win: true,
+        externalId: 'sgg:1:g1',
+        opponent: 'rival',
+        opponentUserSlug: 'user/9fb774ae',
+      }),
+    ];
+    renderTimeline(matches);
+    const link = screen.getByRole('link', { name: 'View rival on start.gg' });
+    expect(link).toHaveAttribute('href', 'https://start.gg/user/9fb774ae');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('omits the opponent profile link when opponentUserSlug is absent', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', opponent: 'rival' }),
+    ];
+    renderTimeline(matches);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows a compact seed/placement context next to the opponent when present', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 100,
+        win: true,
+        externalId: 'sgg:1:g1',
+        opponent: 'rival',
+        opponentSeed: 56,
+        opponentPlacement: 129,
+      }),
+    ];
+    renderTimeline(matches);
+    expect(screen.getByText('(seed 56 · placed 129th)')).toBeInTheDocument();
+  });
+
+  it('omits the seed/placement context when neither is present', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', opponent: 'rival' }),
+    ];
+    renderTimeline(matches);
+    expect(screen.queryByText(/seed|placed/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -6,6 +7,8 @@ import { stagesById } from '@/data/stages';
 import { stageAbbreviation } from '@/components/StageOption';
 import type { Match } from '@smash-tracker/shared';
 import type { TournamentSet } from '../lib/setTimeline';
+import { buildStartggUrl } from '../lib/startggLinks';
+import { formatOpponentEventContext } from '../lib/ordinal';
 import { cn } from '@/lib/utils';
 
 function GameChip({ match }: { match: Match }) {
@@ -52,6 +55,37 @@ function OpponentTags({ opponentFighterIds }: { opponentFighterIds: number[] }) 
   );
 }
 
+function OpponentLabel({ set }: { set: TournamentSet }) {
+  if (!set.opponentName) {
+    return null;
+  }
+  const profileUrl = buildStartggUrl(set.opponentUserSlug);
+  const context = formatOpponentEventContext({
+    seed: set.opponentSeed,
+    placement: set.opponentPlacement,
+  });
+
+  return (
+    <span className="flex items-center gap-1 text-sm text-muted-foreground">
+      <span className="inline-flex items-center gap-1">
+        vs {set.opponentName}
+        {profileUrl && (
+          <a
+            href={profileUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`View ${set.opponentName} on start.gg`}
+            className="inline-flex text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink className="size-3.5" />
+          </a>
+        )}
+      </span>
+      {context && <span className="text-xs">({context})</span>}
+    </span>
+  );
+}
+
 function SetRow({ set }: { set: TournamentSet }) {
   const isLosersSide = set.bracketRound != null && set.bracketRound < 0;
 
@@ -65,6 +99,7 @@ function SetRow({ set }: { set: TournamentSet }) {
       <div className="flex flex-wrap items-center gap-3">
         <span className="min-w-32 text-sm font-medium">{set.roundText ?? `Set ${set.setId}`}</span>
         <OpponentTags opponentFighterIds={set.opponentFighterIds} />
+        <OpponentLabel set={set} />
         <div className="flex items-center gap-1">
           {set.games.map((g) => (
             <GameChip key={g.match.id} match={g.match} />
@@ -85,9 +120,12 @@ function SetRow({ set }: { set: TournamentSet }) {
  * Chronological set-by-set breakdown of an entry's matches: round label
  * (falling back to "Set {id}" when start.gg's `roundText` hasn't synced
  * yet), a losers-side tint when `bracketRound` is negative, opponent
- * character tag(s), per-game stage chips (color = win/loss, tooltip = stage
- * name + result), and the derived set score/result. Matches without a
- * parseable set id render in a separate list below.
+ * character tag(s), the opponent's human tag with an outbound start.gg
+ * profile link (when `opponentUserSlug` synced) and a compact
+ * "seed N · placed Nth" context label (when either is known), per-game stage
+ * chips (color = win/loss, tooltip = stage name + result), and the derived
+ * set score/result. Matches without a parseable set id render in a separate
+ * list below.
  */
 export function SetTimeline({
   sets,

--- a/apps/web/src/pages/Tournaments/components/TournamentHeader.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/TournamentHeader.test.tsx
@@ -81,4 +81,33 @@ describe('TournamentHeader', () => {
     render(<TournamentHeader entry={makeEntry({ setsPlayed: 7 })} />);
     expect(screen.getByText('7 sets played')).toBeInTheDocument();
   });
+
+  it('shows a "View on start.gg" button linking to the event slug when present', () => {
+    render(
+      <TournamentHeader
+        entry={makeEntry({
+          slug: 'tournament/the-box-juice-box-26',
+          eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+        })}
+      />,
+    );
+    const link = screen.getByRole('link', { name: /View on start\.gg/ });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://start.gg/tournament/the-box-juice-box-26/event/ultimate-singles',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('falls back to the tournament slug when eventSlug is absent', () => {
+    render(<TournamentHeader entry={makeEntry({ slug: 'tournament/the-box-juice-box-26' })} />);
+    const link = screen.getByRole('link', { name: /View on start\.gg/ });
+    expect(link).toHaveAttribute('href', 'https://start.gg/tournament/the-box-juice-box-26');
+  });
+
+  it('omits the "View on start.gg" button when neither slug is present', () => {
+    render(<TournamentHeader entry={makeEntry({ slug: undefined, eventSlug: undefined })} />);
+    expect(screen.queryByRole('link', { name: /View on start\.gg/ })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Tournaments/components/TournamentHeader.tsx
+++ b/apps/web/src/pages/Tournaments/components/TournamentHeader.tsx
@@ -1,6 +1,9 @@
+import { ExternalLink } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import type { TournamentEntry } from '@smash-tracker/shared';
+import { buildEventStartggUrl } from '../lib/startggLinks';
 
 function formatDate(time: number): string {
   return new Date(time).toLocaleDateString('en-US', {
@@ -45,12 +48,16 @@ export function buildSeedPlacementBadge(entry: TournamentEntry): SeedPlacementBa
 /**
  * Tournament detail header: tournament name (falling back to the event name
  * when start.gg didn't provide one), the event name sub-line, date range,
- * entrant count, and the seed->placement badge when both are known.
+ * entrant count, the seed->placement badge when both are known, and an
+ * outbound "View on start.gg" button when `eventSlug`/`slug` has synced
+ * (falls back to the tournament slug when the event slug isn't available
+ * yet; hidden entirely when neither is present).
  */
 export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
   const title = entry.tournamentName ?? entry.eventName;
   const showEventSubline = entry.tournamentName != null && entry.tournamentName !== entry.eventName;
   const badge = buildSeedPlacementBadge(entry);
+  const startggUrl = buildEventStartggUrl(entry);
 
   return (
     <Card>
@@ -70,6 +77,14 @@ export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
             <Badge variant={badge.tone === 'secondary' ? 'secondary' : badge.tone}>
               {badge.label}
             </Badge>
+          )}
+          {startggUrl && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={startggUrl} target="_blank" rel="noreferrer">
+                View on start.gg
+                <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
           )}
         </div>
       </CardHeader>

--- a/apps/web/src/pages/Tournaments/lib/eventResults.test.ts
+++ b/apps/web/src/pages/Tournaments/lib/eventResults.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type { EventStanding, Match } from '@smash-tracker/shared';
+import {
+  buildEventResultRows,
+  opponentTagsPlayedAtEvent,
+  standingMatchesPlayedOpponent,
+} from './eventResults';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 1, name: 'Battlefield' },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'offline-tourney',
+    ...overrides,
+  };
+}
+
+function makeStanding(overrides: Partial<EventStanding> = {}): EventStanding {
+  return {
+    placement: 1,
+    name: 'Sponsor | Rival',
+    ...overrides,
+  };
+}
+
+describe('opponentTagsPlayedAtEvent', () => {
+  it('collects distinct lowercased opponent tags', () => {
+    const matches = [
+      makeMatch({ id: 'a', time: 100, win: true, opponent: 'Rival' }),
+      makeMatch({ id: 'b', time: 200, win: false, opponent: 'RIVAL' }),
+      makeMatch({ id: 'c', time: 300, win: true, opponent: 'someone-else' }),
+    ];
+    expect(opponentTagsPlayedAtEvent(matches)).toEqual(new Set(['rival', 'someone-else']));
+  });
+
+  it('skips matches with no opponent tag', () => {
+    const matches = [makeMatch({ id: 'a', time: 100, win: true, opponent: undefined })];
+    expect(opponentTagsPlayedAtEvent(matches)).toEqual(new Set());
+  });
+});
+
+describe('standingMatchesPlayedOpponent', () => {
+  it('matches on gamerTag case-insensitively', () => {
+    const played = new Set(['rival']);
+    expect(
+      standingMatchesPlayedOpponent({ name: 'Sponsor | Rival', gamerTag: 'Rival' }, played),
+    ).toBe(true);
+  });
+
+  it('matches on name case-insensitively when gamerTag is absent', () => {
+    const played = new Set(['rival']);
+    expect(standingMatchesPlayedOpponent({ name: 'RIVAL' }, played)).toBe(true);
+  });
+
+  it('returns false when neither name nor gamerTag match', () => {
+    const played = new Set(['rival']);
+    expect(standingMatchesPlayedOpponent({ name: 'Someone Else', gamerTag: 'Other' }, played)).toBe(
+      false,
+    );
+  });
+});
+
+describe('buildEventResultRows', () => {
+  it('returns an empty array when topStandings is absent', () => {
+    expect(buildEventResultRows({ topStandings: undefined }, [])).toEqual([]);
+  });
+
+  it('uses gamerTag as displayName when it differs from name, with name as subLabel', () => {
+    const rows = buildEventResultRows(
+      {
+        topStandings: [makeStanding({ placement: 1, name: 'Sponsor | Rival', gamerTag: 'Rival' })],
+      },
+      [],
+    );
+    expect(rows[0]?.displayName).toBe('Rival');
+    expect(rows[0]?.subLabel).toBe('Sponsor | Rival');
+  });
+
+  it('uses name as displayName with no subLabel when gamerTag matches name or is absent', () => {
+    const rows = buildEventResultRows(
+      { topStandings: [makeStanding({ placement: 1, name: 'Rival', gamerTag: undefined })] },
+      [],
+    );
+    expect(rows[0]?.displayName).toBe('Rival');
+    expect(rows[0]?.subLabel).toBeNull();
+  });
+
+  it('flags playedAtEvent for standings matching an opponent tag played at this event', () => {
+    const matches = [makeMatch({ id: 'a', time: 100, win: true, opponent: 'rival' })];
+    const rows = buildEventResultRows(
+      {
+        topStandings: [makeStanding({ placement: 1, name: 'Sponsor | Rival', gamerTag: 'Rival' })],
+      },
+      matches,
+    );
+    expect(rows[0]?.playedAtEvent).toBe(true);
+  });
+
+  it('leaves playedAtEvent false for standings not matching any played opponent', () => {
+    const matches = [makeMatch({ id: 'a', time: 100, win: true, opponent: 'someone-else' })];
+    const rows = buildEventResultRows(
+      {
+        topStandings: [makeStanding({ placement: 1, name: 'Sponsor | Rival', gamerTag: 'Rival' })],
+      },
+      matches,
+    );
+    expect(rows[0]?.playedAtEvent).toBe(false);
+  });
+
+  it('builds a profile URL when userSlug is present', () => {
+    const rows = buildEventResultRows(
+      { topStandings: [makeStanding({ placement: 1, userSlug: 'user/9fb774ae' })] },
+      [],
+    );
+    expect(rows[0]?.profileUrl).toBe('https://start.gg/user/9fb774ae');
+  });
+
+  it('leaves profileUrl null when userSlug is absent', () => {
+    const rows = buildEventResultRows(
+      { topStandings: [makeStanding({ placement: 1, userSlug: undefined })] },
+      [],
+    );
+    expect(rows[0]?.profileUrl).toBeNull();
+  });
+
+  it('preserves standings order (placement ascending, as start.gg provides)', () => {
+    const rows = buildEventResultRows(
+      {
+        topStandings: [
+          makeStanding({ placement: 1, name: 'Winner' }),
+          makeStanding({ placement: 2, name: 'Runner-up' }),
+        ],
+      },
+      [],
+    );
+    expect(rows.map((r) => r.standing.placement)).toEqual([1, 2]);
+  });
+});

--- a/apps/web/src/pages/Tournaments/lib/eventResults.ts
+++ b/apps/web/src/pages/Tournaments/lib/eventResults.ts
@@ -1,0 +1,74 @@
+import type { EventStanding, Match, TournamentEntry } from '@smash-tracker/shared';
+import { buildStartggUrl } from './startggLinks';
+
+export interface EventResultRow {
+  standing: EventStanding;
+  /** Display name — `gamerTag` when it differs from `name` (e.g. "Sponsor | Tag" -> "Tag"), otherwise just `name`. */
+  displayName: string;
+  /** The raw entrant name, shown as a sub-label only when it differs from `displayName`. */
+  subLabel: string | null;
+  /** True when this standings row matches an opponent tag actually played at this event (case-insensitive). */
+  playedAtEvent: boolean;
+  /** start.gg profile URL, when the standing carries a `userSlug`. */
+  profileUrl: string | null;
+}
+
+/**
+ * Collects the distinct opponent tags (`match.opponent`, already lowercased
+ * at write time — see `normalizeOpponentTag` in the sync service) the user
+ * actually played across the matches attributed to this event, as a Set for
+ * O(1) case-insensitive lookup. Manual matches with no `opponent` are
+ * skipped (nothing to match against).
+ */
+export function opponentTagsPlayedAtEvent(entryMatches: Match[]): Set<string> {
+  const tags = new Set<string>();
+  for (const match of entryMatches) {
+    if (match.opponent) {
+      tags.add(match.opponent.toLowerCase());
+    }
+  }
+  return tags;
+}
+
+/**
+ * True when a standings entry's `gamerTag` OR `name` matches (case
+ * insensitive) an opponent tag actually played at this event. Checking both
+ * fields covers start.gg's "Sponsor | Tag" display name convention, since
+ * the tracked opponent tag is normalized from whichever of the two matches.
+ */
+export function standingMatchesPlayedOpponent(
+  standing: Pick<EventStanding, 'name' | 'gamerTag'>,
+  playedTags: Set<string>,
+): boolean {
+  const candidates = [standing.name, standing.gamerTag].filter((v): v is string => v != null);
+  return candidates.some((candidate) => playedTags.has(candidate.toLowerCase()));
+}
+
+/**
+ * Builds the top-8 standings table rows for the Event Results card: display
+ * name (gamerTag when it differs from the raw name), the "you played them"
+ * highlight flag, and a start.gg profile link when available. Returns `[]`
+ * when `topStandings` is absent — callers render the resync-hint empty state
+ * in that case.
+ */
+export function buildEventResultRows(
+  entry: Pick<TournamentEntry, 'topStandings'>,
+  entryMatches: Match[],
+): EventResultRow[] {
+  const standings = entry.topStandings ?? [];
+  const playedTags = opponentTagsPlayedAtEvent(entryMatches);
+
+  return standings.map((standing) => {
+    const displayName =
+      standing.gamerTag && standing.gamerTag !== standing.name ? standing.gamerTag : standing.name;
+    const subLabel = displayName !== standing.name ? standing.name : null;
+
+    return {
+      standing,
+      displayName,
+      subLabel,
+      playedAtEvent: standingMatchesPlayedOpponent(standing, playedTags),
+      profileUrl: buildStartggUrl(standing.userSlug),
+    };
+  });
+}

--- a/apps/web/src/pages/Tournaments/lib/ordinal.test.ts
+++ b/apps/web/src/pages/Tournaments/lib/ordinal.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { ordinalSuffix, formatOrdinal, formatOpponentEventContext } from './ordinal';
+
+describe('ordinalSuffix', () => {
+  it('returns "st" for numbers ending in 1 (except 11)', () => {
+    expect(ordinalSuffix(1)).toBe('st');
+    expect(ordinalSuffix(21)).toBe('st');
+    expect(ordinalSuffix(101)).toBe('st');
+  });
+
+  it('returns "nd" for numbers ending in 2 (except 12)', () => {
+    expect(ordinalSuffix(2)).toBe('nd');
+    expect(ordinalSuffix(22)).toBe('nd');
+  });
+
+  it('returns "rd" for numbers ending in 3 (except 13)', () => {
+    expect(ordinalSuffix(3)).toBe('rd');
+    expect(ordinalSuffix(23)).toBe('rd');
+  });
+
+  it('returns "th" for the 11-13 teens regardless of last digit', () => {
+    expect(ordinalSuffix(11)).toBe('th');
+    expect(ordinalSuffix(12)).toBe('th');
+    expect(ordinalSuffix(13)).toBe('th');
+    expect(ordinalSuffix(111)).toBe('th');
+    expect(ordinalSuffix(112)).toBe('th');
+    expect(ordinalSuffix(113)).toBe('th');
+  });
+
+  it('returns "th" for everything else', () => {
+    expect(ordinalSuffix(0)).toBe('th');
+    expect(ordinalSuffix(4)).toBe('th');
+    expect(ordinalSuffix(129)).toBe('th');
+  });
+});
+
+describe('formatOrdinal', () => {
+  it('formats a number with its ordinal suffix', () => {
+    expect(formatOrdinal(1)).toBe('1st');
+    expect(formatOrdinal(129)).toBe('129th');
+    expect(formatOrdinal(2)).toBe('2nd');
+    expect(formatOrdinal(3)).toBe('3rd');
+  });
+});
+
+describe('formatOpponentEventContext', () => {
+  it('formats both seed and placement when present', () => {
+    expect(formatOpponentEventContext({ seed: 56, placement: 129 })).toBe('seed 56 · placed 129th');
+  });
+
+  it('formats seed alone when placement is absent', () => {
+    expect(formatOpponentEventContext({ seed: 56 })).toBe('seed 56');
+  });
+
+  it('formats placement alone when seed is absent', () => {
+    expect(formatOpponentEventContext({ placement: 129 })).toBe('placed 129th');
+  });
+
+  it('returns null when both are absent', () => {
+    expect(formatOpponentEventContext({})).toBeNull();
+  });
+});

--- a/apps/web/src/pages/Tournaments/lib/ordinal.ts
+++ b/apps/web/src/pages/Tournaments/lib/ordinal.ts
@@ -1,0 +1,48 @@
+/**
+ * English ordinal suffix for a positive integer (1st, 2nd, 3rd, 4th, ...11th,
+ * 12th, 13th, 21st...). The 11-13 teens are a special case that always take
+ * "th" regardless of their last digit. Exported standalone (rather than
+ * baked into a single formatter) so callers can compose it with their own
+ * label text.
+ */
+export function ordinalSuffix(n: number): string {
+  const abs = Math.abs(n);
+  const lastTwo = abs % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) {
+    return 'th';
+  }
+  switch (abs % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+/** Formats a positive integer with its ordinal suffix, e.g. `129` -> "129th". */
+export function formatOrdinal(n: number): string {
+  return `${n}${ordinalSuffix(n)}`;
+}
+
+/**
+ * Compact "seed 56 · placed 129th" label for an opponent's per-event
+ * context, when at least one of seed/placement is known. Returns `null`
+ * when both are absent so callers can omit the fragment cleanly.
+ */
+export function formatOpponentEventContext(opponent: {
+  seed?: number;
+  placement?: number;
+}): string | null {
+  const parts: string[] = [];
+  if (opponent.seed != null) {
+    parts.push(`seed ${opponent.seed}`);
+  }
+  if (opponent.placement != null) {
+    parts.push(`placed ${formatOrdinal(opponent.placement)}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/apps/web/src/pages/Tournaments/lib/setTimeline.test.ts
+++ b/apps/web/src/pages/Tournaments/lib/setTimeline.test.ts
@@ -118,4 +118,32 @@ describe('buildSetTimeline', () => {
     expect(sets).toEqual([]);
     expect(otherMatches).toEqual([]);
   });
+
+  it('reads opponentName/opponentSeed/opponentPlacement/opponentUserSlug off whichever game carries them', () => {
+    const withMeta = makeMatch({
+      id: 'a',
+      time: 100,
+      externalId: 'sgg:1:g1',
+      opponent: 'rival',
+      opponentSeed: 56,
+      opponentPlacement: 129,
+      opponentUserSlug: 'user/9fb774ae',
+    });
+    const withoutMeta = makeMatch({ id: 'b', time: 200, externalId: 'sgg:1:g2' });
+    const { sets } = buildSetTimeline([withoutMeta, withMeta]);
+
+    expect(sets[0]?.opponentName).toBe('rival');
+    expect(sets[0]?.opponentSeed).toBe(56);
+    expect(sets[0]?.opponentPlacement).toBe(129);
+    expect(sets[0]?.opponentUserSlug).toBe('user/9fb774ae');
+  });
+
+  it('leaves opponent seed/placement/userSlug undefined when no game in the set carries them', () => {
+    const games = [makeMatch({ id: 'a', time: 100, externalId: 'sgg:1:g1', opponent: undefined })];
+    const { sets } = buildSetTimeline(games);
+    expect(sets[0]?.opponentName).toBeUndefined();
+    expect(sets[0]?.opponentSeed).toBeUndefined();
+    expect(sets[0]?.opponentPlacement).toBeUndefined();
+    expect(sets[0]?.opponentUserSlug).toBeUndefined();
+  });
 });

--- a/apps/web/src/pages/Tournaments/lib/setTimeline.ts
+++ b/apps/web/src/pages/Tournaments/lib/setTimeline.ts
@@ -39,6 +39,14 @@ export interface TournamentSet {
   bracketRound: number | undefined;
   /** The opponent's fighter id(s) faced across this set's games, in first-seen order. */
   opponentFighterIds: number[];
+  /** The human opponent's free-text tag for this set, when any game carries one. */
+  opponentName: string | undefined;
+  /** The human opponent's seed in this event, when start.gg provided it (Phase B sync). */
+  opponentSeed: number | undefined;
+  /** The human opponent's final placement in this event, when start.gg provided it (Phase B sync). */
+  opponentPlacement: number | undefined;
+  /** The human opponent's start.gg profile slug, when start.gg provided it (Phase B sync). */
+  opponentUserSlug: string | undefined;
   /** Games in the set, ordered by game number. */
   games: SetGame[];
   /** Games won by the tracked user within this set. */
@@ -53,8 +61,9 @@ export interface TournamentSet {
  * Groups an entry's matches into sets (parsed from `externalId`), ordered
  * chronologically, plus a separate list of matches that don't belong to any
  * parseable set (manual entries, or imports predating the externalId
- * convention). `roundText`/`bracketRound` are read off the first game that
- * carries them (imports before the Phase A resync lack these fields
+ * convention). `roundText`/`bracketRound`/`opponentName`/`opponentSeed`/
+ * `opponentPlacement`/`opponentUserSlug` are read off the first game that
+ * carries them (imports before the relevant resync lack these fields
  * entirely — every consumer must tolerate `undefined`).
  */
 export interface SetTimeline {
@@ -100,6 +109,10 @@ export function buildSetTimeline(entryMatches: Match[]): SetTimeline {
       roundText: ordered.map((g) => g.match.roundText).find((r) => r != null),
       bracketRound: ordered.map((g) => g.match.bracketRound).find((r) => r != null),
       opponentFighterIds,
+      opponentName: ordered.map((g) => g.match.opponent).find((r) => r != null),
+      opponentSeed: ordered.map((g) => g.match.opponentSeed).find((r) => r != null),
+      opponentPlacement: ordered.map((g) => g.match.opponentPlacement).find((r) => r != null),
+      opponentUserSlug: ordered.map((g) => g.match.opponentUserSlug).find((r) => r != null),
       games: ordered,
       gamesWon,
       gamesLost,

--- a/apps/web/src/pages/Tournaments/lib/startggLinks.test.ts
+++ b/apps/web/src/pages/Tournaments/lib/startggLinks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildStartggUrl, buildEventStartggUrl } from './startggLinks';
+
+describe('buildStartggUrl', () => {
+  it('builds a start.gg URL from a slug', () => {
+    expect(buildStartggUrl('user/9fb774ae')).toBe('https://start.gg/user/9fb774ae');
+  });
+
+  it('builds a start.gg URL from a tournament slug', () => {
+    expect(buildStartggUrl('tournament/the-box-juice-box-26')).toBe(
+      'https://start.gg/tournament/the-box-juice-box-26',
+    );
+  });
+
+  it('returns null when the slug is undefined', () => {
+    expect(buildStartggUrl(undefined)).toBeNull();
+  });
+
+  it('returns null when the slug is an empty string', () => {
+    expect(buildStartggUrl('')).toBeNull();
+  });
+});
+
+describe('buildEventStartggUrl', () => {
+  it('prefers the event slug over the tournament slug', () => {
+    const url = buildEventStartggUrl({
+      slug: 'tournament/the-box-juice-box-26',
+      eventSlug: 'tournament/the-box-juice-box-26/event/ultimate-singles',
+    });
+    expect(url).toBe('https://start.gg/tournament/the-box-juice-box-26/event/ultimate-singles');
+  });
+
+  it('falls back to the tournament slug when the event slug is absent', () => {
+    const url = buildEventStartggUrl({ slug: 'tournament/the-box-juice-box-26' });
+    expect(url).toBe('https://start.gg/tournament/the-box-juice-box-26');
+  });
+
+  it('returns null when neither slug is present', () => {
+    expect(buildEventStartggUrl({})).toBeNull();
+  });
+});

--- a/apps/web/src/pages/Tournaments/lib/startggLinks.ts
+++ b/apps/web/src/pages/Tournaments/lib/startggLinks.ts
@@ -1,0 +1,25 @@
+const STARTGG_BASE_URL = 'https://start.gg';
+
+/**
+ * Builds a start.gg deep link from a slug (tournament, event, or user
+ * profile slug — all are relative paths off start.gg's root, e.g.
+ * "tournament/the-box-juice-box-26" or "user/9fb774ae"). Returns `null` when
+ * the slug is absent so callers can omit the link cleanly instead of
+ * rendering a dead/malformed href.
+ */
+export function buildStartggUrl(slug: string | undefined): string | null {
+  if (!slug) {
+    return null;
+  }
+  return `${STARTGG_BASE_URL}/${slug}`;
+}
+
+/**
+ * Prefers the more specific event slug (deep-links straight to the bracket
+ * the entry belongs to), falling back to the tournament slug when the event
+ * slug hasn't synced yet. Returns `null` when neither is present — callers
+ * hide the "View on start.gg" affordance entirely in that case.
+ */
+export function buildEventStartggUrl(entry: { slug?: string; eventSlug?: string }): string | null {
+  return buildStartggUrl(entry.eventSlug ?? entry.slug);
+}

--- a/apps/web/src/pages/Trends/components/Tournaments.test.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.test.tsx
@@ -154,4 +154,24 @@ describe('Tournaments component', () => {
       );
     });
   });
+
+  it('shows an outbound start.gg icon-link when the entry has a slug', async () => {
+    listTournaments.mockResolvedValue([
+      makeEntry({ eventId: 42, slug: 'tournament/the-box-juice-box-26' }),
+    ]);
+    renderTournaments([]);
+
+    const link = await screen.findByRole('link', { name: 'View on start.gg' });
+    expect(link).toHaveAttribute('href', 'https://start.gg/tournament/the-box-juice-box-26');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('omits the start.gg icon-link when the entry has no slug', async () => {
+    listTournaments.mockResolvedValue([makeEntry({ eventId: 42, slug: undefined })]);
+    renderTournaments([]);
+
+    await screen.findByRole('link', { name: 'Ultimate Singles' });
+    expect(screen.queryByRole('link', { name: 'View on start.gg' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Trends/components/Tournaments.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { ExternalLink } from 'lucide-react';
 import type { Match, TournamentEntry } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -12,6 +13,7 @@ import {
 import { getWinLossRecord, type WinLossRecord } from '@/lib/stats';
 import { useTournamentEntries } from '@/hooks/useTournamentEntries';
 import { matchesForEntry } from '@/pages/Tournaments/lib/matchesForEntry';
+import { buildStartggUrl } from '@/pages/Tournaments/lib/startggLinks';
 
 export interface TournamentEntryRow {
   entry: TournamentEntry;
@@ -61,6 +63,10 @@ function formatDateRange(entry: TournamentEntry): string {
  * only start showing up after a sync that populates the registry, so the
  * resync-hint empty state is preserved for accounts with matches but no
  * entries yet.
+ *
+ * V5 Phase B: rows also carry a small outbound start.gg icon-link when the
+ * entry's `slug` has synced (`stopPropagation` on click so it doesn't also
+ * trigger the internal row link); hidden entirely when the slug is absent.
  */
 export function Tournaments({ matches }: { matches: Match[] }) {
   const { data: entries, isLoading } = useTournamentEntries();
@@ -96,25 +102,42 @@ export function Tournaments({ matches }: { matches: Match[] }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map(({ entry, record }) => (
-                <TableRow key={entry.eventId}>
-                  <TableCell className="font-medium">
-                    <Link
-                      to={`/tournaments/${entry.eventId}`}
-                      className="underline-offset-2 hover:underline"
-                    >
-                      {entry.tournamentName ?? entry.eventName}
-                    </Link>
-                  </TableCell>
-                  <TableCell className="whitespace-normal">{entry.eventName}</TableCell>
-                  <TableCell>{formatDateRange(entry)}</TableCell>
-                  <TableCell>
-                    {record.wins}-{record.losses}
-                  </TableCell>
-                  <TableCell>{record.winRate}%</TableCell>
-                  <TableCell>{record.total}</TableCell>
-                </TableRow>
-              ))}
+              {rows.map(({ entry, record }) => {
+                const startggUrl = buildStartggUrl(entry.slug);
+                return (
+                  <TableRow key={entry.eventId}>
+                    <TableCell className="font-medium">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Link
+                          to={`/tournaments/${entry.eventId}`}
+                          className="underline-offset-2 hover:underline"
+                        >
+                          {entry.tournamentName ?? entry.eventName}
+                        </Link>
+                        {startggUrl && (
+                          <a
+                            href={startggUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            aria-label="View on start.gg"
+                            className="inline-flex text-muted-foreground hover:text-foreground"
+                          >
+                            <ExternalLink className="size-3.5" />
+                          </a>
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="whitespace-normal">{entry.eventName}</TableCell>
+                    <TableCell>{formatDateRange(entry)}</TableCell>
+                    <TableCell>
+                      {record.wins}-{record.losses}
+                    </TableCell>
+                    <TableCell>{record.winRate}%</TableCell>
+                    <TableCell>{record.total}</TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}


### PR DESCRIPTION
## Summary

- **Event Results card** (tournament detail page, after the header): winner callout for placement 1 + top-8 standings table (placement, entrant name, gamerTag shown alongside the raw name when they differ). Rows whose name/gamerTag match an opponent actually played at this event (case-insensitive, scoped to matches attributed to the entry) get a subtle tint + "You played them at this event" tooltip. Rows with a `userSlug` link out to `https://start.gg/{userSlug}` (external icon, `target=_blank rel=noreferrer`). Shows "Full results attach on your next start.gg sync." when `topStandings` hasn't synced yet.
- **Deep links**:
  - `TournamentHeader` gains a "View on start.gg" outbound button, preferring `eventSlug` and falling back to `slug`; hidden entirely when both are absent.
  - `SetTimeline` shows each set's human opponent tag with an outbound start.gg profile link (when that set's matches carry `opponentUserSlug`), plus a compact "seed N · placed Nth" context label next to the opponent when `opponentSeed`/`opponentPlacement` are present.
- **Trends**: tournament rows keep the internal `/tournaments/:eventId` link and gain a small external start.gg icon-link when the entry has a `slug` (`stopPropagation` so it doesn't also trigger row navigation).
- All new derivations are exported pure helpers with dedicated unit tests:
  - `apps/web/src/pages/Tournaments/lib/eventResults.ts` — `buildEventResultRows`, `opponentTagsPlayedAtEvent`, `standingMatchesPlayedOpponent`
  - `apps/web/src/pages/Tournaments/lib/startggLinks.ts` — `buildStartggUrl`, `buildEventStartggUrl`
  - `apps/web/src/pages/Tournaments/lib/ordinal.ts` — `ordinalSuffix`, `formatOrdinal`, `formatOpponentEventContext`
- Every new field (`slug`, `eventSlug`, `topStandings`, `opponentSeed`, `opponentPlacement`, `opponentUserSlug`) is optional per the schema (populates after the user's next start.gg sync) — all UI paths degrade gracefully to hidden/empty-state when absent.

Scope: `apps/web/src/pages/Tournaments/**` and `apps/web/src/pages/Trends/**` only (link touch-ups), plus tests. No changes to `pages/Opponents` or `shared/opponent.ts` (concurrently owned).

## Test counts

- New/updated test files: `eventResults.test.ts` (11), `startggLinks.test.ts` (7), `ordinal.test.ts` (13), `EventResults.test.tsx` (9), `TournamentHeader.test.tsx` (+3), `SetTimeline.test.tsx` (+5), `setTimeline.test.ts` (+2), `TournamentDetailPage.test.tsx` (+2), `Tournaments.test.tsx` (Trends, +2)
- Full repo test run: **674 tests passing** (shared: 44, api: 101, web: 529)

## Test plan

- [x] `pnpm lint` — 0 errors (31 pre-existing warnings, unrelated to this change)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 674/674 passing
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)