### PR TITLE
V6: harvest vodUrl + richer set data from start.gg

### DIFF
--- a/apps/api/src/startgg/client.ts
+++ b/apps/api/src/startgg/client.ts
@@ -93,6 +93,15 @@ const setsPageSchema = z.object({
               /** Literally the string "DQ" for sets decided by disqualification. */
               displayScore: z.string().nullish(),
               totalGames: z.number().int().nullish(),
+              /**
+               * URL of a VOD for this set, when a TO has attached one.
+               * Confirmed via schema introspection during the V6-W1b probe
+               * ("Url of a VOD for this set") but observed null on every
+               * sampled set, including majors' streamed Grand Finals — TOs
+               * rarely populate it in practice. Harvested anyway since it's
+               * free and additive; applies to every game of the set.
+               */
+              vodUrl: z.string().nullish(),
               event: z
                 .object({
                   id: z.number().nullish(),
@@ -137,7 +146,16 @@ const setsPageSchema = z.object({
                 .array(
                   z.object({
                     winnerId: z.number().nullish(),
-                    stage: z.object({ name: z.string() }).nullish(),
+                    /**
+                     * `id` is start.gg's stable, global numeric stage id
+                     * (verified via the V6-W1b probe: the same stage
+                     * consistently returns the same id across unrelated
+                     * sets/events/years). `name` remains for the
+                     * name-resolution fallback in `resolveStage`.
+                     */
+                    stage: z
+                      .object({ id: z.union([z.number(), z.string()]).nullish(), name: z.string() })
+                      .nullish(),
                     selections: z
                       .array(
                         z.object({
@@ -146,6 +164,18 @@ const setsPageSchema = z.object({
                         }),
                       )
                       .nullish(),
+                    /**
+                     * Score of entrant1/entrant2 in this game — per
+                     * start.gg's own field description, "For smash, this is
+                     * equivalent to stocks remaining." Verified during the
+                     * V6-W1b probe: positionally corresponds to
+                     * `slots[0]`/`slots[1]`, ranges 0-3, and the winner's
+                     * value is always strictly greater than the loser's
+                     * when both are present (frequently both are null —
+                     * stock counts aren't tracked for every set).
+                     */
+                    entrant1Score: z.number().int().nullish(),
+                    entrant2Score: z.number().int().nullish(),
                   }),
                 )
                 .nullish(),
@@ -162,8 +192,8 @@ export type StartggSet = NonNullable<
 >['nodes'][number];
 
 // Complexity budget per page (perPage 10): ~10 sets x (2 slots x ~4 fields +
-// ~5 games x 3 fields + ~8 set/event fields) stays well under the 1000
-// object limit — nowhere near the ~180 objects/page this shape produces.
+// ~5 games x 5 fields + ~9 set/event fields) stays well under the 1000
+// object limit — nowhere near the ~200 objects/page this shape produces.
 const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!) {
   player(id: $playerId) {
     sets(perPage: $perPage, page: $page) {
@@ -175,6 +205,7 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
         round
         displayScore
         totalGames
+        vodUrl
         event { id name isOnline numEntrants videogame { id } tournament { name } }
         slots {
           entrant {
@@ -187,8 +218,10 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
         }
         games {
           winnerId
-          stage { name }
+          stage { id name }
           selections { character { id } entrant { id } }
+          entrant1Score
+          entrant2Score
         }
       }
     }

--- a/apps/api/src/startgg/stageMap.ts
+++ b/apps/api/src/startgg/stageMap.ts
@@ -26,3 +26,68 @@ for (const stage of StageList) {
 export function resolveStageByName(name: string): Stage | null {
   return stagesByNormalizedName.get(normalize(name)) ?? null;
 }
+
+/**
+ * start.gg's own numeric stage database id (`game.stage.id` from the GQL
+ * API), mapped to this app's stage id. Verified stable/global via manual
+ * probe queries (V6-W1b): the same stage consistently returned the same
+ * numeric id across dozens of unrelated sets spanning different players,
+ * events, and years (e.g. Battlefield was always 311, Pokémon Stadium 2
+ * always 378 — whether queried from player 1802316's set history or from
+ * Genesis 9's Ultimate Singles bracket). This is a curated table of every
+ * start.gg stage id observed during that probe (built by cross-referencing
+ * the observed name against `resolveStageByName`) rather than a generated
+ * runtime lookup — start.gg does not expose a "list all stages with ids"
+ * query, only ids attached to already-played games, so there is no
+ * authoritative bulk source to generate this from at sync time.
+ *
+ * Deliberately NOT exhaustive: start.gg has far more stage entries than
+ * this app's legal/common counterpick list, and only ids actually observed
+ * in probe data are included here. `resolveStage` falls back to name
+ * resolution for any id missing from this table, so an unmapped id never
+ * causes a worse outcome than before this map existed.
+ *
+ * Note: id 513 (Hollow Bastion) was observed in probe data but has no
+ * corresponding entry in this app's `StageList` (no Kingdom Hearts stage) —
+ * the build loop below silently skips it, so it's a harmless no-op kept
+ * here purely as a record of what start.gg returned.
+ */
+const STARTGG_STAGE_ID_TO_NAME: Readonly<Record<number, string>> = {
+  311: 'Battlefield',
+  328: 'Final Destination',
+  348: 'Kalos Pokémon League',
+  353: 'Lylat Cruise',
+  378: 'Pokémon Stadium 2',
+  385: 'Skyloft',
+  387: 'Smashville',
+  397: 'Town and City',
+  484: 'Small Battlefield',
+  513: 'Hollow Bastion',
+};
+
+const stagesByStartggId = new Map<number, Stage>();
+for (const [startggId, name] of Object.entries(STARTGG_STAGE_ID_TO_NAME)) {
+  const stage = resolveStageByName(name);
+  if (stage) {
+    stagesByStartggId.set(Number(startggId), stage);
+  }
+}
+
+/**
+ * Resolves a start.gg stage using its numeric `stage.id` first (stable,
+ * accent/punctuation-proof), falling back to name resolution when the id
+ * isn't in the curated table above (e.g. a stage this app hasn't observed
+ * yet). Returns null when neither resolves.
+ */
+export function resolveStage(
+  startggId: number | null | undefined,
+  name: string | null | undefined,
+): Stage | null {
+  if (startggId != null) {
+    const byId = stagesByStartggId.get(startggId);
+    if (byId) {
+      return byId;
+    }
+  }
+  return name ? resolveStageByName(name) : null;
+}

--- a/apps/api/src/startgg/sync.test.ts
+++ b/apps/api/src/startgg/sync.test.ts
@@ -7,7 +7,7 @@ import {
   importPlayerMatches,
   normalizeOpponentTag,
 } from './sync.js';
-import { resolveStageByName } from './stageMap.js';
+import { resolveStage, resolveStageByName } from './stageMap.js';
 import type { StartggSet } from './client.js';
 
 const PLAYER_ID = 1802316;
@@ -66,19 +66,26 @@ function makeSet(overrides: Partial<StartggSet> = {}): StartggSet {
     games: [
       {
         winnerId: 1,
-        stage: { name: 'Battlefield' },
+        // 311 is start.gg's real, verified-stable numeric id for Battlefield
+        // (see stageMap.ts) — exercises the id-based resolution path by
+        // default; a mismatched `name` here would still resolve correctly.
+        stage: { id: 311, name: 'Battlefield' },
         selections: [
           { character: { id: 1271 }, entrant: { id: 1 } },
           { character: { id: 1332 }, entrant: { id: 2 } },
         ],
+        entrant1Score: 3,
+        entrant2Score: 0,
       },
       {
         winnerId: 2,
-        stage: { name: 'Pokémon Stadium 2' },
+        stage: { id: 378, name: 'Pokémon Stadium 2' },
         selections: [
           { character: { id: 1271 }, entrant: { id: 1 } },
           { character: { id: 1332 }, entrant: { id: 2 } },
         ],
+        entrant1Score: 0,
+        entrant2Score: 2,
       },
     ],
     ...overrides,
@@ -128,12 +135,17 @@ describe('gamesFromSet', () => {
       opponentSeed: 12,
       opponentPlacement: 33,
       opponentUserSlug: 'user/9fb774ae',
+      // Game 1: user (slot 0) won with entrant1Score=3 remaining stocks.
+      stocksLeft: 3,
     });
     expect(g1?.record.fighter_id).toBeGreaterThan(0);
     expect(g1?.record.map?.name).toBe('Battlefield');
-    // Game 2: lost, accent-insensitive stage resolution
+    expect(g1?.record.map?.id).toBe(1); // resolved via start.gg stage id 311, not name
+    // Game 2: lost, accent-insensitive stage resolution, opponent (slot 1)
+    // won with entrant2Score=2 remaining stocks.
     expect(g2?.record.win).toBe(false);
     expect(g2?.record.map?.name).toContain('Stadium 2');
+    expect(g2?.record.stocksLeft).toBe(2);
   });
 
   it('omits opponentSeed/opponentPlacement/opponentUserSlug when start.gg provides none', () => {
@@ -207,6 +219,113 @@ describe('gamesFromSet', () => {
     expect(games).toHaveLength(1);
     expect(games[0]?.record.map).toEqual({ id: 0, name: 'unknown' });
     expect(summary.gamesUnknownStage).toBe(1);
+  });
+
+  it('resolves stage by start.gg numeric id even when name would not match (id takes priority)', () => {
+    const summary = emptySummary();
+    const set = makeSet({
+      games: [
+        {
+          winnerId: 1,
+          // 484 is start.gg's real id for Small Battlefield (verified during
+          // the V6-W1b probe); a garbled/renamed `name` should not matter
+          // when the id resolves.
+          stage: { id: 484, name: 'Some Renamed Stage Label' },
+          selections: [
+            { character: { id: 1271 }, entrant: { id: 1 } },
+            { character: { id: 1332 }, entrant: { id: 2 } },
+          ],
+        },
+      ],
+    });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games[0]?.record.map?.name).toBe('Small Battlefield');
+    expect(summary.gamesUnknownStage).toBe(0);
+  });
+
+  it('falls back to name resolution when the start.gg stage id is not in the curated table', () => {
+    const summary = emptySummary();
+    const set = makeSet({
+      games: [
+        {
+          winnerId: 1,
+          // An id start.gg could plausibly use for some other stage, not in
+          // our curated STARTGG_STAGE_ID_TO_NAME table — name resolution
+          // should still succeed.
+          stage: { id: 999999, name: 'Yoshi’s Story' },
+          selections: [
+            { character: { id: 1271 }, entrant: { id: 1 } },
+            { character: { id: 1332 }, entrant: { id: 2 } },
+          ],
+        },
+      ],
+    });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games[0]?.record.map?.name).toBe("Yoshi's Story");
+    expect(summary.gamesUnknownStage).toBe(0);
+  });
+
+  it('harvests vodUrl onto every game of the set when start.gg provides one', () => {
+    const summary = emptySummary();
+    const set = makeSet({ vodUrl: 'https://youtube.com/watch?v=abc123' });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games).toHaveLength(2);
+    expect(games[0]?.record.vodUrl).toBe('https://youtube.com/watch?v=abc123');
+    expect(games[1]?.record.vodUrl).toBe('https://youtube.com/watch?v=abc123');
+  });
+
+  it('omits vodUrl entirely when start.gg provides none (the common case)', () => {
+    const summary = emptySummary();
+    const set = makeSet({ vodUrl: null });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect('vodUrl' in games[0]!.record).toBe(false);
+  });
+
+  it('omits stocksLeft when start.gg tracks neither entrant score', () => {
+    const summary = emptySummary();
+    const set = makeSet({
+      games: [
+        {
+          winnerId: 1,
+          stage: { id: 311, name: 'Battlefield' },
+          selections: [
+            { character: { id: 1271 }, entrant: { id: 1 } },
+            { character: { id: 1332 }, entrant: { id: 2 } },
+          ],
+          entrant1Score: null,
+          entrant2Score: null,
+        },
+      ],
+    });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect('stocksLeft' in games[0]!.record).toBe(false);
+  });
+
+  it("omits stocksLeft when the winner's own score is null even though the loser's reads 0", () => {
+    // Regression guard: start.gg can report `{ entrant1Score: null,
+    // entrant2Score: 0 }` where entrant1 (slot 0) is the WINNER — the
+    // winner's stock count simply isn't tracked here, so max()-style logic
+    // would wrongly report `stocksLeft: 0` ("won with zero stocks left").
+    // Verified live during the V6-W1b probe (Genesis 9 set 56194830, game
+    // 15505434).
+    const summary = emptySummary();
+    const set = makeSet({
+      games: [
+        {
+          winnerId: 1, // entrant 1 = userEntrant, slot index 0
+          stage: { id: 311, name: 'Battlefield' },
+          selections: [
+            { character: { id: 1271 }, entrant: { id: 1 } },
+            { character: { id: 1332 }, entrant: { id: 2 } },
+          ],
+          entrant1Score: null,
+          entrant2Score: 0,
+        },
+      ],
+    });
+    const games = gamesFromSet(set, PLAYER_ID, summary);
+    expect(games[0]?.record.win).toBe(true);
+    expect('stocksLeft' in games[0]!.record).toBe(false);
   });
 
   it('marks offline events as offline-tourney', () => {
@@ -351,6 +470,49 @@ describe('resolveStageByName', () => {
   });
 });
 
+describe('resolveStage', () => {
+  it("resolves every start.gg stage id observed during the V6-W1b probe that exists in this app's stage list", () => {
+    // id -> expected app stage name, taken verbatim from live start.gg data
+    // (player 1802316's set history + Genesis 9 Ultimate Singles). Hollow
+    // Bastion (id 513) was also observed but is intentionally excluded here
+    // — this app's stage list has no Kingdom Hearts stage, so that curated
+    // entry is a harmless no-op (see the next test).
+    const observed: [number, string][] = [
+      [311, 'Battlefield'],
+      [328, 'Final Destination'],
+      [348, 'Kalos Pokémon League'],
+      [353, 'Lylat Cruise'],
+      [378, 'Pokémon Stadium 2'],
+      [385, 'Skyloft'],
+      [387, 'Smashville'],
+      [397, 'Town and City'],
+      [484, 'Small Battlefield'],
+    ];
+    for (const [id, name] of observed) {
+      expect(resolveStage(id, 'irrelevant-mismatched-name')?.name).toBe(name);
+    }
+  });
+
+  it("harmlessly no-ops for a curated id whose stage is not in this app's stage list (Hollow Bastion)", () => {
+    expect(resolveStage(513, 'Hollow Bastion')).toBeNull();
+  });
+
+  it('prefers the numeric id over the name when both are present', () => {
+    expect(resolveStage(311, 'Not Battlefield At All')?.name).toBe('Battlefield');
+  });
+
+  it('falls back to name resolution when the id is unmapped or absent', () => {
+    expect(resolveStage(123456789, 'Pokemon Stadium 2')?.name).toBe('Pokémon Stadium 2');
+    expect(resolveStage(null, 'Pokemon Stadium 2')?.name).toBe('Pokémon Stadium 2');
+    expect(resolveStage(undefined, 'Pokemon Stadium 2')?.name).toBe('Pokémon Stadium 2');
+  });
+
+  it('returns null when neither the id nor the name resolve', () => {
+    expect(resolveStage(123456789, 'Not A Real Stage')).toBeNull();
+    expect(resolveStage(null, null)).toBeNull();
+  });
+});
+
 describe('importPlayerMatches', () => {
   function pageResponse(sets: StartggSet[], totalPages = 1) {
     return new Response(
@@ -391,6 +553,30 @@ describe('importPlayerMatches', () => {
     );
     const matchesAfter = tree['matches']?.['uid-1'] as Record<string, unknown>;
     expect(Object.keys(matchesAfter)).toHaveLength(2);
+  });
+
+  it('writes vodUrl and stocksLeft through to RTDB end-to-end', async () => {
+    const database = new FakeDatabase();
+    const fetchMock = async () =>
+      pageResponse([makeSet({ vodUrl: 'https://youtube.com/watch?v=abc123' })]);
+
+    await importPlayerMatches(
+      database as never,
+      'uid-1',
+      PLAYER_ID,
+      'server-token',
+      fetchMock as typeof fetch,
+    );
+
+    const tree = database.dump() as Record<string, Record<string, unknown>>;
+    const matches = tree['matches']?.['uid-1'] as Record<
+      string,
+      { vodUrl?: string; stocksLeft?: number }
+    >;
+    expect(matches['sgg-111-g1']?.vodUrl).toBe('https://youtube.com/watch?v=abc123');
+    expect(matches['sgg-111-g1']?.stocksLeft).toBe(3);
+    expect(matches['sgg-111-g2']?.vodUrl).toBe('https://youtube.com/watch?v=abc123');
+    expect(matches['sgg-111-g2']?.stocksLeft).toBe(2);
   });
 
   it('counts imported games by unique key, not once per page (pagination overlap)', async () => {

--- a/apps/api/src/startgg/sync.ts
+++ b/apps/api/src/startgg/sync.ts
@@ -7,7 +7,7 @@ import {
   type StartggSet,
 } from './client.js';
 import { startggCharacterToFighterId } from './characterMap.js';
-import { resolveStageByName } from './stageMap.js';
+import { resolveStage } from './stageMap.js';
 
 /** Hard cap on pages per sync — 40 pages x 10 sets stays well inside the 80 req/60s rate limit. */
 const MAX_PAGES = 40;
@@ -85,12 +85,23 @@ export function gamesFromSet(
   const tournamentName = set.event?.tournament?.name?.trim();
   const roundText = set.fullRoundText?.trim();
   const bracketRound = typeof set.round === 'number' ? set.round : undefined;
+  // `Set.vodUrl` is TO-curated and near-always null in practice (see the
+  // V6-W1b probe notes on client.ts's `vodUrl` schema field), but when
+  // present it applies to every game of the set.
+  const vodUrl = set.vodUrl ?? undefined;
   // Per-event facts about the human opponent, duplicated per game by design
   // (RTDB read simplicity beats normalization here).
   const opponentSeed = opponentEntrant.seeds?.find((s) => typeof s?.seedNum === 'number')?.seedNum;
   const opponentPlacement = opponentEntrant.standing?.placement ?? undefined;
   const opponentUserSlug = (opponentEntrant.participants ?? []).find((p) => p?.user?.slug != null)
     ?.user?.slug;
+  // `game.entrant1Score`/`entrant2Score` correspond positionally to
+  // `slots[0]`/`slots[1]` (verified during the V6-W1b probe against live
+  // start.gg data — never by entrant id, which the API doesn't expose per
+  // score). `slots` here is the same entrant-only, order-preserving array
+  // used to find userEntrant/opponentEntrant above.
+  const userSlotIndex = slots.findIndex((entrant) => entrant.id === userEntrant.id);
+  const opponentSlotIndex = slots.findIndex((entrant) => entrant.id === opponentEntrant.id);
   const results: ImportableGame[] = [];
 
   games.forEach((game, index) => {
@@ -114,10 +125,46 @@ export function gamesFromSet(
       return;
     }
 
-    const resolvedStage = game.stage?.name ? resolveStageByName(game.stage.name) : null;
+    // Numeric start.gg stage id first (stable/global — see stageMap.ts),
+    // falling back to name resolution when the id isn't in the curated
+    // table (or is absent) — same "unknown sentinel" outcome either way.
+    const rawStageId = game.stage?.id;
+    const stageId =
+      typeof rawStageId === 'number'
+        ? rawStageId
+        : typeof rawStageId === 'string'
+          ? Number(rawStageId)
+          : null;
+    const resolvedStage = resolveStage(
+      stageId != null && Number.isFinite(stageId) ? stageId : null,
+      game.stage?.name,
+    );
     if (!resolvedStage) {
       summary.gamesUnknownStage += 1;
     }
+
+    // Winner's remaining-stock count for this individual game (start.gg:
+    // "Score of entrant 1/2 ... equivalent to stocks remaining" — see
+    // client.ts). Read from whichever slot the winner occupies, never via
+    // max(), since one side can be null while the other is a meaningless 0
+    // (see sync.test.ts for the exact case this guards against). Clamped to
+    // matchRecordSchema's 0-3 range (standard 4-stock games only — every
+    // sampled value during the V6-W1b probe fell in this range, but a
+    // non-standard stock count ruleset could in principle report higher).
+    const winnerScore =
+      game.winnerId === userEntrant.id
+        ? userSlotIndex === 0
+          ? game.entrant1Score
+          : game.entrant2Score
+        : game.winnerId === opponentEntrant.id
+          ? opponentSlotIndex === 0
+            ? game.entrant1Score
+            : game.entrant2Score
+          : null;
+    const stocksLeft =
+      typeof winnerScore === 'number' && winnerScore >= 0 && winnerScore <= 3
+        ? winnerScore
+        : undefined;
 
     const externalId = `sgg:${set.id}:g${index + 1}`;
     results.push({
@@ -143,6 +190,8 @@ export function gamesFromSet(
         ...(opponentSeed != null ? { opponentSeed } : {}),
         ...(opponentPlacement != null ? { opponentPlacement } : {}),
         ...(opponentUserSlug ? { opponentUserSlug } : {}),
+        ...(stocksLeft !== undefined ? { stocksLeft } : {}),
+        ...(vodUrl ? { vodUrl } : {}),
       },
     });
   });

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -114,6 +114,16 @@ export const matchRecordSchema = z.object({
    * `opponentSeed`. Server-set, imported matches only.
    */
   opponentUserSlug: z.string().optional(),
+  /**
+   * URL of a VOD for the set this game belonged to, when start.gg's
+   * `Set.vodUrl` is populated (a TO-curated field — verified via the
+   * V6-W1b probe to exist but be null on essentially every real set
+   * sampled, including majors' streamed Grand Finals; harvested anyway in
+   * case a TO does populate it). Duplicated across every game of the set,
+   * same rationale as `opponentSeed`/`opponentPlacement`. Server-set,
+   * imported matches only.
+   */
+  vodUrl: z.string().url().optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 


### PR DESCRIPTION
## Summary

start.gg data harvest (V6-W1b): `vodUrl`, per-game stock counts, and a stable stage-id-based mapping, wired into the existing `sync.ts` pipeline with the same conditional-spread / idempotent-key discipline as the rest of the module. No `apps/web` changes.

## Probe findings (exact)

Ran read-only probe queries against `https://api.start.gg/gql/alpha` (player id `1802316`, plus a full page of Genesis 9's Ultimate Singles bracket) before writing any code — roughly 20 requests total, comfortably under the 80 req/60s shared rate limit.

- **`Set.vodUrl`** — real field, confirmed via schema introspection: `"Url of a VOD for this set"`, type `String`. **Always `null`** in every sample checked: all 75 of player 1802316's sets across 15 pages, and a full page of Genesis 9 Ultimate Singles including Grand Final / Grand Final Reset / Winners Final. TOs essentially never populate it in practice. **Decision: harvest it anyway** — it's free and additive, and if a TO ever does populate it, we now capture it automatically.

- **`Game.stage.id`** — a numeric id, confirmed **stable and global**: the same stage consistently returned the same id across dozens of unrelated sets spanning different players, tournaments, and years (2020–2026). Examples verified live: Battlefield=311, Final Destination=328, Pokémon Stadium 2=378, Small Battlefield=484, Kalos Pokémon League=348, Lylat Cruise=353, Smashville=387, Town and City=397, Skyloft=385, Hollow Bastion=513. **Decision: built a curated `start.gg-id → app-stage` table** (`stageMap.ts`'s `resolveStage`), generated once via name resolution and preferred over name matching (accent/punctuation-proof), with name resolution kept as the fallback for any id not yet observed. (Hollow Bastion's id was observed but has no corresponding entry in this app's stage list — a harmless no-op, documented in code.)

- **Stock/score fields** — `Game.entrant1Score` / `entrant2Score` exist and are exactly the "stock" data referenced in the task. Introspection confirms start.gg's own description: *"Score of entrant 1/2. For smash, this is equivalent to stocks remaining."* Verified via live data: positionally correspond to `slots[0]`/`slots[1]` (not by entrant id — the API doesn't expose that per score), range 0–3 (matches the existing `stocksLeft` schema cap exactly), winner's score always strictly greater than loser's when both present, and frequently both/one side is `null` (untracked). Also found the exact edge case `{ entrant1Score: null, entrant2Score: 0 }` where entrant1 was the winner — guards against naively taking `max()`, which would have wrongly reported `stocksLeft: 0` for a winner whose stock count simply wasn't tracked. **Decision: harvest the winner's remaining-stock value into the existing `stocksLeft` field** (already defined, previously only populated by manual entry), read from the winner's own slot position, never via `max()`.

- `selections` (character picks) carry no stock data — confirmed no stock info lives there, as the task suspected might be needed.

## What was harvested vs. skipped

Harvested:
- `vodUrl` (set-level, duplicated onto every game of the set) — `matchRecordSchema.vodUrl`, optional, URL-validated.
- `stocksLeft` (per-game, winner's remaining stock count) — reuses the existing `matchRecordSchema.stocksLeft` field, now also populated by sync (previously manual-entry only).
- Stage resolution via start.gg's numeric id first, name as fallback — `stageMap.ts`'s new `resolveStage(startggId, name)`, used in `sync.ts` in place of the old `resolveStageByName`-only call.

Skipped / not built:
- No dynamic/runtime-generated stage-id map — start.gg doesn't expose a "list all stages" query, so there's no authoritative bulk source to generate from at sync time. Table is curated from probe-observed ids instead, with a safe fallback for anything unmapped.
- No tournament/set-level schema additions beyond `vodUrl` — the probe didn't surface further fields worth harvesting beyond what's already captured (event/tournament name, round, seed, placement, slug, standings).

## Test plan

- [x] `apps/api/src/startgg/sync.test.ts` — 6 new `gamesFromSet` cases (id-priority-over-name, id-fallback-to-name, vodUrl present/omitted, stocksLeft omitted-when-untracked, the null-vs-0 winner-score regression guard) + a new `describe('resolveStage', ...)` block (4 cases) + a new `importPlayerMatches` end-to-end case asserting `vodUrl`/`stocksLeft` reach RTDB. Existing fixture (`makeSet`) updated to include real start.gg stage ids + entrant scores.
- [x] `apps/api` test suite: **127/127 passing** (up from 115 baseline; +12 new)
- [x] `packages/shared` test suite: **52/52 passing**
- [x] `pnpm lint`: 0 errors (pre-existing `apps/web` warnings only, untouched by this change)
- [x] `pnpm typecheck`: clean across `shared`/`api`/`web`
- [x] `pnpm build`: clean across all packages
- [x] `pnpm format:check`: clean
- [ ] `apps/web` test suite showed 4 failed files / 6 failed tests under full-monorepo concurrent load (worker timeouts + one `findByPlaceholderText` timeout) — confirmed pre-existing/environmental: this PR touches zero `apps/web` files, and the flagged test (`AddMatchForm.test.tsx`) passes 11/11 when re-run in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)