### PR TITLE
Restore Donorbox donate button in sidebar

### DIFF
--- a/apps/web/src/layouts/MainLayout.test.tsx
+++ b/apps/web/src/layouts/MainLayout.test.tsx
@@ -62,4 +62,27 @@ describe('MainLayout', () => {
     expect(screen.getAllByText('pilot@example.com').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
   });
+
+  it('renders the Donorbox donate link below Training Grounds in the sidebar', async () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <AuthProvider>
+          <AnalyticsFilterProvider>
+            <MainLayout>
+              <div>Page content</div>
+            </MainLayout>
+          </AnalyticsFilterProvider>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Page content');
+
+    const donateLinks = screen.getAllByRole('link', { name: /donate/i });
+    expect(donateLinks.length).toBeGreaterThan(0);
+    for (const link of donateLinks) {
+      expect(link).toHaveAttribute('href', 'https://donorbox.org/support-smash-tracker');
+      expect(link).toHaveAttribute('target', '_blank');
+    }
+  });
 });

--- a/apps/web/src/layouts/SidebarContent.tsx
+++ b/apps/web/src/layouts/SidebarContent.tsx
@@ -65,6 +65,23 @@ export function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
         />
         Training Grounds
       </a>
+
+      {/* Donorbox blue (#41a2d8) kept from the legacy button so it reads as
+          the familiar Donate control rather than another nav item. */}
+      <a
+        href="https://donorbox.org/support-smash-tracker"
+        target="_blank"
+        rel="noreferrer"
+        className="flex items-center justify-center gap-3 rounded-md bg-[#41a2d8] px-3 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+      >
+        <img
+          src="https://donorbox.org/images/white_logo.svg"
+          alt=""
+          role="presentation"
+          className="h-4 shrink-0"
+        />
+        Donate
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Restores the legacy Donorbox button (lost with the CRA deletion) as a sidebar footer link below Training Grounds, linking to https://donorbox.org/support-smash-tracker. Donorbox blue + white logo preserved from the original. Layout test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)