### PR TITLE
V7-B: Agentic scouting reports (Claude API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,25 @@ gcloud run deploy smash-tracker-api \
 The service name (`smash-tracker-api`) and region (`us-central1`) must match `firebase.json`'s
 `hosting.rewrites` entry for `/api/**`.
 
+**AI scouting reports (optional)**
+
+V7-B's AI-generated pre-bracket scouting reports (`/api/reports`) are powered by the Claude API and
+gated behind two env vars, both required together:
+
+- `ANTHROPIC_API_KEY` — a Claude API key.
+- `REPORTS_ALLOWED_UIDS` — a comma-separated list of Firebase uids allowed to generate reports (this
+  is a paid, per-token feature, so it's opt-in per uid even once a key is configured).
+
+```sh
+gcloud run deploy smash-tracker-api \
+  --source . \
+  --region us-central1 \
+  --set-env-vars FIREBASE_DATABASE_URL=https://smash-tracker-f97b7-default-rtdb.firebaseio.com,ANTHROPIC_API_KEY=sk-ant-...,REPORTS_ALLOWED_UIDS=uid1,uid2
+```
+
+Until both vars are set, every `/api/reports*` route answers `503` and the web app's "Generate AI
+report" button never renders — the rest of the app (including `/api/scout`) is unaffected.
+
 **2. Configure `apps/web/.env.production`**
 
 ```sh

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -61,3 +61,15 @@ STARTGG_STATE_SECRET=any-long-random-string
 
 # SPA origin that OAuth callbacks redirect back to.
 WEB_BASE_URL=http://localhost:5173
+
+# --- V7-B: AI scouting reports (optional) ---
+# Both values must be set for /api/reports to work; when either is missing,
+# every /api/reports* route answers 503 and the rest of the API works
+# normally (including /api/scout, which the reports feature is layered on).
+
+# Claude API key used to generate scouting reports.
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Comma-separated list of Firebase uids allowed to generate AI reports. This
+# is a paid, per-token feature, so it's opt-in per uid even once a key is set.
+REPORTS_ALLOWED_UIDS=uid1,uid2

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.110.0",
     "@fastify/cors": "^11.2.0",
     "@smash-tracker/shared": "workspace:*",
     "fastify": "^5.9.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,10 +17,12 @@ import opponentAliasesRoutes from './routes/opponentAliases.js';
 import opponentNotesRoutes from './routes/opponentNotes.js';
 import startggRoutes from './routes/startgg.js';
 import scoutRoutes from './routes/scout.js';
+import reportsRoutes from './routes/reports.js';
 import tournamentsRoutes from './routes/tournaments.js';
 import { NotFoundError } from './services/rtdb.js';
 import type { FirebaseServices } from './firebase/admin.js';
-import type { StartggConfig } from './config/env.js';
+import type { ReportsConfig, StartggConfig } from './config/env.js';
+import type { AnthropicLikeClient } from './reports/generate.js';
 
 export interface BuildAppOptions {
   firebase: FirebaseServices;
@@ -30,6 +32,10 @@ export interface BuildAppOptions {
   startgg?: StartggConfig | null;
   /** Overridable fetch for the start.gg OAuth/GraphQL calls (tests). */
   startggFetch?: typeof fetch;
+  /** AI reports config; null/omitted disables /api/reports (503). */
+  reports?: ReportsConfig | null;
+  /** Overridable Anthropic client for /api/reports (tests). */
+  reportsClient?: AnthropicLikeClient;
   logger?: boolean | FastifyBaseLogger;
 }
 
@@ -124,6 +130,12 @@ export function buildApp(options: BuildAppOptions) {
       });
       await api.register(scoutRoutes, {
         config: options.startgg ?? null,
+        fetchImpl: options.startggFetch,
+      });
+      await api.register(reportsRoutes, {
+        config: options.reports ?? null,
+        startggConfig: options.startgg ?? null,
+        client: options.reportsClient,
         fetchImpl: options.startggFetch,
       });
     },

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -46,6 +46,13 @@ const envSchema = z.object({
   STARTGG_STATE_SECRET: z.string().optional(),
   /** SPA origin that OAuth callbacks redirect users back to. */
   WEB_BASE_URL: z.string().default('http://localhost:5173'),
+
+  // ---- V7-B: AI scouting reports (all optional — when incomplete, the
+  // /api/reports routes answer 503) ----------------------------------------
+  /** Claude API key used to generate scouting reports. */
+  ANTHROPIC_API_KEY: z.string().optional(),
+  /** Comma-separated list of Firebase uids allowed to generate AI reports. */
+  REPORTS_ALLOWED_UIDS: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -102,5 +109,36 @@ export function getStartggConfig(env: Env): StartggConfig | null {
     apiToken: env.STARTGG_API_TOKEN,
     stateSecret: env.STARTGG_STATE_SECRET,
     webBaseUrl: env.WEB_BASE_URL,
+  };
+}
+
+export interface ReportsConfig {
+  anthropicApiKey: string;
+  /** Firebase uids allowed to generate AI scouting reports. */
+  allowedUids: Set<string>;
+}
+
+/**
+ * Assembles the AI-reports config when fully present (a key AND a non-empty
+ * allowlist), else null (the /api/reports routes then respond 503, same
+ * all-or-nothing pattern as `getStartggConfig`) — this is a paid, per-token
+ * feature, so it stays opt-in per deployment even once `ANTHROPIC_API_KEY` is
+ * set.
+ */
+export function getReportsConfig(env: Env): ReportsConfig | null {
+  if (!env.ANTHROPIC_API_KEY || !env.REPORTS_ALLOWED_UIDS) {
+    return null;
+  }
+  const allowedUids = new Set(
+    env.REPORTS_ALLOWED_UIDS.split(',')
+      .map((uid) => uid.trim())
+      .filter((uid) => uid.length > 0),
+  );
+  if (allowedUids.size === 0) {
+    return null;
+  }
+  return {
+    anthropicApiKey: env.ANTHROPIC_API_KEY,
+    allowedUids,
   };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import { buildApp } from './app.js';
-import { getStartggConfig, loadEnv, parseCorsOrigins } from './config/env.js';
+import { getReportsConfig, getStartggConfig, loadEnv, parseCorsOrigins } from './config/env.js';
 import { initFirebase } from './firebase/admin.js';
 
 let env;
@@ -16,6 +16,7 @@ const app = buildApp({
   firebase,
   corsOrigin: parseCorsOrigins(env.CORS_ORIGIN),
   startgg: getStartggConfig(env),
+  reports: getReportsConfig(env),
 });
 
 app

--- a/apps/api/src/reports/generate.test.ts
+++ b/apps/api/src/reports/generate.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest';
+import type { ScoutReportData } from '@smash-tracker/shared';
+import { FakeDatabase } from '../test-support/fakeDatabase.js';
+import {
+  assembleReportPayload,
+  generateScoutReport,
+  ReportGenerationError,
+  type AnthropicLikeClient,
+} from './generate.js';
+
+const UID = 'test-uid-123';
+
+const SCOUT: ScoutReportData = {
+  player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+  sampledSets: 10,
+  sampledGames: 20,
+  characters: [
+    { fighterId: 8, games: 12, wins: 8 }, // Fox
+    { fighterId: 22, games: 8, wins: 4 }, // Falco
+  ],
+  stages: [{ stageId: 1, games: 20, wins: 12 }],
+  recentEvents: [],
+  commonOpponents: [],
+};
+
+describe('assembleReportPayload', () => {
+  it('returns empty head-to-head, zeroed userContext, and null notes with no data', async () => {
+    const database = new FakeDatabase();
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.scout).toBe(SCOUT);
+    expect(payload.headToHead).toEqual([]);
+    expect(payload.userContext.vsTopCharacters).toEqual([
+      { opponentCharacter: 'Fox', wins: 0, losses: 0, topStages: [] },
+      { opponentCharacter: 'Falco', wins: 0, losses: 0, topStages: [] },
+    ]);
+    expect(payload.userContext.recentForm).toEqual({ wins: 0, losses: 0, sampleSize: 0 });
+    expect(payload.notes).toBeNull();
+  });
+
+  it('matches head-to-head by opponentUserSlug (strongest signal)', async () => {
+    const database = new FakeDatabase();
+    database.seed(`matches/${UID}`, {
+      m1: {
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1_700_000_000_000,
+        win: true,
+        map: { id: 1, name: 'Battlefield' },
+        opponent: 'someone else entirely',
+        opponentUserSlug: 'user/07dc2239',
+        eventName: 'Ultimate Singles',
+        roundText: 'Winners Round 2',
+        stocksLeft: 2,
+      },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.headToHead).toEqual([
+      {
+        result: 'win',
+        userCharacter: 'Mario',
+        opponentCharacter: 'Fox',
+        stage: 'Battlefield',
+        eventName: 'Ultimate Singles',
+        roundText: 'Winners Round 2',
+        stocksLeft: 2,
+        date: new Date(1_700_000_000_000).toISOString(),
+      },
+    ]);
+  });
+
+  it('matches head-to-head by canonical opponent name when no userSlug is present', async () => {
+    const database = new FakeDatabase();
+    database.seed(`matches/${UID}`, {
+      m1: {
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1_700_000_000_000,
+        win: false,
+        opponent: 'pandem1c',
+      },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.headToHead).toHaveLength(1);
+    expect(payload.headToHead[0]).toMatchObject({ result: 'loss' });
+  });
+
+  it('resolves the opponent name through the alias map before matching', async () => {
+    const database = new FakeDatabase();
+    database.seed(`opponentAliases/${UID}`, { 'sponsor tag': 'pandem1c' });
+    database.seed(`matches/${UID}`, {
+      m1: {
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1_700_000_000_000,
+        win: true,
+        opponent: 'sponsor tag',
+      },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.headToHead).toHaveLength(1);
+  });
+
+  it('does not include matches against other opponents in head-to-head', async () => {
+    const database = new FakeDatabase();
+    database.seed(`matches/${UID}`, {
+      m1: {
+        fighter_id: 1,
+        opponent_id: 8,
+        time: 1_700_000_000_000,
+        win: true,
+        opponent: 'someone unrelated',
+      },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.headToHead).toEqual([]);
+  });
+
+  it('aggregates raw W/L and top stages against the scouted player’s top characters', async () => {
+    const database = new FakeDatabase();
+    database.seed(`matches/${UID}`, {
+      m1: {
+        fighter_id: 1,
+        opponent_id: 8, // Fox
+        time: 3,
+        win: true,
+        map: { id: 1, name: 'Battlefield' },
+        opponent: 'a',
+      },
+      m2: {
+        fighter_id: 1,
+        opponent_id: 8, // Fox
+        time: 2,
+        win: false,
+        map: { id: 1, name: 'Battlefield' },
+        opponent: 'b',
+      },
+      m3: {
+        fighter_id: 1,
+        opponent_id: 22, // Falco
+        time: 1,
+        win: true,
+        map: { id: 3, name: 'Final Destination' },
+        opponent: 'c',
+      },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.userContext.vsTopCharacters).toEqual([
+      {
+        opponentCharacter: 'Fox',
+        wins: 1,
+        losses: 1,
+        topStages: [{ stage: 'Battlefield', wins: 1, losses: 1 }],
+      },
+      {
+        opponentCharacter: 'Falco',
+        wins: 1,
+        losses: 0,
+        topStages: [{ stage: 'Final Destination', wins: 1, losses: 0 }],
+      },
+    ]);
+  });
+
+  it('computes recent form over the most recent 50 matches only', async () => {
+    const database = new FakeDatabase();
+    const seed: Record<string, unknown> = {};
+    // 3 wins then 2 losses, all older than a big losing streak that should
+    // be excluded once more than 50 matches exist.
+    for (let i = 0; i < 3; i += 1) {
+      seed[`old-win-${i}`] = { fighter_id: 1, opponent_id: 2, time: i, win: true, opponent: 'x' };
+    }
+    for (let i = 0; i < 60; i += 1) {
+      seed[`recent-${i}`] = {
+        fighter_id: 1,
+        opponent_id: 2,
+        time: 1000 + i,
+        win: i % 2 === 0,
+        opponent: 'x',
+      };
+    }
+
+    database.seed(`matches/${UID}`, seed);
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.userContext.recentForm.sampleSize).toBe(50);
+    expect(payload.userContext.recentForm.wins + payload.userContext.recentForm.losses).toBe(50);
+  });
+
+  it('includes the saved opponent note for the scouted player, keyed by canonical name', async () => {
+    const database = new FakeDatabase();
+    database.seed(`opponentNotes/${UID}`, {
+      pandem1c: { habits: 'likes to dash dance', updatedAt: 1_700_000_000_000 },
+    });
+
+    const payload = await assembleReportPayload(
+      UID,
+      SCOUT,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.notes).toEqual({
+      habits: 'likes to dash dance',
+      updatedAt: 1_700_000_000_000,
+    });
+  });
+});
+
+const VALID_REPORT = {
+  overview: 'A fast-falling Fox/Falco player who plays aggressively.',
+  gameplan: ['Punish landing lag hard.'],
+  stageStrategy: {
+    bans: ['Final Destination'],
+    picks: ['Battlefield'],
+    reasoning: 'They perform best on flat stages.',
+  },
+  headToHead: null,
+  watchFor: ['Likes to shine spike off stage.'],
+  confidenceNotes: 'Only 20 games sampled — treat character splits as light samples.',
+};
+
+function stubClient(response: {
+  stop_reason: string | null;
+  parsed_output: unknown;
+}): AnthropicLikeClient {
+  return {
+    messages: {
+      parse: async () => response as Awaited<ReturnType<AnthropicLikeClient['messages']['parse']>>,
+    },
+  };
+}
+
+const PAYLOAD = {
+  scout: SCOUT,
+  headToHead: [],
+  userContext: {
+    vsTopCharacters: [],
+    recentForm: { wins: 0, losses: 0, sampleSize: 0 },
+  },
+  notes: null,
+};
+
+describe('generateScoutReport', () => {
+  it('returns the parsed output on a normal completion', async () => {
+    const client = stubClient({ stop_reason: 'end_turn', parsed_output: VALID_REPORT });
+    const report = await generateScoutReport(client, PAYLOAD);
+    expect(report).toEqual(VALID_REPORT);
+  });
+
+  it('throws ReportGenerationError("refusal") when stop_reason is refusal', async () => {
+    const client = stubClient({ stop_reason: 'refusal', parsed_output: null });
+    await expect(generateScoutReport(client, PAYLOAD)).rejects.toMatchObject(
+      new ReportGenerationError('refusal'),
+    );
+  });
+
+  it('throws ReportGenerationError("truncated") when stop_reason is max_tokens', async () => {
+    const client = stubClient({ stop_reason: 'max_tokens', parsed_output: null });
+    await expect(generateScoutReport(client, PAYLOAD)).rejects.toMatchObject(
+      new ReportGenerationError('truncated'),
+    );
+  });
+
+  it('throws ReportGenerationError("unparseable") when parsed_output is null on a normal stop', async () => {
+    const client = stubClient({ stop_reason: 'end_turn', parsed_output: null });
+    await expect(generateScoutReport(client, PAYLOAD)).rejects.toMatchObject(
+      new ReportGenerationError('unparseable'),
+    );
+  });
+});

--- a/apps/api/src/reports/generate.ts
+++ b/apps/api/src/reports/generate.ts
@@ -1,0 +1,272 @@
+import type { Database } from 'firebase-admin/database';
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import {
+  generatedScoutReportSchema,
+  matchRecordSchema,
+  opponentNoteMapSchema,
+  SpriteList,
+  type GeneratedScoutReport,
+  type OpponentNote,
+  type ScoutReportData,
+} from '@smash-tracker/shared';
+import { normalizeOpponentTag } from '../startgg/sync.js';
+
+// ---------------------------------------------------------------------------
+// Payload assembly
+// ---------------------------------------------------------------------------
+
+const fighterNameById = new Map(SpriteList.map((fighter) => [fighter.id, fighter.name]));
+
+function fighterName(fighterId: number): string {
+  return fighterNameById.get(fighterId) ?? `Unknown fighter (${fighterId})`;
+}
+
+/** One of the caller's own matches against the scouted player, prepared for the model. */
+export interface HeadToHeadMatch {
+  result: 'win' | 'loss';
+  userCharacter: string;
+  opponentCharacter: string;
+  stage: string;
+  eventName: string | null;
+  roundText: string | null;
+  stocksLeft: number | null;
+  date: string;
+}
+
+/** Raw-count aggregate of the caller's results against one of the scouted player's top characters. */
+export interface MatchupAggregate {
+  opponentCharacter: string;
+  wins: number;
+  losses: number;
+  topStages: Array<{ stage: string; wins: number; losses: number }>;
+}
+
+export interface ReportPayload {
+  scout: ScoutReportData;
+  headToHead: HeadToHeadMatch[];
+  userContext: {
+    /** W/L vs each of the scouted player's top-5 characters, across ALL the user's matches. */
+    vsTopCharacters: MatchupAggregate[];
+    /** W/L over the user's most recent 50 matches (any opponent). */
+    recentForm: { wins: number; losses: number; sampleSize: number };
+  };
+  notes: OpponentNote | null;
+}
+
+const TOP_CHARACTERS_COUNT = 5;
+const TOP_STAGES_PER_MATCHUP = 5;
+const RECENT_FORM_SAMPLE_SIZE = 50;
+
+/**
+ * Assembles the JSON payload handed to Claude: the scout data verbatim, the
+ * caller's own head-to-head history against this specific player, raw-count
+ * aggregates against players of similar characters, and any saved opponent
+ * note. Every aggregate here is a RAW COUNT — no Wilson/statistics — the
+ * model is instructed (see SYSTEM_PROMPT) to caveat small samples itself.
+ */
+export async function assembleReportPayload(
+  uid: string,
+  scout: ScoutReportData,
+  database: Database,
+): Promise<ReportPayload> {
+  const [matchesSnapshot, aliasSnapshot, noteSnapshot] = await Promise.all([
+    database.ref(`matches/${uid}`).get(),
+    database.ref(`opponentAliases/${uid}`).get(),
+    database.ref(`opponentNotes/${uid}`).get(),
+  ]);
+
+  const aliasMap = aliasSnapshot.exists()
+    ? (aliasSnapshot.val() as Record<string, string>)
+    : ({} as Record<string, string>);
+
+  const rawMatches = matchesSnapshot.exists()
+    ? (Object.values(matchesSnapshot.val() as Record<string, unknown>).map((value) =>
+        matchRecordSchema.parse(value),
+      ) as Array<ReturnType<typeof matchRecordSchema.parse> & { time: number }>)
+    : [];
+
+  // Single-hop alias lookup: opponentAliases/{uid} is already transitively
+  // flattened by the write path (RtdbService.setOpponentAlias), so one
+  // lookup suffices — no need to walk chains here.
+  function canonicalOpponentName(name: string | undefined): string {
+    const tag = normalizeOpponentTag(name);
+    return aliasMap[tag] ?? tag;
+  }
+
+  const scoutedCanonicalName = normalizeOpponentTag(scout.player.gamerTag);
+
+  const matchesVsScoutedPlayer = rawMatches.filter((match) => {
+    if (
+      match.opponentUserSlug &&
+      scout.player.userSlug &&
+      match.opponentUserSlug === scout.player.userSlug
+    ) {
+      return true;
+    }
+    return canonicalOpponentName(match.opponent) === scoutedCanonicalName;
+  });
+
+  const headToHead: HeadToHeadMatch[] = matchesVsScoutedPlayer
+    .sort((a, b) => b.time - a.time)
+    .map((match) => ({
+      result: match.win ? 'win' : 'loss',
+      userCharacter: fighterName(match.fighter_id),
+      opponentCharacter: fighterName(match.opponent_id),
+      stage: match.map ? match.map.name : 'Unknown stage',
+      eventName: match.eventName ?? null,
+      roundText: match.roundText ?? null,
+      stocksLeft: match.stocksLeft ?? null,
+      date: new Date(match.time).toISOString(),
+    }));
+
+  // vsTopCharacters: for each of the scouted player's top-5 characters (by
+  // games played), the user's W/L across ALL their own matches where THEIR
+  // opponent's in-game character (opponent_id) matches that fighter, plus a
+  // per-stage breakdown within those matchups (top stages by games played).
+  const topCharacterIds = scout.characters.slice(0, TOP_CHARACTERS_COUNT).map((c) => c.fighterId);
+
+  const vsTopCharacters: MatchupAggregate[] = topCharacterIds.map((fighterId) => {
+    const matchesVsCharacter = rawMatches.filter((match) => match.opponent_id === fighterId);
+    const wins = matchesVsCharacter.filter((match) => match.win).length;
+    const losses = matchesVsCharacter.length - wins;
+
+    const stageTally = new Map<string, { wins: number; losses: number; games: number }>();
+    for (const match of matchesVsCharacter) {
+      const name = match.map ? match.map.name : 'Unknown stage';
+      const existing = stageTally.get(name) ?? { wins: 0, losses: 0, games: 0 };
+      existing.games += 1;
+      if (match.win) {
+        existing.wins += 1;
+      } else {
+        existing.losses += 1;
+      }
+      stageTally.set(name, existing);
+    }
+
+    const topStages = [...stageTally.entries()]
+      .sort((a, b) => b[1].games - a[1].games)
+      .slice(0, TOP_STAGES_PER_MATCHUP)
+      .map(([stage, tally]) => ({ stage, wins: tally.wins, losses: tally.losses }));
+
+    return {
+      opponentCharacter: fighterName(fighterId),
+      wins,
+      losses,
+      topStages,
+    };
+  });
+
+  const recentMatches = [...rawMatches]
+    .sort((a, b) => b.time - a.time)
+    .slice(0, RECENT_FORM_SAMPLE_SIZE);
+  const recentWins = recentMatches.filter((match) => match.win).length;
+
+  const notesMap = noteSnapshot.exists()
+    ? opponentNoteMapSchema.parse(noteSnapshot.val())
+    : ({} as Record<string, OpponentNote>);
+  const notes = notesMap[scoutedCanonicalName] ?? null;
+
+  return {
+    scout,
+    headToHead,
+    userContext: {
+      vsTopCharacters,
+      recentForm: {
+        wins: recentWins,
+        losses: recentMatches.length - recentWins,
+        sampleSize: recentMatches.length,
+      },
+    },
+    notes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Claude call
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for the Anthropic client — just the one
+ * method this module calls. Lets tests pass a plain stub with a mocked
+ * `messages.parse` instead of constructing a real `Anthropic` instance.
+ */
+export interface AnthropicLikeClient {
+  messages: {
+    parse: (params: {
+      model: string;
+      max_tokens: number;
+      thinking: { type: 'adaptive' };
+      system: string;
+      messages: Array<{ role: 'user'; content: string }>;
+      output_config: {
+        format: ReturnType<typeof zodOutputFormat<typeof generatedScoutReportSchema>>;
+      };
+    }) => Promise<{
+      stop_reason: string | null;
+      parsed_output: GeneratedScoutReport | null;
+    }>;
+  };
+}
+
+const REPORT_MODEL = 'claude-opus-4-8';
+const REPORT_MAX_TOKENS = 16000;
+
+const SYSTEM_PROMPT = `You are a competitive Super Smash Bros. Ultimate coach writing a pre-bracket scouting brief for "you" (the user) about an opponent you are about to play.
+
+Hard rules — follow these exactly:
+- Ground every claim in the provided JSON payload ONLY. Never invent results, characters, stages, or events that are not present in the data.
+- If a conclusion is drawn from fewer than 5 games of evidence (a character matchup, a stage record, a head-to-head record, etc.), you MUST flag that sample-size caveat explicitly in confidenceNotes.
+- Stage names and character names in your output must come VERBATIM from the data provided — do not paraphrase, translate, or invent alternate spellings.
+- Be concise and actionable. No filler, no generic advice that isn't grounded in this specific opponent's data.
+- The payload contains: "scout" (the opponent's public start.gg history — their characters, stages, recent events, common opponents), "headToHead" (the user's own past matches against this exact player, if any), "userContext" (the user's raw W/L record against players of the opponent's most-used characters, broken down by stage, plus the user's recent overall form), and "notes" (a saved tendency note about this opponent, if the user has one).
+- When headToHead is empty, set the headToHead field in your response to null — do not fabricate a head-to-head summary.
+- Output must conform to the provided JSON schema exactly.`;
+
+/** Thrown for a Claude response that didn't produce a usable report. */
+export class ReportGenerationError extends Error {
+  constructor(readonly reason: 'refusal' | 'truncated' | 'unparseable') {
+    super(
+      reason === 'refusal'
+        ? 'Claude declined to generate a report for this request'
+        : reason === 'truncated'
+          ? 'Claude report generation was truncated before completing'
+          : 'Claude returned a response that could not be parsed into a report',
+    );
+    this.name = 'ReportGenerationError';
+  }
+}
+
+/**
+ * Calls Claude to generate a `GeneratedScoutReport` from the assembled
+ * payload. Uses `client.messages.parse` with `output_config.format` built
+ * from `zodOutputFormat` (validated against the installed
+ * `@anthropic-ai/sdk` version to accept zod v4 schemas directly).
+ */
+export async function generateScoutReport(
+  client: AnthropicLikeClient,
+  payload: ReportPayload,
+): Promise<GeneratedScoutReport> {
+  const response = await client.messages.parse({
+    model: REPORT_MODEL,
+    max_tokens: REPORT_MAX_TOKENS,
+    thinking: { type: 'adaptive' },
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: JSON.stringify(payload) }],
+    output_config: { format: zodOutputFormat(generatedScoutReportSchema) },
+  });
+
+  if (response.stop_reason === 'refusal') {
+    throw new ReportGenerationError('refusal');
+  }
+  if (response.stop_reason === 'max_tokens') {
+    throw new ReportGenerationError('truncated');
+  }
+  if (response.parsed_output == null) {
+    throw new ReportGenerationError('unparseable');
+  }
+
+  return response.parsed_output;
+}
+
+export { Anthropic };

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, it } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
+import type { StartggConfig, ReportsConfig } from '../config/env.js';
+import type { AnthropicLikeClient } from '../reports/generate.js';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+const STARTGG_CONFIG: StartggConfig = {
+  clientId: 'client-123',
+  clientSecret: 'secret-456',
+  redirectUri: 'http://localhost:3001/api/integrations/startgg/callback',
+  apiToken: 'server-data-token',
+  stateSecret: 'state-secret',
+  webBaseUrl: 'http://localhost:5173',
+};
+
+const REPORTS_CONFIG: ReportsConfig = {
+  anthropicApiKey: 'sk-test-key',
+  allowedUids: new Set([TEST_UID]),
+};
+
+function gqlResponse(data: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify({ data }), init);
+}
+
+const RESOLVE_RESPONSE = {
+  user: { id: 1111624, slug: 'user/07dc2239', player: { id: 1802316, gamerTag: 'Pandem1c' } },
+};
+
+const EMPTY_SETS_RESPONSE = {
+  player: { sets: { pageInfo: { totalPages: 1 }, nodes: [] } },
+};
+
+function scoutFetchMock(): typeof fetch {
+  return (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as { query: string };
+    if (body.query.includes('ResolveBySlug') || body.query.includes('ResolveById')) {
+      return gqlResponse(RESOLVE_RESPONSE);
+    }
+    return gqlResponse(EMPTY_SETS_RESPONSE);
+  }) as typeof fetch;
+}
+
+const VALID_REPORT = {
+  overview: 'A fast-falling Fox/Falco player.',
+  gameplan: ['Punish landing lag.'],
+  stageStrategy: {
+    bans: ['Final Destination'],
+    picks: ['Battlefield'],
+    reasoning: 'Flat stages favor us.',
+  },
+  headToHead: null,
+  watchFor: ['Shine spikes off stage.'],
+  confidenceNotes: 'No sampled sets — treat this as a cold read.',
+};
+
+function stubClient(
+  impl: (params: unknown) => Promise<{ stop_reason: string | null; parsed_output: unknown }>,
+): AnthropicLikeClient {
+  return {
+    messages: {
+      parse: impl as AnthropicLikeClient['messages']['parse'],
+    },
+  };
+}
+
+describe('/api/reports (unconfigured)', () => {
+  it('answers 503 on GET /reports/config when reports config is missing', async () => {
+    const { app } = buildTestApp({ startgg: STARTGG_CONFIG, startggFetch: scoutFetchMock() });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/config',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 on POST /reports when start.gg config is missing (reports config alone is not enough)', async () => {
+    const { app } = buildTestApp({
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 on GET /reports when both configs are missing', async () => {
+    const { app } = buildTestApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(503);
+  });
+});
+
+describe('GET /api/reports/config (configured)', () => {
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({ method: 'GET', url: '/api/reports/config' });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns enabled: true for an allowlisted uid', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/config',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ enabled: true });
+  });
+
+  it('returns enabled: false for a non-allowlisted uid (never 403s)', async () => {
+    const emptyAllowlistConfig: ReportsConfig = {
+      anthropicApiKey: 'sk-test-key',
+      allowedUids: new Set(['someone-else']),
+    };
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: emptyAllowlistConfig,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/config',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ enabled: false });
+  });
+});
+
+describe('POST /api/reports (configured, allowlisted)', () => {
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 403 when the signed-in uid is not allowlisted', async () => {
+    const emptyAllowlistConfig: ReportsConfig = {
+      anthropicApiKey: 'sk-test-key',
+      allowedUids: new Set(['someone-else']),
+    };
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: emptyAllowlistConfig,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('returns 400 for malformed scout input', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'not a valid start.gg reference' },
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 404 when the player cannot be resolved', async () => {
+    const fetchMock = (async () => gqlResponse({ user: null })) as typeof fetch;
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: fetchMock,
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/doesnotexist' },
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('passes through a 429 from start.gg', async () => {
+    const fetchMock = (async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes('ResolveBySlug')) {
+        return gqlResponse(RESOLVE_RESPONSE);
+      }
+      return new Response('rate limited', { status: 429 });
+    }) as typeof fetch;
+
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: fetchMock,
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(429);
+  });
+
+  it('happy path: generates a report, writes it to RTDB, and returns the stored record', async () => {
+    let capturedParams: unknown;
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async (params) => {
+        capturedParams = params;
+        return { stop_reason: 'end_turn', parsed_output: VALID_REPORT };
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      model: 'claude-opus-4-8',
+      player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+      report: VALID_REPORT,
+    });
+    expect(typeof body.id).toBe('string');
+    expect(typeof body.createdAt).toBe('number');
+
+    // Assert the Claude call shape: adaptive thinking, no temperature/top_p,
+    // output_config.format present.
+    expect(capturedParams).toMatchObject({
+      model: 'claude-opus-4-8',
+      thinking: { type: 'adaptive' },
+    });
+    expect(capturedParams).not.toHaveProperty('temperature');
+    expect(capturedParams).not.toHaveProperty('top_p');
+
+    // Assert the RTDB write.
+    const dump = database.dump() as Record<string, unknown>;
+    const scoutReports = dump.scoutReports as Record<string, Record<string, unknown>>;
+    const stored = Object.values(scoutReports[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({
+      model: 'claude-opus-4-8',
+      player: { id: 1802316, gamerTag: 'Pandem1c' },
+      report: VALID_REPORT,
+    });
+  });
+
+  it('maps a refusal to 502 with a human-readable message', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({ stop_reason: 'refusal', parsed_output: null })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(502);
+    expect(response.json()).toMatchObject({ statusCode: 502 });
+    expect(response.json().message).toMatch(/declined/i);
+  });
+
+  it('maps a truncated (max_tokens) response to 502', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({ stop_reason: 'max_tokens', parsed_output: null })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(502);
+    expect(response.json().message).toMatch(/truncated/i);
+  });
+
+  it('maps Anthropic.RateLimitError to 429', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => {
+        throw new Anthropic.RateLimitError(
+          429,
+          { type: 'error', error: { type: 'rate_limit_error', message: 'slow down' } },
+          'slow down',
+          new Headers(),
+        );
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(429);
+  });
+
+  it('maps other Anthropic API errors to 502', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => {
+        throw new Anthropic.InternalServerError(
+          500,
+          { type: 'error', error: { type: 'api_error', message: 'boom' } },
+          'boom',
+          new Headers(),
+        );
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(502);
+  });
+});
+
+describe('GET /api/reports (configured, allowlisted)', () => {
+  it('returns 403 when not allowlisted', async () => {
+    const emptyAllowlistConfig: ReportsConfig = {
+      anthropicApiKey: 'sk-test-key',
+      allowedUids: new Set(['someone-else']),
+    };
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: emptyAllowlistConfig,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('returns an empty array when there are no reports', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([]);
+  });
+
+  it('lists stored reports newest-first', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+
+    database.seed(`scoutReports/${TEST_UID}`, {
+      older: {
+        createdAt: 1000,
+        model: 'claude-opus-4-8',
+        player: { id: 1, gamerTag: 'Old' },
+        report: VALID_REPORT,
+      },
+      newer: {
+        createdAt: 2000,
+        model: 'claude-opus-4-8',
+        player: { id: 2, gamerTag: 'New' },
+        report: VALID_REPORT,
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveLength(2);
+    expect(body[0]).toMatchObject({ id: 'newer', createdAt: 2000 });
+    expect(body[1]).toMatchObject({ id: 'older', createdAt: 1000 });
+  });
+});
+
+describe('GET /api/reports/:id (configured, allowlisted)', () => {
+  it('returns 403 when not allowlisted', async () => {
+    const emptyAllowlistConfig: ReportsConfig = {
+      anthropicApiKey: 'sk-test-key',
+      allowedUids: new Set(['someone-else']),
+    };
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: emptyAllowlistConfig,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/some-id',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('returns 404 for a report that does not exist', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/does-not-exist',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns the stored record for a known id', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+
+    database.seed(`scoutReports/${TEST_UID}/report1`, {
+      createdAt: 1234,
+      model: 'claude-opus-4-8',
+      player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+      report: VALID_REPORT,
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/report1',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: 'report1',
+      createdAt: 1234,
+      player: { gamerTag: 'Pandem1c' },
+      report: VALID_REPORT,
+    });
+  });
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,273 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  errorResponseSchema,
+  generateReportRequestSchema,
+  reportsConfigSchema,
+  scoutReportRecordSchema,
+} from '@smash-tracker/shared';
+import type { ReportsConfig, StartggConfig } from '../config/env.js';
+import { StartggApiError } from '../startgg/client.js';
+import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
+import {
+  assembleReportPayload,
+  Anthropic,
+  generateScoutReport,
+  ReportGenerationError,
+  type AnthropicLikeClient,
+} from '../reports/generate.js';
+
+export interface ReportsRoutesOptions {
+  config: ReportsConfig | null;
+  startggConfig: StartggConfig | null;
+  /** Overridable Anthropic client (tests) — a real client is built when omitted. */
+  client?: AnthropicLikeClient;
+  /** Overridable fetch for the start.gg GraphQL calls (tests). */
+  fetchImpl?: typeof fetch;
+}
+
+const reportIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+/**
+ * /api/reports — AI-generated pre-bracket scouting reports (V7-B), layered on
+ * top of the V7-A scout data layer. Requires BOTH `config` (Claude API key +
+ * a non-empty uid allowlist) and `startggConfig` (the scout layer's own
+ * config) to be present; either missing means every route here answers 503,
+ * same shape scout.ts uses for its own dependency.
+ *
+ * Access is allowlist-gated on top of ordinary sign-in (`REPORTS_ALLOWED_UIDS`)
+ * because report generation spends real Claude API tokens per request — this
+ * is a paid feature, not a general one. `/reports/config` never 403s (it's
+ * how the web app decides whether to show the "Generate AI report" button at
+ * all); every other route 403s for a signed-in-but-not-allowlisted uid.
+ */
+const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, options) => {
+  const { config, startggConfig } = options;
+
+  if (!config || !startggConfig) {
+    app.all('/reports*', async (_request, reply) => {
+      return reply.code(503).send({
+        error: 'Service Unavailable',
+        message: 'AI reports are not enabled on this server',
+        statusCode: 503,
+      });
+    });
+    return;
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const scoutCache = new ScoutCache();
+  const client: AnthropicLikeClient =
+    options.client ?? new Anthropic({ apiKey: config.anthropicApiKey });
+
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/reports/config — never 403s; tells the web app whether to show
+  // the "Generate AI report" button for the signed-in user.
+  app.get(
+    '/reports/config',
+    {
+      schema: {
+        response: {
+          200: reportsConfigSchema,
+        },
+      },
+    },
+    async (request) => {
+      return { enabled: config.allowedUids.has(request.uid) };
+    },
+  );
+
+  // POST /api/reports
+  app.post(
+    '/reports',
+    {
+      schema: {
+        body: generateReportRequestSchema,
+        response: {
+          200: scoutReportRecordSchema,
+          400: errorResponseSchema,
+          403: errorResponseSchema,
+          404: errorResponseSchema,
+          429: errorResponseSchema,
+          502: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!config.allowedUids.has(request.uid)) {
+        return reply.code(403).send({
+          error: 'Forbidden',
+          message: 'AI reports are not enabled for this account',
+          statusCode: 403,
+        });
+      }
+
+      let input;
+      try {
+        input = parseScoutInput(request.body.query);
+      } catch (err) {
+        if (err instanceof ScoutInputError) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            message: err.message,
+            statusCode: 400,
+          });
+        }
+        throw err;
+      }
+
+      let scout;
+      try {
+        scout = await scoutPlayer(startggConfig.apiToken, input, fetchImpl, scoutCache);
+      } catch (err) {
+        if (err instanceof StartggApiError && err.status === 429) {
+          return reply.code(429).send({
+            error: 'Too Many Requests',
+            message: 'start.gg is rate-limiting requests right now — try again shortly',
+            statusCode: 429,
+          });
+        }
+        request.log.error({ err }, 'start.gg scout lookup failed during report generation');
+        throw err;
+      }
+
+      if (!scout) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: 'No start.gg player found for that query',
+          statusCode: 404,
+        });
+      }
+
+      const payload = await assembleReportPayload(request.uid, scout, app.firebase.database);
+
+      let report;
+      try {
+        report = await generateScoutReport(client, payload);
+      } catch (err) {
+        if (err instanceof ReportGenerationError) {
+          const message =
+            err.reason === 'refusal'
+              ? 'The model declined to generate a report for this request'
+              : err.reason === 'truncated'
+                ? 'Report generation was truncated — try again'
+                : 'The model returned a response that could not be parsed — try again';
+          return reply.code(502).send({
+            error: 'Bad Gateway',
+            message,
+            statusCode: 502,
+          });
+        }
+        if (err instanceof Anthropic.RateLimitError) {
+          return reply.code(429).send({
+            error: 'Too Many Requests',
+            message: 'Claude is rate-limiting requests right now — try again shortly',
+            statusCode: 429,
+          });
+        }
+        if (err instanceof Anthropic.APIError) {
+          request.log.error({ err }, 'Claude report generation failed');
+          return reply.code(502).send({
+            error: 'Bad Gateway',
+            message: 'The model provider returned an error — try again shortly',
+            statusCode: 502,
+          });
+        }
+        throw err;
+      }
+
+      const ref = app.firebase.database.ref(`scoutReports/${request.uid}`).push();
+      const record = {
+        createdAt: Date.now(),
+        model: 'claude-opus-4-8',
+        player: scout.player,
+        report,
+      };
+      await ref.set(record);
+
+      const id = ref.key;
+      if (!id) {
+        throw new Error('Failed to generate a push key for the new scout report');
+      }
+
+      return { id, ...record };
+    },
+  );
+
+  // GET /api/reports — newest-first.
+  app.get(
+    '/reports',
+    {
+      schema: {
+        response: {
+          200: z.array(scoutReportRecordSchema),
+          403: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!config.allowedUids.has(request.uid)) {
+        return reply.code(403).send({
+          error: 'Forbidden',
+          message: 'AI reports are not enabled for this account',
+          statusCode: 403,
+        });
+      }
+
+      const snapshot = await app.firebase.database.ref(`scoutReports/${request.uid}`).get();
+      if (!snapshot.exists()) {
+        return [];
+      }
+
+      const raw = snapshot.val() as Record<string, unknown>;
+      return Object.entries(raw)
+        .map(([id, value]) => scoutReportRecordSchema.parse({ id, ...(value as object) }))
+        .sort((a, b) => b.createdAt - a.createdAt);
+    },
+  );
+
+  // GET /api/reports/:id
+  app.get(
+    '/reports/:id',
+    {
+      schema: {
+        params: reportIdParamsSchema,
+        response: {
+          200: scoutReportRecordSchema,
+          403: errorResponseSchema,
+          404: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!config.allowedUids.has(request.uid)) {
+        return reply.code(403).send({
+          error: 'Forbidden',
+          message: 'AI reports are not enabled for this account',
+          statusCode: 403,
+        });
+      }
+
+      const snapshot = await app.firebase.database
+        .ref(`scoutReports/${request.uid}/${request.params.id}`)
+        .get();
+      if (!snapshot.exists()) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: `Report ${request.params.id} not found`,
+          statusCode: 404,
+        });
+      }
+
+      return scoutReportRecordSchema.parse({
+        id: request.params.id,
+        ...(snapshot.val() as object),
+      });
+    },
+  );
+};
+
+export default reportsRoutes;

--- a/apps/api/src/test-support/testApp.ts
+++ b/apps/api/src/test-support/testApp.ts
@@ -9,7 +9,10 @@ export const TEST_EMAIL = 'test@example.com';
 export const TEST_TOKEN = 'valid-test-token';
 
 export function buildTestApp(
-  options: Pick<Parameters<typeof buildApp>[0], 'startgg' | 'startggFetch'> = {},
+  options: Pick<
+    Parameters<typeof buildApp>[0],
+    'startgg' | 'startggFetch' | 'reports' | 'reportsClient'
+  > = {},
 ) {
   const database = new FakeDatabase();
   const auth = new FakeAuth();

--- a/apps/web/src/hooks/useScoutReports.test.tsx
+++ b/apps/web/src/hooks/useScoutReports.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useGenerateReport, useReportsConfig, useScoutReportsList } from './useScoutReports';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+import { AuthProvider } from '@/context/AuthContext';
+
+const reportsConfig = vi.fn();
+const reportsGenerate = vi.fn();
+const reportsList = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    reports: {
+      config: (...args: unknown[]) => reportsConfig(...args),
+      generate: (...args: unknown[]) => reportsGenerate(...args),
+      list: (...args: unknown[]) => reportsList(...args),
+    },
+  },
+}));
+
+const RECORD = {
+  id: 'r1',
+  createdAt: 1_700_000_000_000,
+  model: 'claude-opus-4-8',
+  player: { id: 1802316, gamerTag: 'Pandem1c' },
+  report: {
+    overview: 'overview',
+    gameplan: ['plan'],
+    stageStrategy: { bans: [], picks: [], reasoning: 'reasoning' },
+    headToHead: null,
+    watchFor: [],
+    confidenceNotes: 'notes',
+  },
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = [new QueryClient({ defaultOptions: { queries: { retry: false } } })];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function ConfigProbe() {
+  const config = useReportsConfig();
+  if (!config.isSuccess) {
+    return <div>loading</div>;
+  }
+  return <div>enabled: {String(config.data.enabled)}</div>;
+}
+
+function GenerateProbe() {
+  const generate = useGenerateReport();
+  return (
+    <div>
+      <button onClick={() => generate.mutate('user/07dc2239')}>generate</button>
+      {generate.isPending && <div>pending</div>}
+      {generate.isSuccess && <div>gamerTag: {generate.data.player.gamerTag}</div>}
+    </div>
+  );
+}
+
+function ListProbe() {
+  const list = useScoutReportsList();
+  if (!list.isSuccess) {
+    return <div>loading</div>;
+  }
+  return <div>reports: {list.data.length}</div>;
+}
+
+describe('useScoutReports', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('useReportsConfig resolves the config response', async () => {
+    reportsConfig.mockResolvedValue({ enabled: true });
+
+    render(
+      <Wrapper>
+        <ConfigProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('enabled: true')).toBeInTheDocument());
+  });
+
+  it('useGenerateReport posts the query and resolves the stored record', async () => {
+    reportsGenerate.mockResolvedValue(RECORD);
+
+    render(
+      <Wrapper>
+        <GenerateProbe />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText('generate'));
+
+    await waitFor(() => expect(screen.getByText('gamerTag: Pandem1c')).toBeInTheDocument());
+    expect(reportsGenerate).toHaveBeenCalledWith('user/07dc2239');
+  });
+
+  it('useScoutReportsList resolves the list response', async () => {
+    reportsList.mockResolvedValue([RECORD]);
+
+    render(
+      <Wrapper>
+        <ListProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('reports: 1')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/hooks/useScoutReports.ts
+++ b/apps/web/src/hooks/useScoutReports.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const reportsConfigQueryKey = ['reportsConfig'] as const;
+export const scoutReportsListQueryKey = ['scoutReports'] as const;
+
+/**
+ * GET /api/reports/config — whether AI scouting reports are enabled for the
+ * signed-in user. Never 403s server-side; the response's `enabled` flag is
+ * how the Scout page decides whether to show the "Generate AI report" button
+ * at all. Long `staleTime` since this rarely changes mid-session.
+ */
+export function useReportsConfig() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: reportsConfigQueryKey,
+    queryFn: () => api.reports.config(),
+    enabled: Boolean(user),
+    staleTime: 60 * 60 * 1000,
+  });
+}
+
+/** POST /api/reports — generate (and store) an AI report. Invalidates the past-reports list. */
+export function useGenerateReport() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (query: string) => api.reports.generate(query),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: scoutReportsListQueryKey });
+    },
+  });
+}
+
+/** GET /api/reports — the signed-in user's past AI reports, newest first. */
+export function useScoutReportsList() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: scoutReportsListQueryKey,
+    queryFn: () => api.reports.list(),
+    enabled: Boolean(user),
+  });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,12 +2,15 @@ import type { z } from 'zod';
 import {
   errorResponseSchema,
   fighterSelectionSchema,
+  generateReportRequestSchema,
   matchSchema,
   opponentAliasMapSchema,
   opponentListSchema,
   opponentNoteMapSchema,
   opponentNoteSchema,
+  reportsConfigSchema,
   scoutReportDataSchema,
+  scoutReportRecordSchema,
   startggAuthorizeResponseSchema,
   startggStatusSchema,
   startggSyncSummarySchema,
@@ -232,6 +235,21 @@ export const api = {
     /** POST /api/scout — scout ANY start.gg player by URL, slug, or numeric id. */
     lookup: (input: ScoutQuery) =>
       apiRequestParsed('/api/scout', scoutReportDataSchema, { method: 'POST', body: input }),
+  },
+  reports: {
+    /** GET /api/reports/config — whether the signed-in user can generate AI reports. */
+    config: () => apiRequestParsed('/api/reports/config', reportsConfigSchema),
+    /** POST /api/reports — generate (and store) an AI scouting report. */
+    generate: (query: string) =>
+      apiRequestParsed('/api/reports', scoutReportRecordSchema, {
+        method: 'POST',
+        body: generateReportRequestSchema.parse({ query }),
+      }),
+    /** GET /api/reports — the signed-in user's past AI reports, newest first. */
+    list: () => apiRequestParsed('/api/reports', scoutReportRecordSchema.array()),
+    /** GET /api/reports/:id — a single stored AI report. */
+    get: (id: string) =>
+      apiRequestParsed(`/api/reports/${encodeURIComponent(id)}`, scoutReportRecordSchema),
   },
 };
 

--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -29,6 +29,9 @@ vi.mock('@/lib/firebase', async () => {
 const scoutLookup = vi.fn();
 const matchesList = vi.fn().mockResolvedValue([]);
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+const reportsConfig = vi.fn().mockResolvedValue({ enabled: false });
+const reportsGenerate = vi.fn();
+const reportsList = vi.fn().mockResolvedValue([]);
 
 vi.mock('@/lib/api', () => {
   class MockApiError extends Error {
@@ -44,6 +47,11 @@ vi.mock('@/lib/api', () => {
       scout: { lookup: (...args: unknown[]) => scoutLookup(...args) },
       matches: { list: (...args: unknown[]) => matchesList(...args) },
       users: { upsertMe: (...args: unknown[]) => upsertMe(...args) },
+      reports: {
+        config: (...args: unknown[]) => reportsConfig(...args),
+        generate: (...args: unknown[]) => reportsGenerate(...args),
+        list: (...args: unknown[]) => reportsList(...args),
+      },
     },
     ApiError: MockApiError,
   };
@@ -87,6 +95,8 @@ describe('ScoutPage', () => {
     resetAuthMock();
     vi.clearAllMocks();
     matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: false });
+    reportsList.mockResolvedValue([]);
     setMockUser(makeMockUser());
   });
 
@@ -187,5 +197,175 @@ describe('ScoutPage', () => {
 
     await screen.findByText('Pandem1c');
     expect(screen.queryByText('Your History vs Them')).not.toBeInTheDocument();
+  });
+});
+
+const GENERATED_RECORD = {
+  id: 'report-1',
+  createdAt: 1_700_000_000_000,
+  model: 'claude-opus-4-8',
+  player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+  report: {
+    overview: 'A fast-falling Fox/Falco player.',
+    gameplan: ['Punish landing lag.'],
+    stageStrategy: {
+      bans: ['Final Destination'],
+      picks: ['Battlefield'],
+      reasoning: 'Flat stages favor us.',
+    },
+    headToHead: null,
+    watchFor: ['Shine spikes off stage.'],
+    confidenceNotes: 'Only 6 games sampled.',
+  },
+};
+
+describe('ScoutPage — AI reports feature disabled', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: false });
+    reportsList.mockResolvedValue([]);
+    setMockUser(makeMockUser());
+  });
+
+  it('never shows the "Generate AI report" button when disabled', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    await screen.findByText('Pandem1c');
+    expect(screen.queryByRole('button', { name: /Generate AI report/ })).not.toBeInTheDocument();
+  });
+
+  it('never shows the past reports card when disabled, even if reports exist', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsList.mockResolvedValue([GENERATED_RECORD]);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    await screen.findByText('Pandem1c');
+    expect(screen.queryByText('Past AI Reports')).not.toBeInTheDocument();
+  });
+});
+
+describe('ScoutPage — AI reports feature enabled', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([]);
+    setMockUser(makeMockUser());
+  });
+
+  it('shows the "Generate AI report" button once a scout result is on screen', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    expect(await screen.findByRole('button', { name: /Generate AI report/ })).toBeInTheDocument();
+  });
+
+  it('generates and renders the AI report on click', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsGenerate.mockResolvedValue(GENERATED_RECORD);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: /Generate AI report/ }));
+
+    await waitFor(() => expect(reportsGenerate).toHaveBeenCalledWith('user/07dc2239'));
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+    expect(screen.getByText(GENERATED_RECORD.report.overview)).toBeInTheDocument();
+  });
+
+  it('shows a pending state with spinner text while generating', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    let resolveGenerate: (value: typeof GENERATED_RECORD) => void = () => {};
+    reportsGenerate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGenerate = resolve;
+        }),
+    );
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: /Generate AI report/ }));
+
+    expect(
+      await screen.findByText(/Generating report — this usually takes a minute or two\./),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Generating report/ })).toBeDisabled();
+
+    resolveGenerate(GENERATED_RECORD);
+    await waitFor(() => expect(screen.getByText('AI Scouting Report')).toBeInTheDocument());
+  });
+
+  it('shows an inline destructive alert with the API message on error', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsGenerate.mockRejectedValue(
+      new ApiError(502, 'The model declined to generate a report for this request'),
+    );
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: /Generate AI report/ }));
+
+    expect(
+      await screen.findByText('The model declined to generate a report for this request'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the past reports card when the list is non-empty, and selecting one renders it', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsList.mockResolvedValue([GENERATED_RECORD]);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByRole('heading', { name: 'Pandem1c' });
+
+    expect(await screen.findByText('Past AI Reports')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Pandem1c/ }));
+
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+    expect(screen.getByText(GENERATED_RECORD.report.overview)).toBeInTheDocument();
+  });
+
+  it('does not show the past reports card when the list is empty', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsList.mockResolvedValue([]);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    expect(screen.queryByText('Past AI Reports')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from 'react';
-import type { ScoutReportData } from '@smash-tracker/shared';
+import { useMemo, useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import type { ScoutReportData, ScoutReportRecord } from '@smash-tracker/shared';
 import { ApiError } from '@/lib/api';
 import { useScoutPlayer } from '@/hooks/useScoutPlayer';
 import { useMatches } from '@/hooks/useMatches';
+import { useGenerateReport, useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
 import { getOpponentProfile } from '@/lib/stats';
+import { Button } from '@/components/ui/button';
 import { ScoutSearchForm } from './components/ScoutSearchForm';
 import { ScoutReportHeader } from './components/ScoutReportHeader';
 import { ScoutCharactersCard } from './components/ScoutCharactersCard';
@@ -11,8 +14,10 @@ import { ScoutStagesCard } from './components/ScoutStagesCard';
 import { ScoutRecentEventsCard } from './components/ScoutRecentEventsCard';
 import { ScoutCommonOpponentsCard } from './components/ScoutCommonOpponentsCard';
 import { YourHistoryStrip } from './components/YourHistoryStrip';
+import { ScoutAiReportCard } from './components/ScoutAiReportCard';
+import { ScoutPastReportsCard } from './components/ScoutPastReportsCard';
 
-function describeError(error: unknown): string {
+function describeError(error: unknown, fallback: string): string {
   if (error instanceof ApiError) {
     if (error.status === 404) {
       return "We couldn't find a start.gg player for that query. Double-check the URL, slug, or player id.";
@@ -23,9 +28,9 @@ function describeError(error: unknown): string {
     if (error.status === 429) {
       return 'start.gg is rate-limiting requests right now. Try again in a minute.';
     }
-    return error.message || 'Something went wrong while scouting that player.';
+    return error.message || fallback;
   }
-  return 'Something went wrong while scouting that player.';
+  return fallback;
 }
 
 /**
@@ -39,12 +44,24 @@ function describeError(error: unknown): string {
  * match history, a "Your History vs Them" strip surfaces the existing
  * head-to-head record (same data the Scouting page shows) above the public
  * report.
+ *
+ * V7-B: when AI reports are enabled for the signed-in user
+ * (`useReportsConfig`), a "Generate AI report" button appears once a scout
+ * result is on screen. The feature is completely invisible when disabled —
+ * no button, no past-reports card, nothing rendered at all.
  */
 export function ScoutPage() {
   const scout = useScoutPlayer();
   const { data: matches = [] } = useMatches();
+  const reportsConfig = useReportsConfig();
+  const generateReport = useGenerateReport();
+  const pastReports = useScoutReportsList();
+
+  const [lastQuery, setLastQuery] = useState<string | null>(null);
+  const [selectedRecord, setSelectedRecord] = useState<ScoutReportRecord | null>(null);
 
   const report: ScoutReportData | undefined = scout.data;
+  const aiReportsEnabled = reportsConfig.data?.enabled ?? false;
 
   const yourHistory = useMemo(() => {
     if (!report) {
@@ -57,15 +74,34 @@ export function ScoutPage() {
     return getOpponentProfile(matches, needle);
   }, [matches, report]);
 
+  const handleSubmit = (query: string) => {
+    setSelectedRecord(null);
+    setLastQuery(query);
+    scout.mutate(query);
+  };
+
+  const handleGenerateReport = () => {
+    if (!lastQuery) {
+      return;
+    }
+    setSelectedRecord(null);
+    generateReport.mutate(lastQuery);
+  };
+
+  // The report to actually render: a freshly generated report takes priority
+  // over a previously-selected past report (a new generation replaces what's
+  // on screen), which in turn takes priority over nothing.
+  const displayedReport = selectedRecord?.report ?? generateReport.data?.report ?? null;
+
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6">
       <h1 className="text-2xl font-semibold tracking-tight">Scout a Player</h1>
 
-      <ScoutSearchForm onSubmit={(query) => scout.mutate(query)} isPending={scout.isPending} />
+      <ScoutSearchForm onSubmit={handleSubmit} isPending={scout.isPending} />
 
       {scout.isError && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-          {describeError(scout.error)}
+          {describeError(scout.error, 'Something went wrong while scouting that player.')}
         </div>
       )}
 
@@ -73,6 +109,35 @@ export function ScoutPage() {
         <div className="flex flex-col gap-4">
           <ScoutReportHeader report={report} />
           {yourHistory && <YourHistoryStrip profile={yourHistory} />}
+
+          {aiReportsEnabled && (
+            <div className="flex flex-col gap-2">
+              <Button
+                onClick={handleGenerateReport}
+                disabled={generateReport.isPending}
+                className="w-fit"
+              >
+                <Sparkles className={generateReport.isPending ? 'animate-spin' : ''} />
+                {generateReport.isPending ? 'Generating report…' : 'Generate AI report'}
+              </Button>
+              {generateReport.isPending && (
+                <p className="text-sm text-muted-foreground">
+                  Generating report — this usually takes a minute or two.
+                </p>
+              )}
+              {generateReport.isError && (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                  {describeError(
+                    generateReport.error,
+                    'Something went wrong while generating the report.',
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {displayedReport && <ScoutAiReportCard report={displayedReport} />}
+
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <ScoutCharactersCard characters={report.characters} />
             <ScoutStagesCard stages={report.stages} />
@@ -82,6 +147,13 @@ export function ScoutPage() {
             <ScoutCommonOpponentsCard opponents={report.commonOpponents} />
           </div>
         </div>
+      )}
+
+      {aiReportsEnabled && (pastReports.data?.length ?? 0) > 0 && (
+        <ScoutPastReportsCard
+          reports={pastReports.data ?? []}
+          onSelect={(record) => setSelectedRecord(record)}
+        />
       )}
 
       {!report && !scout.isError && !scout.isPending && (

--- a/apps/web/src/pages/Scout/components/ScoutAiReportCard.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutAiReportCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { GeneratedScoutReport } from '@smash-tracker/shared';
+import { ScoutAiReportCard } from './ScoutAiReportCard';
+
+const REPORT: GeneratedScoutReport = {
+  overview: 'A fast-falling Fox/Falco player who plays aggressively.',
+  gameplan: ['Punish landing lag hard.', 'Avoid neutral vs their dash dance.'],
+  stageStrategy: {
+    bans: ['Final Destination'],
+    picks: ['Battlefield'],
+    reasoning: 'They perform best on flat stages with no platforms.',
+  },
+  headToHead: null,
+  watchFor: ['Likes to shine spike off stage.'],
+  confidenceNotes: 'Only 20 games sampled — treat character splits as light samples.',
+};
+
+describe('ScoutAiReportCard', () => {
+  it('renders the overview, gameplan, stage strategy, watch-for, and confidence notes', () => {
+    render(<ScoutAiReportCard report={REPORT} />);
+
+    expect(screen.getByText(REPORT.overview)).toBeInTheDocument();
+    expect(screen.getByText('Punish landing lag hard.')).toBeInTheDocument();
+    expect(screen.getByText('Avoid neutral vs their dash dance.')).toBeInTheDocument();
+    expect(screen.getByText('Final Destination')).toBeInTheDocument();
+    expect(screen.getByText('Battlefield')).toBeInTheDocument();
+    expect(screen.getByText(REPORT.stageStrategy.reasoning)).toBeInTheDocument();
+    expect(screen.getByText('Likes to shine spike off stage.')).toBeInTheDocument();
+    expect(screen.getByText(REPORT.confidenceNotes)).toBeInTheDocument();
+  });
+
+  it('does not render a head-to-head section when headToHead is null', () => {
+    render(<ScoutAiReportCard report={REPORT} />);
+    expect(screen.queryByText('Head-to-head')).not.toBeInTheDocument();
+  });
+
+  it('renders the head-to-head section when present', () => {
+    render(
+      <ScoutAiReportCard
+        report={{ ...REPORT, headToHead: 'You are 2-1 against this player, all on Battlefield.' }}
+      />,
+    );
+    expect(screen.getByText('Head-to-head')).toBeInTheDocument();
+    expect(
+      screen.getByText('You are 2-1 against this player, all on Battlefield.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutAiReportCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutAiReportCard.tsx
@@ -1,0 +1,78 @@
+import { Sparkles } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { GeneratedScoutReport } from '@smash-tracker/shared';
+
+/**
+ * Renders one AI-generated scouting report (V7-B). Used both for a freshly
+ * generated report and for a past report selected from `ScoutPastReportsCard`
+ * — same component either way, since both are just a `GeneratedScoutReport`.
+ */
+export function ScoutAiReportCard({ report }: { report: GeneratedScoutReport }) {
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="size-4 text-primary" />
+          AI Scouting Report
+        </CardTitle>
+        <CardDescription>{report.overview}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-semibold">Game plan</h3>
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {report.gameplan.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-semibold">Stage strategy</h3>
+          <div className="flex flex-col gap-2 text-sm">
+            {report.stageStrategy.bans.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Bans:</span>
+                {report.stageStrategy.bans.map((stage) => (
+                  <Badge key={stage} variant="destructive">
+                    {stage}
+                  </Badge>
+                ))}
+              </div>
+            )}
+            {report.stageStrategy.picks.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Picks:</span>
+                {report.stageStrategy.picks.map((stage) => (
+                  <Badge key={stage} variant="success">
+                    {stage}
+                  </Badge>
+                ))}
+              </div>
+            )}
+            <p className="text-muted-foreground">{report.stageStrategy.reasoning}</p>
+          </div>
+        </div>
+
+        {report.headToHead && (
+          <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-semibold">Head-to-head</h3>
+            <p className="text-sm text-muted-foreground">{report.headToHead}</p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-semibold">Watch for</h3>
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {report.watchFor.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </div>
+
+        <p className="text-xs text-muted-foreground">{report.confidenceNotes}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Scout/components/ScoutPastReportsCard.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutPastReportsCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ScoutReportRecord } from '@smash-tracker/shared';
+import { ScoutPastReportsCard } from './ScoutPastReportsCard';
+
+const RECORDS: ScoutReportRecord[] = [
+  {
+    id: 'r1',
+    createdAt: 1_700_000_000_000,
+    model: 'claude-opus-4-8',
+    player: { id: 1802316, gamerTag: 'Pandem1c' },
+    report: {
+      overview: 'overview',
+      gameplan: [],
+      stageStrategy: { bans: [], picks: [], reasoning: '' },
+      headToHead: null,
+      watchFor: [],
+      confidenceNotes: '',
+    },
+  },
+  {
+    id: 'r2',
+    createdAt: 1_700_100_000_000,
+    model: 'claude-opus-4-8',
+    player: { id: 999, gamerTag: 'PowPow' },
+    report: {
+      overview: 'overview 2',
+      gameplan: [],
+      stageStrategy: { bans: [], picks: [], reasoning: '' },
+      headToHead: null,
+      watchFor: [],
+      confidenceNotes: '',
+    },
+  },
+];
+
+describe('ScoutPastReportsCard', () => {
+  it('renders one entry per report, showing gamer tag and date', () => {
+    render(<ScoutPastReportsCard reports={RECORDS} onSelect={() => {}} />);
+
+    expect(screen.getByText('Pandem1c')).toBeInTheDocument();
+    expect(screen.getByText('PowPow')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the clicked record', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ScoutPastReportsCard reports={RECORDS} onSelect={onSelect} />);
+
+    await user.click(screen.getByText('Pandem1c'));
+
+    expect(onSelect).toHaveBeenCalledWith(RECORDS[0]);
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutPastReportsCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutPastReportsCard.tsx
@@ -1,0 +1,47 @@
+import { History } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { ScoutReportRecord } from '@smash-tracker/shared';
+
+/**
+ * Recent AI-generated reports (V7-B), newest first. Visible only when AI
+ * reports are enabled AND the list is non-empty (both checks happen in
+ * `ScoutPage`) — clicking a past report re-renders it in the same
+ * `ScoutAiReportCard` used for a freshly generated one, without navigating
+ * to a new page.
+ */
+export function ScoutPastReportsCard({
+  reports,
+  onSelect,
+}: {
+  reports: ScoutReportRecord[];
+  onSelect: (report: ScoutReportRecord) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <History className="size-4" />
+          Past AI Reports
+        </CardTitle>
+        <CardDescription>Reports you've generated before, most recent first.</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1">
+        {reports.map((record) => (
+          <Button
+            key={record.id}
+            type="button"
+            variant="ghost"
+            onClick={() => onSelect(record)}
+            className="h-auto justify-between px-2 py-2 font-normal"
+          >
+            <span className="font-medium">{record.player.gamerTag}</span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(record.createdAt).toLocaleDateString()}
+            </span>
+          </Button>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,3 +29,4 @@ export * from './error.js';
 export * from './startgg.js';
 export * from './fighterData.js';
 export * from './stageData.js';
+export * from './reports.js';

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { scoutPlayerIdentitySchema } from './startgg.js';
+
+/**
+ * V7-B: AI-generated pre-bracket scouting reports, powered by the Claude API,
+ * layered on top of the V7-A scout data layer (`ScoutReportData`). Everything
+ * here concerns the STRUCTURED REPORT Claude produces and the stored record
+ * wrapping it — the raw data assembly (`ScoutReportData` + the user's own
+ * match history) lives in apps/api's `reports/generate.ts`.
+ *
+ * Kept to plain strings/arrays/objects deliberately: structured outputs
+ * (`output_config.format`) don't support JSON Schema min/max/length
+ * constraints, so none are added here even where they'd read naturally
+ * (e.g. `overview` being "2-4 sentences").
+ */
+
+/**
+ * The report Claude generates for one scouted opponent. Grounded entirely in
+ * the JSON payload assembled server-side (the scout data, the caller's own
+ * head-to-head history, aggregate tendencies against similar characters, and
+ * any saved opponent note) — see the SYSTEM_PROMPT in reports/generate.ts for
+ * the grounding rules enforced on the model.
+ */
+export const generatedScoutReportSchema = z.object({
+  /** 2-4 sentence read on the opponent: who they are, how they play, what stands out. */
+  overview: z.string(),
+  /** Actionable bullets for how to approach the set. */
+  gameplan: z.array(z.string()),
+  /** Stage strike/pick strategy, grounded in the opponent's sampled stage results. */
+  stageStrategy: z.object({
+    /** Stages to strike/ban against this opponent. */
+    bans: z.array(z.string()),
+    /** Stages to counterpick toward. */
+    picks: z.array(z.string()),
+    /** Why — tied to the opponent's actual sampled stage performance. */
+    reasoning: z.string(),
+  }),
+  /** Summary of the caller's own history against this specific player; null when there is none. */
+  headToHead: z.string().nullable(),
+  /** Habits/threats to watch for, drawn from sampled sets and any saved opponent note. */
+  watchFor: z.array(z.string()),
+  /** Explicit sample-size caveats (e.g. "only 3 games on this character — light sample"). */
+  confidenceNotes: z.string(),
+});
+export type GeneratedScoutReport = z.infer<typeof generatedScoutReportSchema>;
+
+/**
+ * `scoutReports/{uid}/{pushKey}` — a stored AI-generated report. `player` is
+ * the identity `ScoutReportData` resolved for this scout (so past reports
+ * remain readable/attributable even if the user later re-scouts and gets a
+ * fresher `ScoutReportData`).
+ */
+export const scoutReportRecordSchema = z.object({
+  id: z.string().min(1),
+  /** Epoch ms when the report was generated. Server-set. */
+  createdAt: z.number().int().nonnegative(),
+  /** The Claude model id that generated this report, e.g. "claude-opus-4-8". */
+  model: z.string().min(1),
+  player: scoutPlayerIdentitySchema,
+  report: generatedScoutReportSchema,
+});
+export type ScoutReportRecord = z.infer<typeof scoutReportRecordSchema>;
+
+/** POST /api/reports request body — same input semantics as POST /api/scout. */
+export const generateReportRequestSchema = z.object({
+  query: z.string().min(1),
+});
+export type GenerateReportRequest = z.infer<typeof generateReportRequestSchema>;
+
+/** GET /api/reports/config response — whether the signed-in caller can generate AI reports. */
+export const reportsConfigSchema = z.object({
+  enabled: z.boolean(),
+});
+export type ReportsConfig = z.infer<typeof reportsConfigSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.110.0
+        version: 0.110.0(zod@4.4.3)
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -199,6 +202,15 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@anthropic-ai/sdk@0.110.0':
+    resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1718,6 +1730,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2448,6 +2463,9 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
@@ -2787,6 +2805,10 @@ packages:
   json-schema-resolver@3.0.0:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3377,6 +3399,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -3488,6 +3513,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3762,6 +3790,13 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5381,6 +5416,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -6151,6 +6188,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.3: {}
 
   fast-xml-builder@1.2.0:
@@ -6658,6 +6697,11 @@ snapshots:
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -7271,6 +7315,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.1.0: {}
 
   stream-events@1.0.5:
@@ -7395,6 +7444,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds AI-generated pre-bracket scouting reports, layered on top of the V7-A scout data layer (`ScoutReportData` / `scoutPlayer`).

**New routes** (`apps/api/src/routes/reports.ts`, `apps/api/src/reports/generate.ts`):
- `GET /api/reports/config` — never 403s; tells the web app whether AI reports are enabled for the signed-in uid.
- `POST /api/reports` — allowlist-gated (403 otherwise). Resolves the scout query (400/404/429 passthrough, same as `/api/scout`), assembles a JSON payload (`assembleReportPayload`: the scout data verbatim, the user's own head-to-head history against this exact player via userSlug or single-hop-resolved canonical name, raw-count W/L + per-stage aggregates against the opponent's top-5 characters, most-recent-50-match form, and any saved opponent note), calls Claude (`client.messages.parse` with `thinking: {type: "adaptive"}` and `output_config.format` via `zodOutputFormat`), and stores the result under `scoutReports/{uid}/{pushKey}`.
- `GET /api/reports` — newest-first list.
- `GET /api/reports/:id` — single stored record, 404 if missing.
- Both `ANTHROPIC_API_KEY` and `REPORTS_ALLOWED_UIDS` must be set for any of this to work; otherwise every `/api/reports*` route 503s (mirrors the start.gg all-or-nothing config pattern).

**New schemas** (`packages/shared/src/reports.ts`): `generatedScoutReportSchema`, `scoutReportRecordSchema`, `generateReportRequestSchema`, `reportsConfigSchema`.

**Web** (`apps/web/src/pages/Scout/`): a "Generate AI report" button appears only when `useReportsConfig().enabled` is true, with a pending state and inline destructive error alert. `ScoutAiReportCard` renders the structured report; `ScoutPastReportsCard` (visible only when enabled + non-empty) lets the user revisit prior reports without a new page. The feature is completely invisible when disabled.

**Docs**: README deployment section documents `ANTHROPIC_API_KEY` / `REPORTS_ALLOWED_UIDS` and the 503 behavior; `apps/api/.env.example` updated with placeholders (no secrets).

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] `pnpm typecheck` — clean across shared/api/web
- [x] `pnpm test` — 914 tests passing (52 shared + 222 api + 640 web); 34 new API tests (`reports/generate.test.ts` + `routes/reports.test.ts`) cover 503-unconfigured, 403-not-allowlisted, config enabled/disabled, POST happy path (asserts the Claude call shape and the RTDB write), refusal→502, truncated→502, RateLimitError→429, other API errors→502, list + get + 404; new web tests cover the hooks and both new components plus ScoutPage integration (button visibility, generate flow, pending/error states, past-reports selection) — all gated on the feature-disabled-by-default baseline still passing unchanged.
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean

Installed `@anthropic-ai/sdk@^0.110.0`; `zodOutputFormat` accepted the zod v4 schema natively (no fallback to raw JSON Schema needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)