### PR TITLE
V7-E: VOD timestamp notes

### DIFF
--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -213,6 +213,37 @@ describe('POST /api/matches', () => {
     expect(response.statusCode).toBe(400);
   });
 
+  it('accepts and stores vodUrl and vodTimestamps', async () => {
+    const { app, database } = buildTestApp();
+
+    const vodTimestamps = [{ seconds: 161, note: 'missed punish on shield' }];
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps,
+    });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps,
+    });
+  });
+
   it('rejects source/externalId from client input (server-only fields)', async () => {
     const { app } = buildTestApp();
 
@@ -360,6 +391,174 @@ describe('PATCH /api/matches/:id', () => {
       url: '/api/matches/existingKey',
       headers: authHeader(),
       payload: { ...validCreateInput, stocksLeft: 4 },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('sets vodUrl and vodTimestamps', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const vodTimestamps = [
+      { seconds: 161, note: 'missed punish on shield' },
+      { seconds: 490, note: 'lost ledge trump war' },
+    ];
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps,
+    });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    expect(matches[TEST_UID]!.existingKey).toMatchObject({
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps,
+    });
+  });
+
+  it('updates existing vodUrl and vodTimestamps', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=xyz789',
+        vodTimestamps: [{ seconds: 300, note: 'updated note' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      vodUrl: 'https://youtube.com/watch?v=xyz789',
+      vodTimestamps: [{ seconds: 300, note: 'updated note' }],
+    });
+  });
+
+  it('clears vodUrl and vodTimestamps when omitted from the update payload', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: validCreateInput,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).not.toHaveProperty('vodUrl');
+    expect(body).not.toHaveProperty('vodTimestamps');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = matches[TEST_UID]!.existingKey!;
+    expect(stored).not.toHaveProperty('vodUrl');
+    expect(stored).not.toHaveProperty('vodTimestamps');
+  });
+
+  it('returns 400 when vodTimestamps exceeds 20 entries', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const vodTimestamps = Array.from({ length: 21 }, (_, i) => ({
+      seconds: i,
+      note: `note ${i}`,
+    }));
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, vodUrl: 'https://youtube.com/watch?v=abc123', vodTimestamps },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 when a vodTimestamps note is empty', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: 10, note: '   ' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 when a vodTimestamps seconds value is negative', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: -5, note: 'negative seconds' }],
+      },
     });
 
     expect(response.statusCode).toBe(400);

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -107,6 +107,8 @@ export class RtdbService {
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
+      ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
+      ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
     };
 
     const ref = this.database.ref(`matches/${uid}`).push();
@@ -138,10 +140,14 @@ export class RtdbService {
       matchType: input.matchType,
       win: input.win,
       // See createMatch — RTDB rejects `undefined` values, so these are
-      // only included when the input actually set them.
+      // only included when the input actually set them. Omitting
+      // vodUrl/vodTimestamps from the input is how a caller clears them,
+      // since this is a full overwrite (`.set()`, not a partial patch).
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
+      ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
+      ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
     };
 
     await ref.set(record);

