### PR TITLE
Matchup matrix polish: centering, sticky width, rate-based hues

### DIFF
--- a/apps/web/src/pages/Matchups/components/MatchupMatrix.tsx
+++ b/apps/web/src/pages/Matchups/components/MatchupMatrix.tsx
@@ -72,10 +72,10 @@ export function MatchupMatrix({ matches }: { matches: Match[] }) {
           </p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="border-separate border-spacing-0 text-sm">
+            <table className="mx-auto w-max border-separate border-spacing-0 text-sm">
               <thead>
                 <tr>
-                  <th className="sticky left-0 z-10 bg-card p-2 text-left align-bottom">
+                  <th className="sticky left-0 z-10 w-40 min-w-40 max-w-40 border-r border-border bg-card p-2 text-left align-bottom">
                     <span className="sr-only">Your fighter</span>
                   </th>
                   {columnIds.map((opponentId) => {
@@ -107,7 +107,7 @@ export function MatchupMatrix({ matches }: { matches: Match[] }) {
                     <tr key={fighterId}>
                       <th
                         scope="row"
-                        className="sticky left-0 z-10 whitespace-nowrap bg-card p-2 text-left font-normal"
+                        className="sticky left-0 z-10 w-40 min-w-40 max-w-40 border-r border-border bg-card p-2 text-left font-normal"
                       >
                         <div className="flex items-center gap-2">
                           {fighter?.url && (
@@ -118,7 +118,9 @@ export function MatchupMatrix({ matches }: { matches: Match[] }) {
                               loading="lazy"
                             />
                           )}
-                          <span>{fighter?.name ?? 'Unknown'}</span>
+                          <span className="truncate" title={fighter?.name ?? 'Unknown'}>
+                            {fighter?.name ?? 'Unknown'}
+                          </span>
                         </div>
                       </th>
                       {columnIds.map((opponentId) => {
@@ -135,7 +137,10 @@ export function MatchupMatrix({ matches }: { matches: Match[] }) {
                                 title={`${cell.wins}-${cell.losses} (${cell.winRate}% over ${cell.total})`}
                                 className="flex size-14 items-center justify-center rounded font-medium text-white transition-transform hover:scale-105 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                                 style={{
-                                  backgroundColor: matchupCellBackground(cell.wilson, cell.total),
+                                  backgroundColor: matchupCellBackground(
+                                    cell.total > 0 ? cell.wins / cell.total : 0,
+                                    cell.total,
+                                  ),
                                 }}
                               >
                                 {cell.wins}-{cell.losses}

--- a/apps/web/src/pages/Matchups/lib/matchupCellColor.test.ts
+++ b/apps/web/src/pages/Matchups/lib/matchupCellColor.test.ts
@@ -3,24 +3,24 @@ import {
   FULL_SAMPLE_SIZE,
   matchupCellBackground,
   sampleSizeToOpacity,
-  wilsonToRgb,
+  rateToRgb,
 } from './matchupCellColor';
 
-describe('wilsonToRgb', () => {
+describe('rateToRgb', () => {
   it('returns the destructive red endpoint at wilson=0', () => {
-    expect(wilsonToRgb(0)).toEqual([217, 62, 52]);
+    expect(rateToRgb(0)).toEqual([217, 62, 52]);
   });
 
   it('returns the emerald endpoint at wilson=1', () => {
-    expect(wilsonToRgb(1)).toEqual([16, 185, 129]);
+    expect(rateToRgb(1)).toEqual([16, 185, 129]);
   });
 
   it('returns the neutral grey midpoint at wilson=0.5', () => {
-    expect(wilsonToRgb(0.5)).toEqual([113, 113, 122]);
+    expect(rateToRgb(0.5)).toEqual([113, 113, 122]);
   });
 
   it('interpolates monotonically from red to grey in the lower half', () => {
-    const quarter = wilsonToRgb(0.25);
+    const quarter = rateToRgb(0.25);
     // Halfway between red and grey on each channel.
     expect(quarter[0]).toBeCloseTo((217 + 113) / 2, 0);
     expect(quarter[1]).toBeCloseTo((62 + 113) / 2, 0);
@@ -28,15 +28,15 @@ describe('wilsonToRgb', () => {
   });
 
   it('interpolates monotonically from grey to emerald in the upper half', () => {
-    const threeQuarter = wilsonToRgb(0.75);
+    const threeQuarter = rateToRgb(0.75);
     expect(threeQuarter[0]).toBeCloseTo((113 + 16) / 2, 0);
     expect(threeQuarter[1]).toBeCloseTo((113 + 185) / 2, 0);
     expect(threeQuarter[2]).toBeCloseTo((122 + 129) / 2, 0);
   });
 
   it('clamps out-of-range inputs to the valid endpoints', () => {
-    expect(wilsonToRgb(-1)).toEqual(wilsonToRgb(0));
-    expect(wilsonToRgb(2)).toEqual(wilsonToRgb(1));
+    expect(rateToRgb(-1)).toEqual(rateToRgb(0));
+    expect(rateToRgb(2)).toEqual(rateToRgb(1));
   });
 });
 

--- a/apps/web/src/pages/Matchups/lib/matchupCellColor.ts
+++ b/apps/web/src/pages/Matchups/lib/matchupCellColor.ts
@@ -38,13 +38,14 @@ function lerpRgb(
 }
 
 /**
- * Interpolates red (wilson=0) -> grey (wilson=0.5) -> emerald (wilson=1).
- * Wilson lower bound is already evidence-adjusted (see `wilsonLowerBound` in
- * lib/stats.ts), so this is the "how good is this matchup, given what we
- * actually know" color, not the raw win rate.
+ * Interpolates red (rate=0) -> grey (rate=0.5) -> emerald (rate=1) from the
+ * RAW win rate. Confidence lives in the opacity channel instead
+ * (`sampleSizeToOpacity`): at real-world sample sizes the Wilson lower bound
+ * sits below 0.5 for almost every pairing, which painted winning records
+ * red — hue answers "am I winning this?", opacity answers "how sure are we?".
  */
-export function wilsonToRgb(wilson: number): [number, number, number] {
-  const clamped = Math.max(0, Math.min(1, wilson));
+export function rateToRgb(rate: number): [number, number, number] {
+  const clamped = Math.max(0, Math.min(1, rate));
   if (clamped <= 0.5) {
     return lerpRgb(LOW_RGB, MID_RGB, clamped / 0.5);
   }
@@ -67,9 +68,9 @@ export function sampleSizeToOpacity(total: number): number {
   return lerp(MIN_OPACITY, MAX_OPACITY, t);
 }
 
-/** CSS `rgba(...)` background-color string for a matrix cell with this Wilson score and sample size. */
-export function matchupCellBackground(wilson: number, total: number): string {
-  const [r, g, b] = wilsonToRgb(wilson);
+/** CSS `rgba(...)` background-color string for a matrix cell with this raw win rate (0-1) and sample size. */
+export function matchupCellBackground(winRate: number, total: number): string {
+  const [r, g, b] = rateToRgb(winRate);
   const alpha = sampleSizeToOpacity(total);
   return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha.toFixed(3)})`;
 }


### PR DESCRIPTION
User feedback from the live matrix (screenshots): top-12 view hugged the left, show-all view had row labels overlapping the first cells, and everything read red. Fixes: centered table when narrow; explicit sticky label-column width with truncation; and the real color bug — hue was driven by the Wilson lower bound (always <0.5 at these sample sizes), so winning records looked losing. Hue now = raw rate, confidence stays in opacity. 46 Matchups tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)