### PR TITLE
Fix: AI report generation 502s behind Hosting's 60s rewrite timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ VITE_FIREBASE_APP_ID=...
 
 # Empty — same-origin in production, requests go to /api/** on this origin
 VITE_API_BASE_URL=
+
+# Cloud Run service URL — used only by requests that can outlive Firebase
+# Hosting's hard 60-second rewrite timeout (AI report generation goes direct
+# to this origin). Requires the API's CORS_ORIGIN env var to allow the
+# Hosting origin, e.g. CORS_ORIGIN=https://your-project.web.app
+VITE_API_DIRECT_URL=https://smash-tracker-api-XXXX.us-central1.run.app
 ```
 
 **3. Build and deploy the web app to Firebase Hosting**

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -23,3 +23,11 @@ VITE_FIREBASE_APP_ID=your-app-id
 # URL):
 #   VITE_API_BASE_URL=
 VITE_API_BASE_URL=http://localhost:3001
+
+# Direct (non-proxied) origin of the API, used only for requests that can
+# outlive Firebase Hosting's hard 60-second rewrite timeout — currently AI
+# report generation. In production set this to the Cloud Run service URL
+# (e.g. https://smash-tracker-api-XXXX.us-central1.run.app) and make sure
+# the API's CORS_ORIGIN env var allows the Hosting origin. Leave unset in
+# local dev — it falls back to VITE_API_BASE_URL.
+# VITE_API_DIRECT_URL=

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -78,6 +78,24 @@ export function getApiBaseUrl(): string {
   return base.replace(/\/+$/, '');
 }
 
+/**
+ * Base URL for requests that must NOT go through the Firebase Hosting
+ * `/api/**` rewrite. The Hosting proxy hard-caps every rewritten request at
+ * 60 seconds (not configurable), which AI report generation can exceed —
+ * the model call alone can run past a minute. `VITE_API_DIRECT_URL` holds
+ * the Cloud Run service URL so those calls hit the API origin directly
+ * (CORS-allowed via the API's CORS_ORIGIN env var) and get Cloud Run's own
+ * 300-second window instead. Falls back to the regular base when unset
+ * (local dev and tests, where there is no proxy in the middle).
+ */
+export function getDirectApiBaseUrl(): string {
+  const configured = import.meta.env.VITE_API_DIRECT_URL;
+  if (typeof configured === 'string' && configured.trim() !== '') {
+    return configured.replace(/\/+$/, '');
+  }
+  return getApiBaseUrl();
+}
+
 async function getAuthHeader(): Promise<Record<string, string>> {
   const user = getFirebaseAuth().currentUser;
   if (!user) {
@@ -90,6 +108,8 @@ async function getAuthHeader(): Promise<Record<string, string>> {
 interface RequestOptions<TBody> {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: TBody;
+  /** Overrides the request origin (see `getDirectApiBaseUrl`). */
+  baseUrl?: string;
 }
 
 /**
@@ -105,7 +125,7 @@ async function apiRequest<TResponse, TBody = unknown>(
   const authHeader = await getAuthHeader();
   const hasBody = options.body !== undefined;
 
-  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+  const response = await fetch(`${options.baseUrl ?? getApiBaseUrl()}${path}`, {
     method: options.method ?? 'GET',
     headers: {
       ...authHeader,
@@ -244,11 +264,16 @@ export const api = {
   reports: {
     /** GET /api/reports/config — whether the signed-in user can generate AI reports. */
     config: () => apiRequestParsed('/api/reports/config', reportsConfigSchema),
-    /** POST /api/reports — generate (and store) an AI scouting report. */
+    /**
+     * POST /api/reports — generate (and store) an AI scouting report.
+     * Goes directly to the API origin: generation regularly outlives the
+     * Hosting proxy's 60s rewrite timeout.
+     */
     generate: (query: string) =>
       apiRequestParsed('/api/reports', scoutReportRecordSchema, {
         method: 'POST',
         body: generateReportRequestSchema.parse({ query }),
+        baseUrl: getDirectApiBaseUrl(),
       }),
     /** GET /api/reports — the signed-in user's past AI reports, newest first. */
     list: () => apiRequestParsed('/api/reports', scoutReportRecordSchema.array()),


### PR DESCRIPTION
## Problem
The first real report generation returned a 502 to the browser while Cloud Run logged a 200 after 61 seconds — Firebase Hosting's `/api/**` rewrite proxy hard-caps requests at 60s (not configurable). The report was actually generated and stored; the client just never saw it.

## Fix
- New `VITE_API_DIRECT_URL` (Cloud Run service URL): `api.reports.generate` — and only it — now calls the API origin directly, getting Cloud Run's 300s window. All other requests stay on the same-origin rewrite.
- `RequestOptions.baseUrl` override in the fetch wrapper.
- Docs: README deploy section + `.env.example`. Production `CORS_ORIGIN` env var already set on the service (rev 00011).

686 web tests, lint, and typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)