--- a/apps/web/src/components/vod/VodNotesDialog.test.tsx
+++ b/apps/web/src/components/vod/VodNotesDialog.test.tsx
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Match } from '@smash-tracker/shared';
+import { VodNotesDialog } from './VodNotesDialog';
+
+const updateMatch = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    matches: {
+      update: (...args: unknown[]) => updateMatch(...args),
+    },
+  },
+}));
+
+function baseMatch(overrides: Partial<Match> = {}): Match {
+  return {
+    id: 'match-1',
+    fighter_id: 1,
+    opponent_id: 8,
+    time: 1700000000000,
+    map: { id: 1, name: 'Battlefield' },
+    opponent: 'rival',
+    notes: 'close game',
+    matchType: 'offline-tourney',
+    win: true,
+    ...overrides,
+  };
+}
+
+function renderDialog(match: Match, onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <VodNotesDialog match={match} open onOpenChange={onOpenChange} />
+    </QueryClientProvider>,
+  );
+  return { onOpenChange };
+}
+
+describe('VodNotesDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefills the VOD URL and existing timestamps', () => {
+    renderDialog(
+      baseMatch({
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+      }),
+    );
+
+    expect(screen.getByLabelText('VOD URL')).toHaveValue('https://youtube.com/watch?v=abc123');
+    expect(screen.getByText('2:41')).toBeInTheDocument();
+    expect(screen.getByText('missed punish on shield')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no timestamps yet', () => {
+    renderDialog(baseMatch());
+    expect(screen.getByText('No timestamp notes yet.')).toBeInTheDocument();
+  });
+
+  it('adds a new timestamp parsed from m:ss input, sorted by seconds', async () => {
+    const user = userEvent.setup();
+    renderDialog(baseMatch({ vodTimestamps: [{ seconds: 490, note: 'lost ledge trump war' }] }));
+
+    await user.type(screen.getByLabelText('Timestamp time'), '2:41');
+    await user.type(screen.getByLabelText('Timestamp note'), 'missed punish on shield');
+    await user.click(screen.getByRole('button', { name: 'Add timestamp' }));
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(within(items[0]!).getByText('2:41')).toBeInTheDocument();
+    expect(within(items[1]!).getByText('8:10')).toBeInTheDocument();
+  });
+
+  it('rejects an unparseable time input', async () => {
+    const user = userEvent.setup();
+    renderDialog(baseMatch());
+
+    await user.type(screen.getByLabelText('Timestamp time'), 'nope');
+    await user.type(screen.getByLabelText('Timestamp note'), 'a note');
+    await user.click(screen.getByRole('button', { name: 'Add timestamp' }));
+
+    expect(screen.getByText('Enter a time as m:ss or h:mm:ss')).toBeInTheDocument();
+    expect(screen.getByText('No timestamp notes yet.')).toBeInTheDocument();
+  });
+
+  it('rejects an empty note', async () => {
+    const user = userEvent.setup();
+    renderDialog(baseMatch());
+
+    await user.type(screen.getByLabelText('Timestamp time'), '1:00');
+    await user.click(screen.getByRole('button', { name: 'Add timestamp' }));
+
+    expect(screen.getByText('Enter a note for this timestamp')).toBeInTheDocument();
+  });
+
+  it('deletes an existing timestamp', async () => {
+    const user = userEvent.setup();
+    renderDialog(baseMatch({ vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }] }));
+
+    await user.click(screen.getByRole('button', { name: 'Delete timestamp 2:41' }));
+    expect(screen.getByText('No timestamp notes yet.')).toBeInTheDocument();
+  });
+
+  it('renders each timestamp as a deep link when a VOD URL is set', () => {
+    renderDialog(
+      baseMatch({
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+      }),
+    );
+
+    const link = screen.getByRole('link', { name: '2:41' });
+    expect(link).toHaveAttribute('href', 'https://youtube.com/watch?v=abc123&t=161s');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('saves vodUrl and vodTimestamps via the matches update API, carrying other fields through unchanged', async () => {
+    const user = userEvent.setup();
+    updateMatch.mockResolvedValue(baseMatch());
+    const match = baseMatch({ stocksLeft: 2, eventName: 'Ultimate Singles' });
+    renderDialog(match);
+
+    await user.type(screen.getByLabelText('VOD URL'), 'https://youtube.com/watch?v=abc123');
+    await user.type(screen.getByLabelText('Timestamp time'), '2:41');
+    await user.type(screen.getByLabelText('Timestamp note'), 'missed punish on shield');
+    await user.click(screen.getByRole('button', { name: 'Add timestamp' }));
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMatch).toHaveBeenCalledTimes(1));
+    expect(updateMatch).toHaveBeenCalledWith('match-1', {
+      fighter_id: 1,
+      opponent_id: 8,
+      map: { id: 1, name: 'Battlefield' },
+      opponent: 'rival',
+      notes: 'close game',
+      matchType: 'offline-tourney',
+      win: true,
+      stocksLeft: 2,
+      eventName: 'Ultimate Singles',
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+    });
+  });
+
+  it('clears vodUrl and vodTimestamps when the URL is emptied and all timestamps removed', async () => {
+    const user = userEvent.setup();
+    updateMatch.mockResolvedValue(baseMatch());
+    const match = baseMatch({
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+    });
+    renderDialog(match);
+
+    await user.click(screen.getByRole('button', { name: 'Delete timestamp 2:41' }));
+    await user.clear(screen.getByLabelText('VOD URL'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMatch).toHaveBeenCalledTimes(1));
+    const payload = updateMatch.mock.calls[0]![1];
+    expect(payload).not.toHaveProperty('vodUrl');
+    expect(payload).not.toHaveProperty('vodTimestamps');
+  });
+
+  it('closes the dialog after a successful save', async () => {
+    const user = userEvent.setup();
+    updateMatch.mockResolvedValue(baseMatch());
+    const { onOpenChange } = renderDialog(baseMatch());
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+});

--- a/apps/web/src/components/vod/VodNotesDialog.tsx
+++ b/apps/web/src/components/vod/VodNotesDialog.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Plus, Trash2 } from 'lucide-react';
+import type { Match, UpdateMatchInput, VodTimestamp } from '@smash-tracker/shared';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useUpdateMatch } from '@/hooks/useUpdateMatch';
+import { formatTimestamp, parseTimestamp, vodDeepLink } from '@/lib/vod';
+
+/**
+ * Builds the full `UpdateMatchInput` PATCH payload for `match`, carrying
+ * every existing field through unchanged except `vodUrl`/`vodTimestamps`
+ * (overridden by the caller). Required because `PATCH /api/matches/:id` is a
+ * full overwrite (see `RtdbService.updateMatch`) — omitting a field here
+ * would clear it, not leave it untouched.
+ */
+function buildUpdateInput(
+  match: Match,
+  overrides: { vodUrl: string | undefined; vodTimestamps: VodTimestamp[] | undefined },
+): UpdateMatchInput {
+  return {
+    fighter_id: match.fighter_id,
+    opponent_id: match.opponent_id,
+    map: match.map ?? { id: 0, name: 'no selection' },
+    opponent: match.opponent ?? '',
+    notes: match.notes ?? '',
+    matchType: match.matchType ? match.matchType : 'none',
+    win: match.win,
+    ...(match.stocksLeft !== undefined ? { stocksLeft: match.stocksLeft } : {}),
+    ...(match.eventName !== undefined ? { eventName: match.eventName } : {}),
+    ...(match.tournamentName !== undefined ? { tournamentName: match.tournamentName } : {}),
+    ...(overrides.vodUrl !== undefined ? { vodUrl: overrides.vodUrl } : {}),
+    ...(overrides.vodTimestamps !== undefined ? { vodTimestamps: overrides.vodTimestamps } : {}),
+  };
+}
+
+const MAX_TIMESTAMPS = 20;
+
+/**
+ * Dialog for attaching a VOD link and timestamped notes to a match (V7-E),
+ * e.g. "2:41 — missed punish on shield". Opened from `SetTimeline` (per-set
+ * VOD edit affordance) and `MatchTable` (per-row VOD icon button). Saves via
+ * `useUpdateMatch` — a full PATCH carrying every other field through
+ * unchanged (see `buildUpdateInput`).
+ */
+export function VodNotesDialog({
+  match,
+  open,
+  onOpenChange,
+}: {
+  match: Match;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const updateMatch = useUpdateMatch();
+  const [url, setUrl] = useState(match.vodUrl ?? '');
+  const [timestamps, setTimestamps] = useState<VodTimestamp[]>(match.vodTimestamps ?? []);
+  const [timeInput, setTimeInput] = useState('');
+  const [noteInput, setNoteInput] = useState('');
+  const [timeError, setTimeError] = useState<string | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    onOpenChange(next);
+    if (next) {
+      setUrl(match.vodUrl ?? '');
+      setTimestamps(match.vodTimestamps ?? []);
+      setTimeInput('');
+      setNoteInput('');
+      setTimeError(null);
+    }
+  }
+
+  function handleAddTimestamp() {
+    const seconds = parseTimestamp(timeInput);
+    if (seconds == null) {
+      setTimeError('Enter a time as m:ss or h:mm:ss');
+      return;
+    }
+    const note = noteInput.trim();
+    if (!note) {
+      setTimeError('Enter a note for this timestamp');
+      return;
+    }
+    if (timestamps.length >= MAX_TIMESTAMPS) {
+      setTimeError(`Limit ${MAX_TIMESTAMPS} timestamps per match`);
+      return;
+    }
+    setTimestamps((prev) => [...prev, { seconds, note }].sort((a, b) => a.seconds - b.seconds));
+    setTimeInput('');
+    setNoteInput('');
+    setTimeError(null);
+  }
+
+  function handleRemoveTimestamp(index: number) {
+    setTimestamps((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function handleSave() {
+    const trimmedUrl = url.trim();
+    const input = buildUpdateInput(match, {
+      vodUrl: trimmedUrl ? trimmedUrl : undefined,
+      vodTimestamps: timestamps.length > 0 ? timestamps : undefined,
+    });
+    try {
+      await updateMatch.mutateAsync({ id: match.id, input });
+      toast.success('VOD notes saved!');
+      onOpenChange(false);
+    } catch {
+      toast.error('Failed to save VOD notes. Please try again.');
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>VOD Notes</DialogTitle>
+          <DialogDescription>
+            Attach a VOD link and timestamped notes, e.g. &quot;2:41 — missed punish on
+            shield&quot;.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="vod-url">VOD URL</Label>
+            <Input
+              id="vod-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://youtube.com/watch?v=..."
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>Timestamps</Label>
+            {timestamps.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No timestamp notes yet.</p>
+            ) : (
+              <ul className="flex flex-col gap-2" aria-label="Timestamp notes">
+                {timestamps.map((stamp, index) => (
+                  <li
+                    key={`${stamp.seconds}-${index}`}
+                    className="flex items-center justify-between gap-2 rounded-md border p-2 text-sm"
+                  >
+                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                      {url.trim() ? (
+                        <a
+                          href={vodDeepLink(url.trim(), stamp.seconds)}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="shrink-0 font-mono text-primary hover:underline"
+                        >
+                          {formatTimestamp(stamp.seconds)}
+                        </a>
+                      ) : (
+                        <span className="shrink-0 font-mono">{formatTimestamp(stamp.seconds)}</span>
+                      )}
+                      <span className="truncate">{stamp.note}</span>
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon-sm"
+                      aria-label={`Delete timestamp ${formatTimestamp(stamp.seconds)}`}
+                      onClick={() => handleRemoveTimestamp(index)}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-1 flex flex-wrap items-start gap-2">
+              <Input
+                value={timeInput}
+                onChange={(e) => {
+                  setTimeInput(e.target.value);
+                  setTimeError(null);
+                }}
+                placeholder="m:ss"
+                aria-label="Timestamp time"
+                className="w-24"
+              />
+              <Input
+                value={noteInput}
+                onChange={(e) => {
+                  setNoteInput(e.target.value);
+                  setTimeError(null);
+                }}
+                placeholder="Note"
+                aria-label="Timestamp note"
+                maxLength={200}
+                className="min-w-[10rem] flex-1"
+              />
+              <Button type="button" variant="outline" size="icon-sm" onClick={handleAddTimestamp}>
+                <Plus />
+                <span className="sr-only">Add timestamp</span>
+              </Button>
+            </div>
+            {timeError && <p className="text-sm text-destructive">{timeError}</p>}
+          </div>
+        </div>
+
+        <DialogFooter className="mt-4">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={updateMatch.isPending}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/vod.test.ts
+++ b/apps/web/src/lib/vod.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { formatTimestamp, parseTimestamp, vodDeepLink } from './vod';
+
+describe('vodDeepLink', () => {
+  it('appends &t=<s>s for a youtube.com/watch URL', () => {
+    expect(vodDeepLink('https://youtube.com/watch?v=abc123', 161)).toBe(
+      'https://youtube.com/watch?v=abc123&t=161s',
+    );
+  });
+
+  it('works for www.youtube.com and m.youtube.com hosts', () => {
+    expect(vodDeepLink('https://www.youtube.com/watch?v=abc123', 30)).toBe(
+      'https://www.youtube.com/watch?v=abc123&t=30s',
+    );
+    expect(vodDeepLink('https://m.youtube.com/watch?v=abc123', 30)).toBe(
+      'https://m.youtube.com/watch?v=abc123&t=30s',
+    );
+  });
+
+  it('overwrites an existing t param on a youtube.com/watch URL', () => {
+    expect(vodDeepLink('https://youtube.com/watch?v=abc123&t=5s', 161)).toBe(
+      'https://youtube.com/watch?v=abc123&t=161s',
+    );
+  });
+
+  it('uses ?t=<s> for a youtu.be short URL', () => {
+    expect(vodDeepLink('https://youtu.be/abc123', 90)).toBe('https://youtu.be/abc123?t=90');
+  });
+
+  it('uses the 1h2m3s format for a twitch.tv/videos URL', () => {
+    expect(vodDeepLink('https://twitch.tv/videos/123456789', 3723)).toBe(
+      'https://twitch.tv/videos/123456789?t=1h2m3s',
+    );
+  });
+
+  it('omits the hours segment in the twitch format when under an hour', () => {
+    expect(vodDeepLink('https://twitch.tv/videos/123456789', 161)).toBe(
+      'https://twitch.tv/videos/123456789?t=2m41s',
+    );
+  });
+
+  it('handles zero seconds for twitch (0h0m0s -> 0s)', () => {
+    expect(vodDeepLink('https://twitch.tv/videos/123456789', 0)).toBe(
+      'https://twitch.tv/videos/123456789?t=0s',
+    );
+  });
+
+  it('works for www.twitch.tv host', () => {
+    expect(vodDeepLink('https://www.twitch.tv/videos/123456789', 65)).toBe(
+      'https://www.twitch.tv/videos/123456789?t=1m5s',
+    );
+  });
+
+  it('returns the base URL unchanged for an unrecognized host', () => {
+    expect(vodDeepLink('https://example.com/some-vod', 161)).toBe('https://example.com/some-vod');
+  });
+
+  it('returns a non-watch youtube.com path unchanged', () => {
+    expect(vodDeepLink('https://youtube.com/channel/abc', 161)).toBe(
+      'https://youtube.com/channel/abc',
+    );
+  });
+
+  it('returns a non-videos twitch.tv path unchanged', () => {
+    expect(vodDeepLink('https://twitch.tv/someuser', 161)).toBe('https://twitch.tv/someuser');
+  });
+
+  it('returns malformed input unchanged rather than throwing', () => {
+    expect(vodDeepLink('not a url', 161)).toBe('not a url');
+  });
+
+  it('floors fractional seconds and clamps negative values to 0', () => {
+    expect(vodDeepLink('https://youtu.be/abc123', 90.9)).toBe('https://youtu.be/abc123?t=90');
+    expect(vodDeepLink('https://youtu.be/abc123', -5)).toBe('https://youtu.be/abc123?t=0');
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('formats sub-minute offsets as m:ss', () => {
+    expect(formatTimestamp(0)).toBe('0:00');
+    expect(formatTimestamp(5)).toBe('0:05');
+    expect(formatTimestamp(59)).toBe('0:59');
+  });
+
+  it('formats minute-scale offsets as m:ss', () => {
+    expect(formatTimestamp(161)).toBe('2:41');
+    expect(formatTimestamp(600)).toBe('10:00');
+  });
+
+  it('formats hour-scale offsets as h:mm:ss', () => {
+    expect(formatTimestamp(3661)).toBe('1:01:01');
+    expect(formatTimestamp(3600)).toBe('1:00:00');
+  });
+
+  it('floors fractional seconds and clamps negatives to 0', () => {
+    expect(formatTimestamp(90.9)).toBe('1:30');
+    expect(formatTimestamp(-5)).toBe('0:00');
+  });
+});
+
+describe('parseTimestamp', () => {
+  it('parses m:ss', () => {
+    expect(parseTimestamp('2:41')).toBe(161);
+    expect(parseTimestamp('0:05')).toBe(5);
+  });
+
+  it('parses h:mm:ss', () => {
+    expect(parseTimestamp('1:01:01')).toBe(3661);
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(parseTimestamp('')).toBeNull();
+    expect(parseTimestamp('   ')).toBeNull();
+  });
+
+  it('returns null for non-numeric parts', () => {
+    expect(parseTimestamp('a:bb')).toBeNull();
+  });
+
+  it('returns null for out-of-range minutes or seconds', () => {
+    expect(parseTimestamp('1:60')).toBeNull();
+    expect(parseTimestamp('1:99:00')).toBeNull();
+  });
+
+  it('returns null for too few or too many segments', () => {
+    expect(parseTimestamp('42')).toBeNull();
+    expect(parseTimestamp('1:2:3:4')).toBeNull();
+  });
+
+  it('round-trips with formatTimestamp', () => {
+    expect(parseTimestamp(formatTimestamp(161))).toBe(161);
+    expect(parseTimestamp(formatTimestamp(3661))).toBe(3661);
+  });
+});

--- a/apps/web/src/lib/vod.ts
+++ b/apps/web/src/lib/vod.ts
@@ -1,0 +1,105 @@
+/**
+ * VOD timestamp helpers (V7-E): building a deep-link URL that opens a VOD at
+ * a specific second, and formatting seconds as a clock-style label for
+ * display. Supports YouTube and Twitch's timestamp query-param conventions;
+ * any other host falls back to the base URL unchanged (still a valid link,
+ * just without a seek).
+ */
+
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com']);
+const YOUTUBE_SHORT_HOSTS = new Set(['youtu.be', 'www.youtu.be']);
+const TWITCH_HOSTS = new Set(['twitch.tv', 'www.twitch.tv']);
+
+/** Formats a whole-seconds offset as a Twitch-style `1h2m3s` duration string. */
+function toTwitchDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  let out = '';
+  if (hours > 0) out += `${hours}h`;
+  if (hours > 0 || minutes > 0) out += `${minutes}m`;
+  out += `${seconds}s`;
+  return out;
+}
+
+/**
+ * Builds a URL that opens `url` at `seconds` in, when the host is a
+ * recognized VOD provider (YouTube long/short form, Twitch VODs). Any other
+ * URL (including a malformed one) is returned unchanged — still usable as a
+ * plain link, just without a seek.
+ */
+export function vodDeepLink(url: string, seconds: number): string {
+  const wholeSeconds = Math.max(0, Math.floor(seconds));
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (YOUTUBE_HOSTS.has(host) && parsed.pathname === '/watch') {
+    parsed.searchParams.set('t', `${wholeSeconds}s`);
+    return parsed.toString();
+  }
+
+  if (YOUTUBE_SHORT_HOSTS.has(host)) {
+    parsed.searchParams.set('t', String(wholeSeconds));
+    return parsed.toString();
+  }
+
+  if (TWITCH_HOSTS.has(host) && parsed.pathname.startsWith('/videos/')) {
+    parsed.searchParams.set('t', toTwitchDuration(wholeSeconds));
+    return parsed.toString();
+  }
+
+  return url;
+}
+
+/**
+ * Formats a whole-seconds offset as `m:ss` (under an hour) or `h:mm:ss` (an
+ * hour or more), e.g. `161` -> `2:41`, `3661` -> `1:01:01`.
+ */
+export function formatTimestamp(seconds: number): string {
+  const wholeSeconds = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(wholeSeconds / 3600);
+  const minutes = Math.floor((wholeSeconds % 3600) / 60);
+  const secs = wholeSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+/**
+ * Parses a `m:ss` or `h:mm:ss` clock-style string (the inverse of
+ * `formatTimestamp`) into whole seconds. Returns `null` for anything that
+ * doesn't match — empty input, non-numeric parts, or out-of-range
+ * minutes/seconds (>= 60).
+ */
+export function parseTimestamp(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parts = trimmed.split(':');
+  if (parts.length < 2 || parts.length > 3) {
+    return null;
+  }
+  if (!parts.every((p) => /^\d+$/.test(p))) {
+    return null;
+  }
+
+  const numbers = parts.map(Number);
+  const [hours, minutes, seconds]: [number, number, number] =
+    numbers.length === 3 ? [numbers[0]!, numbers[1]!, numbers[2]!] : [0, numbers[0]!, numbers[1]!];
+
+  if (minutes >= 60 || seconds >= 60) {
+    return null;
+  }
+
+  return hours * 3600 + minutes * 60 + seconds;
+}

--- a/apps/web/src/pages/MatchData/MatchDataPage.test.tsx
+++ b/apps/web/src/pages/MatchData/MatchDataPage.test.tsx
@@ -283,6 +283,63 @@ describe('MatchDataPage', () => {
     expect(screen.getAllByText('rival').length).toBeGreaterThan(0);
   });
 
+  it('shows "Add VOD notes" for a match without a vodUrl and "Edit VOD notes" for one with', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([
+      makeMatch({ id: 'm1', opponent: 'rival' }),
+      makeMatch({
+        id: 'm2',
+        opponent: 'someone-else',
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+      }),
+    ]);
+
+    renderMatchData();
+
+    await waitFor(() => expect(screen.getAllByLabelText('Add VOD notes')).toHaveLength(1));
+    expect(screen.getAllByLabelText('Edit VOD notes')).toHaveLength(1);
+  });
+
+  it('opens the VOD notes dialog and saves a new VOD URL and timestamp', async () => {
+    const user = userEvent.setup();
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([
+      makeMatch({
+        id: 'm1',
+        fighter_id: mario.id,
+        opponent_id: luigi.id,
+        opponent: 'rival',
+        notes: 'gg',
+        matchType: 'quickplay',
+        win: true,
+        map: { id: 0, name: 'no selection' },
+      }),
+    ]);
+
+    renderMatchData();
+
+    await waitFor(() => expect(screen.getByLabelText('Add VOD notes')).toBeInTheDocument());
+    await user.click(screen.getByLabelText('Add VOD notes'));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('VOD Notes')).toBeInTheDocument();
+
+    await user.type(within(dialog).getByLabelText('VOD URL'), 'https://youtube.com/watch?v=abc123');
+    await user.type(within(dialog).getByLabelText('Timestamp time'), '2:41');
+    await user.type(within(dialog).getByLabelText('Timestamp note'), 'missed punish on shield');
+    await user.click(within(dialog).getByRole('button', { name: 'Add timestamp' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMatch).toHaveBeenCalledTimes(1));
+    expect(updateMatch).toHaveBeenCalledWith(
+      'm1',
+      expect.objectContaining({
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+      }),
+    );
+  });
+
   it('deletes a match after confirmation', async () => {
     const user = userEvent.setup();
     getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });

--- a/apps/web/src/pages/MatchData/components/MatchTable.tsx
+++ b/apps/web/src/pages/MatchData/components/MatchTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Download, Pencil, SlidersHorizontal, Trash2 } from 'lucide-react';
+import { Download, Pencil, SlidersHorizontal, Trash2, Video } from 'lucide-react';
 import {
   flexRender,
   getCoreRowModel,
@@ -62,6 +62,8 @@ import {
 } from '../lib/matchTableFilters';
 import { persistColumnVisibility, readStoredColumnVisibility } from '../lib/columnVisibility';
 import { EditMatchForm } from './EditMatchForm';
+import { VodNotesDialog } from '@/components/vod/VodNotesDialog';
+import { cn } from '@/lib/utils';
 
 const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50];
 
@@ -148,6 +150,7 @@ export function MatchTable({
   );
   const [editingMatch, setEditingMatch] = useState<Match | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Match | null>(null);
+  const [vodMatch, setVodMatch] = useState<Match | null>(null);
   const deleteMatch = useDeleteMatch();
 
   useEffect(() => {
@@ -245,26 +248,38 @@ export function MatchTable({
         header: 'Manage',
         enableSorting: false,
         enableHiding: false,
-        cell: ({ row }) => (
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Edit match"
-              onClick={() => setEditingMatch(row.original.match)}
-            >
-              <Pencil />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Delete match"
-              onClick={() => setPendingDelete(row.original.match)}
-            >
-              <Trash2 />
-            </Button>
-          </div>
-        ),
+        cell: ({ row }) => {
+          const hasVod = row.original.match.vodUrl != null;
+          return (
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label={hasVod ? 'Edit VOD notes' : 'Add VOD notes'}
+                className={cn(hasVod && 'border-primary text-primary')}
+                onClick={() => setVodMatch(row.original.match)}
+              >
+                <Video />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label="Edit match"
+                onClick={() => setEditingMatch(row.original.match)}
+              >
+                <Pencil />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label="Delete match"
+                onClick={() => setPendingDelete(row.original.match)}
+              >
+                <Trash2 />
+              </Button>
+            </div>
+          );
+        },
       },
     ],
     [],
@@ -495,6 +510,14 @@ export function MatchTable({
           fighterSprites={fighterSprites}
           open={editingMatch != null}
           onOpenChange={(open) => !open && setEditingMatch(null)}
+        />
+      )}
+
+      {vodMatch && (
+        <VodNotesDialog
+          match={vodMatch}
+          open={vodMatch != null}
+          onOpenChange={(open) => !open && setVodMatch(null)}
         />
       )}
 

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
@@ -1,10 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Match } from '@smash-tracker/shared';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { SetTimeline } from './SetTimeline';
 import { buildSetTimeline } from '../lib/setTimeline';
 import { SpriteList } from '@/data/sprites';
+
+const updateMatch = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    matches: {
+      update: (...args: unknown[]) => updateMatch(...args),
+    },
+  },
+}));
 
 const mario = SpriteList.find((s) => s.id === 1)!; // Mario
 const luigi = SpriteList.find((s) => s.id === 10)!; // Luigi
@@ -23,14 +35,21 @@ function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'
 
 function renderTimeline(matches: Match[]) {
   const { sets, otherMatches } = buildSetTimeline(matches);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <TooltipProvider>
-      <SetTimeline sets={sets} otherMatches={otherMatches} />
-    </TooltipProvider>,
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <SetTimeline sets={sets} otherMatches={otherMatches} />
+      </TooltipProvider>
+    </QueryClientProvider>,
   );
 }
 
 describe('SetTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('shows an empty state when there are no matches', () => {
     renderTimeline([]);
     expect(screen.getByText('No matches recorded for this event yet.')).toBeInTheDocument();
@@ -209,5 +228,55 @@ describe('SetTimeline', () => {
     const matches = [makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1' })];
     renderTimeline(matches);
     expect(screen.queryByText('Watch VOD')).not.toBeInTheDocument();
+  });
+
+  it('shows clickable timestamp chips with deep links when the set has vodTimestamps', () => {
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 100,
+        win: true,
+        externalId: 'sgg:1:g1',
+        roundText: 'Grand Final',
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [
+          { seconds: 490, note: 'lost ledge trump war' },
+          { seconds: 161, note: 'missed punish on shield' },
+        ],
+      }),
+    ];
+    renderTimeline(matches);
+
+    const firstChip = screen.getByRole('link', { name: '2:41' });
+    expect(firstChip).toHaveAttribute('href', 'https://youtube.com/watch?v=abc123&t=161s');
+    expect(screen.getByRole('link', { name: '8:10' })).toBeInTheDocument();
+  });
+
+  it('always shows a VOD edit affordance, even when the set has no vodUrl yet', () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', roundText: 'Pools' }),
+    ];
+    renderTimeline(matches);
+    expect(screen.getByRole('button', { name: 'Edit VOD notes for Pools' })).toBeInTheDocument();
+  });
+
+  it('opens the VOD notes dialog from the edit affordance', async () => {
+    const user = userEvent.setup();
+    const matches = [
+      makeMatch({
+        id: 'g1',
+        time: 100,
+        win: true,
+        externalId: 'sgg:1:g1',
+        roundText: 'Grand Final',
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+      }),
+    ];
+    renderTimeline(matches);
+
+    await user.click(screen.getByRole('button', { name: 'Edit VOD notes for Grand Final' }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'VOD Notes' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
@@ -1,6 +1,8 @@
-import { ExternalLink } from 'lucide-react';
+import { useState } from 'react';
+import { ExternalLink, Pencil } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { getFighterById } from '@/data/sprites';
 import { stagesById } from '@/data/stages';
@@ -10,6 +12,8 @@ import type { TournamentSet } from '../lib/setTimeline';
 import { buildStartggUrl } from '../lib/startggLinks';
 import { formatOpponentEventContext } from '../lib/ordinal';
 import { cn } from '@/lib/utils';
+import { formatTimestamp, vodDeepLink } from '@/lib/vod';
+import { VodNotesDialog } from '@/components/vod/VodNotesDialog';
 
 function GameChip({ match }: { match: Match }) {
   const stageId = match.map?.id ?? 0;
@@ -56,29 +60,86 @@ function OpponentTags({ opponentFighterIds }: { opponentFighterIds: number[] }) 
 }
 
 /**
- * Outbound "Watch VOD" link for a set, shown when any game in the set
- * carries a `vodUrl` (start.gg's TO-curated `Set.vodUrl`, duplicated across
- * every game of the set during sync — see `MatchRecord.vodUrl`). Currently
- * null on essentially all production data (no TO has attached one to a
- * sampled set yet, per the V6-W1b probe), so this simply doesn't render
- * until a TO does.
+ * Clickable timestamp chips for a set's VOD notes (V7-E): each chip opens
+ * the VOD at that moment via `vodDeepLink`. Renders nothing when the match
+ * carrying the `vodUrl` has no `vodTimestamps`.
  */
-function VodLink({ set }: { set: TournamentSet }) {
-  const vodUrl = set.games.map((g) => g.match.vodUrl).find((url) => url != null);
-  if (!vodUrl) {
+function VodTimestampChips({ vodUrl, match }: { vodUrl: string; match: Match }) {
+  const timestamps = match.vodTimestamps;
+  if (!timestamps || timestamps.length === 0) {
     return null;
   }
+  const sorted = [...timestamps].sort((a, b) => a.seconds - b.seconds);
   return (
-    <a
-      href={vodUrl}
-      target="_blank"
-      rel="noreferrer"
-      aria-label={`Watch VOD for ${set.roundText ?? `Set ${set.setId}`}`}
-      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-    >
-      Watch VOD
-      <ExternalLink className="size-3.5" />
-    </a>
+    <div className="flex flex-wrap items-center gap-1">
+      {sorted.map((stamp, index) => (
+        <Tooltip key={`${stamp.seconds}-${index}`}>
+          <TooltipTrigger asChild>
+            <a
+              href={vodDeepLink(vodUrl, stamp.seconds)}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+            >
+              {formatTimestamp(stamp.seconds)}
+            </a>
+          </TooltipTrigger>
+          <TooltipContent>{stamp.note}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Outbound "Watch VOD" link plus timestamp-note chips for a set, shown when
+ * any game in the set carries a `vodUrl` (start.gg's TO-curated
+ * `Set.vodUrl`, duplicated across every game of the set during sync — see
+ * `MatchRecord.vodUrl`), or when the player has manually attached one via
+ * the edit affordance (V7-E). A pencil button always renders (using the
+ * set's first game as the record to edit when no `vodUrl` exists yet) so a
+ * VOD can be attached even for sets that never got one from start.gg.
+ */
+function VodLink({ set }: { set: TournamentSet }) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const vodMatch =
+    set.games.map((g) => g.match).find((m) => m.vodUrl != null) ?? set.games[0]?.match;
+  const vodUrl = vodMatch?.vodUrl;
+
+  if (!vodMatch) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {vodUrl && (
+        <>
+          <a
+            href={vodUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Watch VOD for ${set.roundText ?? `Set ${set.setId}`}`}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            Watch VOD
+            <ExternalLink className="size-3.5" />
+          </a>
+          <VodTimestampChips vodUrl={vodUrl} match={vodMatch} />
+        </>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label={`Edit VOD notes for ${set.roundText ?? `Set ${set.setId}`}`}
+        onClick={() => setDialogOpen(true)}
+      >
+        <Pencil className="size-3.5" />
+      </Button>
+      {dialogOpen && (
+        <VodNotesDialog match={vodMatch} open={dialogOpen} onOpenChange={setDialogOpen} />
+      )}
+    </div>
   );
 }
 

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -21,6 +21,22 @@ export const matchTypeSchema = z.enum(matchTypeValues);
 export type MatchType = z.infer<typeof matchTypeSchema>;
 
 /**
+ * A single VOD timestamp note (V7-E): `seconds` is the offset into the VOD
+ * to deep-link to, `note` is the free-text callout (e.g. "missed punish on
+ * shield"). Lives alongside `vodUrl` on `matchRecordSchema` — user-editable
+ * via the same update path (see `createMatchInputSchema`/
+ * `updateMatchInputSchema`), unlike the server-only start.gg-sync fields
+ * below.
+ */
+export const vodTimestampSchema = z.object({
+  /** Offset in whole seconds into the VOD this note refers to. */
+  seconds: z.number().int().min(0),
+  /** Free-text callout for this moment, e.g. "missed punish on shield". */
+  note: z.string().trim().min(1).max(200),
+});
+export type VodTimestamp = z.infer<typeof vodTimestampSchema>;
+
+/**
  * `matches/{uid}/{pushKey}` — the stored shape, derived verbatim from
  * legacy AddMatchForm.js `onSaveMatchClick` / EditMatchForm.js
  * `onSaveMatchClick` (both `.set()` the full record — legacy never used
@@ -115,15 +131,23 @@ export const matchRecordSchema = z.object({
    */
   opponentUserSlug: z.string().optional(),
   /**
-   * URL of a VOD for the set this game belonged to, when start.gg's
-   * `Set.vodUrl` is populated (a TO-curated field — verified via the
-   * V6-W1b probe to exist but be null on essentially every real set
-   * sampled, including majors' streamed Grand Finals; harvested anyway in
-   * case a TO does populate it). Duplicated across every game of the set,
-   * same rationale as `opponentSeed`/`opponentPlacement`. Server-set,
-   * imported matches only.
+   * URL of a VOD for the set this game belonged to. Originally populated
+   * only by start.gg's TO-curated `Set.vodUrl` (verified via the V6-W1b
+   * probe to exist but be null on essentially every real set sampled,
+   * including majors' streamed Grand Finals; duplicated across every game of
+   * the set, same rationale as `opponentSeed`/`opponentPlacement`) — as of
+   * V7-E, also user-editable directly (see `createMatchInputSchema` /
+   * `updateMatchInputSchema`), so players can attach a VOD link themselves
+   * when the TO never does.
    */
   vodUrl: z.string().url().optional(),
+  /**
+   * User-authored VOD timestamp notes (V7-E), e.g. "2:41 — missed punish on
+   * shield". Unlike the start.gg-only fields above, this is set entirely by
+   * the player via the update path — capped at 20 entries per match so a
+   * single game's notes stay skimmable.
+   */
+  vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 
@@ -193,6 +217,11 @@ const optionalNameInputSchema = z
  * additions (set wizard + tournament hint fields) — `source`/`externalId`
  * remain server-set only (see `matchRecordSchema`) and are intentionally
  * NOT accepted here.
+ *
+ * `vodUrl`/`vodTimestamps` (V7-E) are user-editable here too — omitting
+ * either field (rather than sending it) is how a caller clears it, following
+ * the same full-overwrite + conditional-spread convention as
+ * `stocksLeft`/`eventName`/`tournamentName` (see `RtdbService.updateMatch`).
  */
 export const createMatchInputSchema = z.object({
   fighter_id: z.number().int().positive(),
@@ -205,6 +234,8 @@ export const createMatchInputSchema = z.object({
   stocksLeft: z.number().int().min(0).max(3).optional(),
   eventName: optionalNameInputSchema,
   tournamentName: optionalNameInputSchema,
+  vodUrl: z.string().url().optional(),
+  vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
 });
 export type CreateMatchInput = z.infer<typeof createMatchInputSchema>;
 


### PR DESCRIPTION
## Summary
- Players can now attach a VOD link and timestamped notes to a match ("2:41 — missed punish on shield") and click a timestamp to open the VOD at that moment.
- `packages/shared`: new `vodTimestampSchema` (`{ seconds, note }`, note trimmed 1-200 chars), `vodTimestamps` added to `matchRecordSchema` (max 20) and to `createMatchInputSchema`/`updateMatchInputSchema` (both user-editable; omitting either field clears it, following the existing conditional-spread + full-overwrite convention).
- `apps/api`: `RtdbService.createMatch`/`updateMatch` persist `vodUrl`/`vodTimestamps` with the same conditional-spread pattern as `stocksLeft`/`eventName`/`tournamentName`.
- `apps/web`: new `lib/vod.ts` (`vodDeepLink` for YouTube/Twitch/fallback, `formatTimestamp`, `parseTimestamp`) and `components/vod/VodNotesDialog.tsx` (set/edit VOD URL, add/delete timestamp notes, saves via the existing matches update mutation). Wired into `SetTimeline` (Watch VOD link + clickable timestamp chips + always-available edit pencil) and `MatchTable` (per-row VOD icon button, highlighted when a vodUrl exists).

## Test plan
- [x] `pnpm lint` — 0 errors (33 pre-existing warnings, unrelated to this change)
- [x] `pnpm typecheck` — passes across shared/api/web
- [x] `pnpm test` — 960 tests pass (52 shared + 229 api + 679 web), including ~60 new tests for the schema, API route, `lib/vod.ts`, `VodNotesDialog`, and the `SetTimeline`/`MatchTable` render points
- [x] `pnpm build` — passes
- [x] `pnpm format:check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)