### PR TITLE
V7-C: Stripe credit packs for AI reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,43 @@ gcloud run deploy smash-tracker-api \
 Until both vars are set, every `/api/reports*` route answers `503` and the web app's "Generate AI
 report" button never renders — the rest of the app (including `/api/scout`) is unaffected.
 
+**V7-C: Stripe-powered credit packs (optional)**
+
+By default, `REPORTS_ALLOWED_UIDS` above is the only way to generate reports — everyone else gets a
+`403`. Configuring Stripe additionally lets non-allowlisted users buy credit packs and generate
+reports themselves (uids in `REPORTS_ALLOWED_UIDS` always stay free/unlimited; the paywall exists
+purely to cover the cost of everyone else's Claude API usage). Two more env vars, both required
+together:
+
+- `STRIPE_SECRET_KEY` — a Stripe secret key (`sk_test_...` in test mode, `sk_live_...` in
+  production), from <https://dashboard.stripe.com/apikeys>.
+- `STRIPE_WEBHOOK_SECRET` — the signing secret for the `/api/billing/webhook` endpoint below, from
+  the webhook's settings in the Stripe dashboard.
+
+```sh
+gcloud run deploy smash-tracker-api \
+  --source . \
+  --region us-central1 \
+  --set-env-vars FIREBASE_DATABASE_URL=https://smash-tracker-f97b7-default-rtdb.firebaseio.com,ANTHROPIC_API_KEY=sk-ant-...,REPORTS_ALLOWED_UIDS=uid1,uid2,STRIPE_SECRET_KEY=sk_live_...,STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+Register a webhook endpoint in the Stripe dashboard (<https://dashboard.stripe.com/webhooks>)
+pointing at:
+
+```
+https://<your-cloud-run-service>/api/billing/webhook
+```
+
+subscribed to at least the `checkout.session.completed` event — this is what credits a purchased
+pack onto the buyer's balance. Until both `STRIPE_*` vars are set, every `/api/billing*` route
+answers `503` and non-allowlisted uids get exactly the pre-V7-C `403` on report generation (no
+behavior change; this is an allowlist-only deployment by default).
+
+Credit pack contents and prices (`pack5` = 5 credits / $8.00, `pack15` = 15 credits / $20.00) are a
+single constant, `CREDIT_PACKS` in `packages/shared/src/billing.ts` — edit that one array to change
+pricing or add a pack; both the checkout endpoint and the credits-status endpoint read from it, so
+nothing else needs to change.
+
 **2. Configure `apps/web/.env.production`**
 
 ```sh

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -73,3 +73,23 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 # Comma-separated list of Firebase uids allowed to generate AI reports. This
 # is a paid, per-token feature, so it's opt-in per uid even once a key is set.
 REPORTS_ALLOWED_UIDS=uid1,uid2
+
+# --- V7-C: Stripe-powered credit packs (optional) ---
+# Both values must be set for /api/billing to work; when either is missing,
+# every /api/billing* route answers 503 AND non-allowlisted uids get exactly
+# the pre-V7-C 403 on report generation (no behavior change). Uids in
+# REPORTS_ALLOWED_UIDS above always stay free/unlimited regardless of these
+# vars — this paywall exists only to cover the cost of everyone else's usage.
+# Credit pack prices/credit counts live in packages/shared/src/billing.ts
+# (CREDIT_PACKS) — edit that one constant to change pricing.
+
+# Stripe secret key used to create Checkout Sessions (sk_test_... in test
+# mode, sk_live_... in production). From https://dashboard.stripe.com/apikeys
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+
+# Signing secret for the POST /api/billing/webhook endpoint, from the
+# webhook's settings in the Stripe dashboard
+# (https://dashboard.stripe.com/webhooks). Register the webhook at
+# https://<your-cloud-run-service>/api/billing/webhook, subscribed to at
+# least the `checkout.session.completed` event.
+STRIPE_WEBHOOK_SECRET=whsec_your-webhook-signing-secret

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "fastify-plugin": "^6.0.0",
     "fastify-type-provider-zod": "^7.0.0",
     "firebase-admin": "^14.1.0",
+    "stripe": "^22.3.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,11 +18,12 @@ import opponentNotesRoutes from './routes/opponentNotes.js';
 import startggRoutes from './routes/startgg.js';
 import scoutRoutes from './routes/scout.js';
 import reportsRoutes from './routes/reports.js';
+import billingRoutes, { type StripeLikeClient } from './routes/billing.js';
 import tournamentsRoutes from './routes/tournaments.js';
 import groupsRoutes from './routes/groups.js';
 import { NotFoundError } from './services/rtdb.js';
 import type { FirebaseServices } from './firebase/admin.js';
-import type { ReportsConfig, StartggConfig } from './config/env.js';
+import type { ReportsConfig, StartggConfig, StripeConfig } from './config/env.js';
 import type { AnthropicLikeClient } from './reports/generate.js';
 
 export interface BuildAppOptions {
@@ -37,6 +38,12 @@ export interface BuildAppOptions {
   reports?: ReportsConfig | null;
   /** Overridable Anthropic client for /api/reports (tests). */
   reportsClient?: AnthropicLikeClient;
+  /** Stripe billing config; null/omitted disables /api/billing (503) and gates /api/reports to allowlist-only (pre-V7-C behavior). */
+  stripe?: StripeConfig | null;
+  /** SPA origin Stripe Checkout redirects back to (`env.WEB_BASE_URL`). */
+  webBaseUrl?: string;
+  /** Overridable Stripe client for /api/billing (tests). */
+  stripeClient?: StripeLikeClient;
   logger?: boolean | FastifyBaseLogger;
 }
 
@@ -137,8 +144,15 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(reportsRoutes, {
         config: options.reports ?? null,
         startggConfig: options.startgg ?? null,
+        stripeConfig: options.stripe ?? null,
         client: options.reportsClient,
         fetchImpl: options.startggFetch,
+      });
+      await api.register(billingRoutes, {
+        stripeConfig: options.stripe ?? null,
+        reportsConfig: options.reports ?? null,
+        webBaseUrl: options.webBaseUrl ?? 'http://localhost:5173',
+        stripeClient: options.stripeClient,
       });
     },
     { prefix: '/api' },

--- a/apps/api/src/billing/credits.ts
+++ b/apps/api/src/billing/credits.ts
@@ -1,0 +1,136 @@
+import type { Database } from 'firebase-admin/database';
+import { creditLedgerEntrySchema, type CreditLedgerEntry } from '@smash-tracker/shared';
+
+/**
+ * V7-C: RTDB credit ledger backing the Stripe-powered report-generation
+ * paywall. RTDB layout (see `packages/shared/src/billing.ts`):
+ *
+ * - `credits/{uid}/balance`         -> number (int, >= 0)
+ * - `creditLedger/{uid}/{pushKey}`  -> creditLedgerEntrySchema
+ *
+ * `spendCredit` is the only mutation that can race (concurrent report
+ * generations from the same uid), so it alone uses `Reference.transaction`
+ * on the balance node — every other mutation here is a single-writer path
+ * (Stripe webhook for purchases, the reports route's own error handler for
+ * refunds) and uses a plain read-then-write, mirroring `startgg/sync.ts`'s
+ * convention of keeping non-concurrent writes simple.
+ */
+
+function balanceRef(database: Database, uid: string) {
+  return database.ref(`credits/${uid}/balance`);
+}
+
+function ledgerRef(database: Database, uid: string) {
+  return database.ref(`creditLedger/${uid}`);
+}
+
+async function appendLedgerEntry(
+  database: Database,
+  uid: string,
+  entry: CreditLedgerEntry,
+): Promise<void> {
+  await ledgerRef(database, uid).push().set(creditLedgerEntrySchema.parse(entry));
+}
+
+/** Current credit balance for `uid`; 0 when the uid has never had a ledger entry. */
+export async function getBalance(database: Database, uid: string): Promise<number> {
+  const snapshot = await balanceRef(database, uid).get();
+  if (!snapshot.exists()) {
+    return 0;
+  }
+  const value = snapshot.val();
+  return typeof value === 'number' ? value : 0;
+}
+
+/**
+ * Credits a purchased pack onto `uid`'s balance and appends a `purchase`
+ * ledger entry. `ref` is the Stripe checkout session id — the webhook
+ * handler's idempotency guard (`processedStripeEvents/{eventId}`) is what
+ * actually prevents double-crediting a replayed Stripe event; this function
+ * itself is a plain add, matching the webhook's single-writer nature.
+ */
+export async function addCredits(
+  database: Database,
+  uid: string,
+  amount: number,
+  ref: string,
+): Promise<void> {
+  const current = await getBalance(database, uid);
+  await balanceRef(database, uid).set(current + amount);
+  await appendLedgerEntry(database, uid, {
+    type: 'purchase',
+    amount,
+    createdAt: Date.now(),
+    ref,
+  });
+}
+
+/**
+ * Atomically spends one credit for `uid` via an RTDB transaction on the
+ * balance node, so concurrent report-generation requests from the same uid
+ * can't both observe a positive balance and double-spend. Returns `false`
+ * (no-op, no ledger entry) when the balance is already 0; `true` and appends
+ * a `spend` ledger entry otherwise.
+ */
+export async function spendCredit(database: Database, uid: string, ref: string): Promise<boolean> {
+  const result = await balanceRef(database, uid).transaction((current) => {
+    const balance = typeof current === 'number' ? current : 0;
+    if (balance <= 0) {
+      // Aborts the transaction — no write happens.
+      return undefined;
+    }
+    return balance - 1;
+  });
+
+  if (!result.committed) {
+    return false;
+  }
+
+  await appendLedgerEntry(database, uid, {
+    type: 'spend',
+    amount: -1,
+    createdAt: Date.now(),
+    ref,
+  });
+  return true;
+}
+
+/**
+ * Refunds one credit to `uid` after a failed generation (every failure path
+ * after `spendCredit` succeeded must call this — see `routes/reports.ts`).
+ * A plain add is safe here without a transaction: refunds only ever follow a
+ * spend the caller itself just made, so there's no concurrent-refund race to
+ * guard against for a single request.
+ */
+export async function refundCredit(database: Database, uid: string, ref: string): Promise<void> {
+  const current = await getBalance(database, uid);
+  await balanceRef(database, uid).set(current + 1);
+  await appendLedgerEntry(database, uid, {
+    type: 'refund',
+    amount: 1,
+    createdAt: Date.now(),
+    ref,
+  });
+}
+
+/**
+ * Idempotency guard for Stripe webhook deliveries: Stripe retries delivery
+ * on any non-2xx/timeout response, so the same `checkout.session.completed`
+ * event can arrive more than once. Returns `true` (and marks the event
+ * processed) the first time `eventId` is seen; `false` for a replay, which
+ * the webhook route treats as a no-op success.
+ */
+export async function markStripeEventProcessed(
+  database: Database,
+  eventId: string,
+): Promise<boolean> {
+  const ref = database.ref(`processedStripeEvents/${eventId}`);
+  const result = await ref.transaction((current) => {
+    if (current !== null && current !== undefined) {
+      // Already processed — abort, no write.
+      return undefined;
+    }
+    return Date.now();
+  });
+  return result.committed;
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -53,6 +53,14 @@ const envSchema = z.object({
   ANTHROPIC_API_KEY: z.string().optional(),
   /** Comma-separated list of Firebase uids allowed to generate AI reports. */
   REPORTS_ALLOWED_UIDS: z.string().optional(),
+
+  // ---- V7-C: Stripe-powered credit packs (all optional — when incomplete,
+  // /api/billing routes answer 503 and non-allowlisted uids get the exact
+  // pre-V7-C 403 on report generation, i.e. no behavior change) -------------
+  /** Stripe secret key used to create Checkout Sessions. */
+  STRIPE_SECRET_KEY: z.string().optional(),
+  /** Signing secret for the `POST /api/billing/webhook` endpoint. */
+  STRIPE_WEBHOOK_SECRET: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -140,5 +148,28 @@ export function getReportsConfig(env: Env): ReportsConfig | null {
   return {
     anthropicApiKey: env.ANTHROPIC_API_KEY,
     allowedUids,
+  };
+}
+
+export interface StripeConfig {
+  secretKey: string;
+  webhookSecret: string;
+}
+
+/**
+ * Assembles the Stripe config when fully present (a secret key AND a webhook
+ * signing secret), else null — same all-or-nothing pattern as
+ * `getStartggConfig`/`getReportsConfig`. When null, `/api/billing/*` routes
+ * answer 503 and non-allowlisted uids get the same 403 on report generation
+ * that existed before V7-C (no behavior change for deployments that don't
+ * opt in to billing).
+ */
+export function getStripeConfig(env: Env): StripeConfig | null {
+  if (!env.STRIPE_SECRET_KEY || !env.STRIPE_WEBHOOK_SECRET) {
+    return null;
+  }
+  return {
+    secretKey: env.STRIPE_SECRET_KEY,
+    webhookSecret: env.STRIPE_WEBHOOK_SECRET,
   };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,11 @@
 import { buildApp } from './app.js';
-import { getReportsConfig, getStartggConfig, loadEnv, parseCorsOrigins } from './config/env.js';
+import {
+  getReportsConfig,
+  getStartggConfig,
+  getStripeConfig,
+  loadEnv,
+  parseCorsOrigins,
+} from './config/env.js';
 import { initFirebase } from './firebase/admin.js';
 
 let env;
@@ -17,6 +23,8 @@ const app = buildApp({
   corsOrigin: parseCorsOrigins(env.CORS_ORIGIN),
   startgg: getStartggConfig(env),
   reports: getReportsConfig(env),
+  stripe: getStripeConfig(env),
+  webBaseUrl: env.WEB_BASE_URL,
 });
 
 app

--- a/apps/api/src/routes/billing.test.ts
+++ b/apps/api/src/routes/billing.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, it, vi } from 'vitest';
+import type Stripe from 'stripe';
+import type { ReportsConfig, StripeConfig } from '../config/env.js';
+import type { StripeLikeClient } from './billing.js';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+const STRIPE_CONFIG: StripeConfig = {
+  secretKey: 'sk-test-123',
+  webhookSecret: 'whsec-test-456',
+};
+
+const REPORTS_CONFIG: ReportsConfig = {
+  anthropicApiKey: 'sk-anthropic-test',
+  allowedUids: new Set(['someone-else']),
+};
+
+const FREE_REPORTS_CONFIG: ReportsConfig = {
+  anthropicApiKey: 'sk-anthropic-test',
+  allowedUids: new Set([TEST_UID]),
+};
+
+function stubStripeClient(overrides: Partial<StripeLikeClient> = {}): StripeLikeClient {
+  return {
+    checkout: {
+      sessions: {
+        create: vi.fn(async () => ({ url: 'https://checkout.stripe.com/session/test' })),
+      },
+    },
+    webhooks: {
+      constructEvent: vi.fn(() => {
+        throw new Error('constructEvent stub not configured for this test');
+      }),
+    },
+    ...overrides,
+  };
+}
+
+function makeCheckoutCompletedEvent(overrides: {
+  id?: string;
+  uid?: string;
+  packId?: string;
+}): Stripe.Event {
+  return {
+    id: overrides.id ?? 'evt_test_1',
+    object: 'event',
+    type: 'checkout.session.completed',
+    data: {
+      object: {
+        id: 'cs_test_1',
+        object: 'checkout.session',
+        metadata: {
+          uid: overrides.uid ?? TEST_UID,
+          packId: overrides.packId ?? 'pack5',
+        },
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+describe('/api/billing (unconfigured)', () => {
+  it('answers 503 on GET /billing/credits when stripe config is missing', async () => {
+    const { app } = buildTestApp({ reports: REPORTS_CONFIG });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/billing/credits',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 on POST /billing/checkout when stripe config is missing', async () => {
+    const { app } = buildTestApp({ reports: REPORTS_CONFIG });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/checkout',
+      headers: authHeader(),
+      payload: { packId: 'pack5' },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 on POST /billing/webhook when stripe config is missing', async () => {
+    const { app } = buildTestApp({ reports: REPORTS_CONFIG });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'anything', 'content-type': 'application/json' },
+      payload: JSON.stringify({}),
+    });
+    expect(response.statusCode).toBe(503);
+  });
+});
+
+describe('GET /api/billing/credits (configured)', () => {
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({ method: 'GET', url: '/api/billing/credits' });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('reports freeAccess: true and packs for an allowlisted uid, ignoring balance', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: FREE_REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/billing/credits',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.freeAccess).toBe(true);
+    expect(body.balance).toBe(0);
+    expect(body.packs).toEqual([
+      { id: 'pack5', credits: 5, amountCents: 800, label: '5 reports' },
+      { id: 'pack15', credits: 15, amountCents: 2000, label: '15 reports' },
+    ]);
+  });
+
+  it('reports freeAccess: false and the current balance for a non-allowlisted uid', async () => {
+    const { app, database } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 3);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/billing/credits',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ freeAccess: false, balance: 3 });
+  });
+
+  it('reports freeAccess: false when reportsConfig is entirely absent', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/billing/credits',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ freeAccess: false, balance: 0 });
+  });
+});
+
+describe('POST /api/billing/checkout (configured)', () => {
+  it('requires auth', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/checkout',
+      payload: { packId: 'pack5' },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('rejects an unknown packId with 400', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/checkout',
+      headers: authHeader(),
+      payload: { packId: 'pack1000' },
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('looks up the pack server-side and creates a Checkout Session with the correct params, ignoring any client amount', async () => {
+    const create = vi.fn(async (params: Stripe.Checkout.SessionCreateParams) => ({
+      url: 'https://checkout.stripe.com/session/abc',
+      params,
+    }));
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      webBaseUrl: 'https://app.example.com',
+      stripeClient: stubStripeClient({
+        checkout: { sessions: { create } },
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/checkout',
+      headers: authHeader(),
+      // Even if a client tried to sneak in an amount, the body schema only
+      // accepts packId — this also documents that intent.
+      payload: { packId: 'pack15' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ url: 'https://checkout.stripe.com/session/abc' });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const params = create.mock.calls[0]![0];
+    expect(params).toMatchObject({
+      mode: 'payment',
+      client_reference_id: TEST_UID,
+      metadata: { uid: TEST_UID, packId: 'pack15' },
+      success_url: 'https://app.example.com/scout?billing=success',
+      cancel_url: 'https://app.example.com/scout?billing=cancelled',
+    });
+    expect(params.line_items).toEqual([
+      {
+        price_data: {
+          currency: 'usd',
+          unit_amount: 2000,
+          product_data: { name: 'Smash Tracker — AI report credits (15 reports)' },
+        },
+        quantity: 1,
+      },
+    ]);
+  });
+});
+
+describe('POST /api/billing/webhook (configured)', () => {
+  it('answers 400 when the stripe-signature header is missing', async () => {
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient(),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ foo: 'bar' }),
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('answers 400 when signature verification fails', async () => {
+    const constructEvent = vi.fn(() => {
+      throw new Error('invalid signature');
+    });
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({ webhooks: { constructEvent } }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'bad-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({ foo: 'bar' }),
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('credits the balance and appends a purchase ledger entry on checkout.session.completed', async () => {
+    const event = makeCheckoutCompletedEvent({ id: 'evt_1', uid: TEST_UID, packId: 'pack5' });
+    const constructEvent = vi.fn(() => event);
+    const { app, database } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({ webhooks: { constructEvent } }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({ irrelevant: 'raw body, verified via the stub' }),
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const balanceSnapshot = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balanceSnapshot.val()).toBe(5);
+
+    const dump = database.dump() as Record<string, unknown>;
+    const ledger = dump.creditLedger as Record<string, Record<string, unknown>>;
+    const entries = Object.values(ledger[TEST_UID]!);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: 'purchase', amount: 5, ref: 'evt_1' });
+  });
+
+  it('does not double-credit a replayed event id', async () => {
+    const event = makeCheckoutCompletedEvent({ id: 'evt_replay', uid: TEST_UID, packId: 'pack5' });
+    const constructEvent = vi.fn(() => event);
+    const { app, database } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({ webhooks: { constructEvent } }),
+    });
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({ n: 1 }),
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({ n: 1 }),
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+
+    const balanceSnapshot = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balanceSnapshot.val()).toBe(5);
+
+    const dump = database.dump() as Record<string, unknown>;
+    const ledger = dump.creditLedger as Record<string, Record<string, unknown>>;
+    expect(Object.values(ledger[TEST_UID]!)).toHaveLength(1);
+  });
+
+  it('answers 200 (acknowledged) for an unknown event type without crediting anything', async () => {
+    const constructEvent = vi.fn(
+      () =>
+        ({
+          id: 'evt_other',
+          object: 'event',
+          type: 'payment_intent.succeeded',
+          data: { object: {} },
+        }) as unknown as Stripe.Event,
+    );
+    const { app, database } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({ webhooks: { constructEvent } }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({}),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const dump = database.dump() as Record<string, unknown>;
+    expect(dump.credits).toBeUndefined();
+  });
+
+  it('does not require Firebase auth (no Authorization header needed)', async () => {
+    const event = makeCheckoutCompletedEvent({ id: 'evt_public', uid: TEST_UID });
+    const constructEvent = vi.fn(() => event);
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({ webhooks: { constructEvent } }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({}),
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('the raw-body content-type parser is scoped to the webhook route only — POST /billing/checkout still gets parsed JSON', async () => {
+    const create = vi.fn(async () => ({ url: 'https://checkout.stripe.com/session/xyz' }));
+    const constructEventImpl: StripeLikeClient['webhooks']['constructEvent'] = () =>
+      makeCheckoutCompletedEvent({ id: 'evt_scope' });
+    const constructEvent = vi.fn(constructEventImpl);
+    const { app } = buildTestApp({
+      stripe: STRIPE_CONFIG,
+      reports: REPORTS_CONFIG,
+      stripeClient: stubStripeClient({
+        checkout: { sessions: { create } },
+        webhooks: { constructEvent },
+      }),
+    });
+
+    // If the webhook's raw-body parser had leaked to the whole plugin scope,
+    // `request.body` here would be a raw Buffer instead of the parsed
+    // `{ packId: 'pack5' }` object, and the zod body-schema validation for
+    // this route (which runs against a parsed object) would reject it.
+    const checkoutResponse = await app.inject({
+      method: 'POST',
+      url: '/api/billing/checkout',
+      headers: authHeader(),
+      payload: { packId: 'pack5' },
+    });
+    expect(checkoutResponse.statusCode).toBe(200);
+
+    // And the webhook route itself still gets the raw bytes it needs.
+    const webhookResponse = await app.inject({
+      method: 'POST',
+      url: '/api/billing/webhook',
+      headers: { 'stripe-signature': 'good-sig', 'content-type': 'application/json' },
+      payload: JSON.stringify({ some: 'payload' }),
+    });
+    expect(webhookResponse.statusCode).toBe(200);
+    expect(constructEvent).toHaveBeenCalledTimes(1);
+    const [rawPayload] = constructEvent.mock.calls[0]!;
+    expect(Buffer.isBuffer(rawPayload) || typeof rawPayload === 'string').toBe(true);
+  });
+});

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -1,0 +1,230 @@
+import Stripe from 'stripe';
+import type { FastifyInstance } from 'fastify';
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import {
+  checkoutRequestSchema,
+  checkoutResponseSchema,
+  creditsStatusSchema,
+  errorResponseSchema,
+  CREDIT_PACKS,
+} from '@smash-tracker/shared';
+import type { ReportsConfig, StripeConfig } from '../config/env.js';
+import { addCredits, getBalance, markStripeEventProcessed } from '../billing/credits.js';
+
+/**
+ * Minimal structural seam over the `stripe` client — just the two calls this
+ * plugin makes. Lets tests inject a stub instead of a real `Stripe` instance
+ * (which would otherwise require a live secret key / network access).
+ */
+export interface StripeLikeClient {
+  checkout: {
+    sessions: {
+      create: (params: Stripe.Checkout.SessionCreateParams) => Promise<{ url: string | null }>;
+    };
+  };
+  webhooks: {
+    constructEvent: (
+      payload: string | Buffer,
+      signature: string | string[],
+      secret: string,
+    ) => Stripe.Event;
+  };
+}
+
+export interface BillingRoutesOptions {
+  stripeConfig: StripeConfig | null;
+  reportsConfig: ReportsConfig | null;
+  /** SPA origin Checkout redirects back to (`env.WEB_BASE_URL`). */
+  webBaseUrl: string;
+  /** Overridable Stripe client (tests); a real `Stripe` instance is built when omitted. */
+  stripeClient?: StripeLikeClient;
+}
+
+/**
+ * /api/billing — V7-C: Stripe-powered credit packs that gate AI report
+ * generation (`routes/reports.ts`) for everyone except `REPORTS_ALLOWED_UIDS`
+ * (unchanged free/unlimited allowlist). Requires `stripeConfig` (secret key +
+ * webhook signing secret, both present — see `getStripeConfig`); when
+ * missing, every `/billing*` route answers 503, same shape `reports.ts` and
+ * `scout.ts` use for their own optional dependencies.
+ *
+ * `POST /billing/webhook` is the one PUBLIC route in this plugin (Stripe
+ * calls it directly, no Firebase ID token) and needs the RAW request body to
+ * verify `stripe-signature` — the raw-body content-type parser is registered
+ * on `app` (this plugin's own encapsulated Fastify context via
+ * `fastify.register`), so it does not leak to sibling plugins/routes that
+ * still want normal JSON body parsing (see `billing.test.ts` for a test that
+ * asserts exactly this).
+ */
+const billingRoutes: FastifyPluginAsyncZod<BillingRoutesOptions> = async (app, options) => {
+  const { stripeConfig, reportsConfig, webBaseUrl } = options;
+
+  if (!stripeConfig) {
+    app.all('/billing*', async (_request, reply) => {
+      return reply.code(503).send({
+        error: 'Service Unavailable',
+        message: 'Billing is not enabled on this server',
+        statusCode: 503,
+      });
+    });
+    return;
+  }
+
+  const stripe: StripeLikeClient = options.stripeClient ?? new Stripe(stripeConfig.secretKey);
+
+  // GET /api/billing/credits — authed.
+  app.get(
+    '/billing/credits',
+    {
+      preHandler: app.authenticate,
+      schema: {
+        response: {
+          200: creditsStatusSchema,
+        },
+      },
+    },
+    async (request) => {
+      const freeAccess = reportsConfig?.allowedUids.has(request.uid) ?? false;
+      const balance = await getBalance(app.firebase.database, request.uid);
+      return {
+        freeAccess,
+        balance,
+        packs: CREDIT_PACKS.map((pack) => ({ ...pack })),
+      };
+    },
+  );
+
+  // POST /api/billing/checkout — authed. Creates a Stripe Checkout Session
+  // for a credit pack, looked up server-side (NEVER trust a client-supplied
+  // amount).
+  app.post(
+    '/billing/checkout',
+    {
+      preHandler: app.authenticate,
+      schema: {
+        body: checkoutRequestSchema,
+        response: {
+          200: checkoutResponseSchema,
+          400: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const pack = CREDIT_PACKS.find((candidate) => candidate.id === request.body.packId);
+      if (!pack) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'Unknown credit pack',
+          statusCode: 400,
+        });
+      }
+
+      const session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        line_items: [
+          {
+            price_data: {
+              currency: 'usd',
+              unit_amount: pack.amountCents,
+              product_data: {
+                name: `Smash Tracker — AI report credits (${pack.label})`,
+              },
+            },
+            quantity: 1,
+          },
+        ],
+        client_reference_id: request.uid,
+        metadata: { uid: request.uid, packId: pack.id },
+        success_url: `${webBaseUrl}/scout?billing=success`,
+        cancel_url: `${webBaseUrl}/scout?billing=cancelled`,
+      });
+
+      if (!session.url) {
+        throw new Error('Stripe Checkout Session was created without a url');
+      }
+
+      return { url: session.url };
+    },
+  );
+
+  // POST /api/billing/webhook — PUBLIC (Stripe calls this directly).
+  // Registered in its own nested plugin scope so the raw-body content-type
+  // parser below applies ONLY to this route, not to sibling JSON routes like
+  // POST /billing/checkout above — Fastify content-type parsers are
+  // encapsulated per-plugin-context, and `app.register` creates a new child
+  // context (see billing.test.ts for a test asserting the isolation holds).
+  await app.register(async (webhookScope: FastifyInstance) => {
+    // Fastify parses JSON by default; `stripe.webhooks.constructEvent` needs
+    // the RAW bytes to verify the signature, so re-register the
+    // 'application/json' parser here to hand back the raw buffer untouched.
+    webhookScope.addContentTypeParser(
+      'application/json',
+      { parseAs: 'buffer' },
+      (_request, body, done) => {
+        done(null, body);
+      },
+    );
+
+    webhookScope.post('/billing/webhook', async (request, reply) => {
+      const signature = request.headers['stripe-signature'];
+      if (!signature) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'Missing stripe-signature header',
+          statusCode: 400,
+        });
+      }
+
+      const rawBody = request.body;
+      if (typeof rawBody !== 'string' && !Buffer.isBuffer(rawBody)) {
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'Missing request body',
+          statusCode: 400,
+        });
+      }
+
+      let event: Stripe.Event;
+      try {
+        event = stripe.webhooks.constructEvent(rawBody, signature, stripeConfig.webhookSecret);
+      } catch (err) {
+        request.log.warn({ err }, 'Stripe webhook signature verification failed');
+        return reply.code(400).send({
+          error: 'Bad Request',
+          message: 'Invalid Stripe webhook signature',
+          statusCode: 400,
+        });
+      }
+
+      if (event.type !== 'checkout.session.completed') {
+        // Unknown/irrelevant event types are acknowledged, not treated as errors.
+        return reply.code(200).send();
+      }
+
+      const session = event.data.object as Stripe.Checkout.Session;
+      const uid = session.metadata?.uid;
+      const packId = session.metadata?.packId;
+      const pack = CREDIT_PACKS.find((candidate) => candidate.id === packId);
+
+      if (!uid || !pack) {
+        request.log.error(
+          { eventId: event.id, uid, packId },
+          'Stripe checkout.session.completed missing uid/packId metadata or unknown pack',
+        );
+        return reply.code(200).send();
+      }
+
+      const shouldProcess = await markStripeEventProcessed(app.firebase.database, event.id);
+      if (!shouldProcess) {
+        // Replayed delivery of an event we've already credited — no-op.
+        return reply.code(200).send();
+      }
+
+      await addCredits(app.firebase.database, uid, pack.credits, event.id);
+
+      return reply.code(200).send();
+    });
+  });
+};
+
+export default billingRoutes;

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -151,7 +151,7 @@ describe('GET /api/reports/config (configured)', () => {
       headers: authHeader(),
     });
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ enabled: true });
+    expect(response.json()).toMatchObject({ enabled: true, freeAccess: true });
   });
 
   it('returns enabled: false for a non-allowlisted uid (never 403s)', async () => {
@@ -174,7 +174,7 @@ describe('GET /api/reports/config (configured)', () => {
       headers: authHeader(),
     });
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ enabled: false });
+    expect(response.json()).toMatchObject({ enabled: false, freeAccess: false });
   });
 });
 
@@ -414,6 +414,260 @@ describe('POST /api/reports (configured, allowlisted)', () => {
       payload: { query: 'user/07dc2239' },
     });
     expect(response.statusCode).toBe(502);
+  });
+});
+
+describe('POST /api/reports (V7-C: non-allowlisted, Stripe-gated)', () => {
+  const NON_ALLOWLIST_CONFIG: ReportsConfig = {
+    anthropicApiKey: 'sk-test-key',
+    allowedUids: new Set(['someone-else']),
+  };
+  const STRIPE_CONFIG = {
+    secretKey: 'sk-test-123',
+    webhookSecret: 'whsec-test-456',
+  };
+
+  it('still returns 403 for a non-allowlisted uid when Stripe is not configured (pre-V7-C behavior, unchanged)', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('returns 402 when Stripe is configured but the caller has a zero credit balance', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(402);
+    expect(response.json().message).toMatch(/credits/i);
+  });
+
+  it('spends exactly one credit on a successful generation', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 3);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(2);
+
+    const dump = database.dump() as Record<string, unknown>;
+    const ledger = dump.creditLedger as Record<string, Record<string, unknown>>;
+    const entries = Object.values(ledger[TEST_UID]!);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: 'spend', amount: -1 });
+  });
+
+  it('refunds the credit when the scout lookup 404s', async () => {
+    const fetchMock = (async () => gqlResponse({ user: null })) as typeof fetch;
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: fetchMock,
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/doesnotexist' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(1);
+
+    const dump = database.dump() as Record<string, unknown>;
+    const ledger = dump.creditLedger as Record<string, Record<string, unknown>>;
+    const entries = Object.values(ledger[TEST_UID]!);
+    expect(entries.map((e) => (e as { type: string }).type)).toEqual(['spend', 'refund']);
+  });
+
+  it('refunds the credit when generation fails (ReportGenerationError)', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({ stop_reason: 'refusal', parsed_output: null })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+
+    expect(response.statusCode).toBe(502);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(1);
+  });
+
+  it('refunds the credit on a start.gg 429', async () => {
+    const fetchMock = (async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes('ResolveBySlug')) {
+        return gqlResponse(RESOLVE_RESPONSE);
+      }
+      return new Response('rate limited', { status: 429 });
+    }) as typeof fetch;
+
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: fetchMock,
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+
+    expect(response.statusCode).toBe(429);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(1);
+  });
+
+  it('does not spend a credit for a 400 (malformed input) — nothing was attempted', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'not a valid start.gg reference' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(1);
+  });
+
+  it('allowlisted uids stay free/unlimited even when Stripe is configured and their credit balance is 0', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.exists()).toBe(false);
+  });
+
+  it('concurrent requests cannot both spend the last credit (RTDB transaction on the balance node)', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const [first, second] = await Promise.all([
+      app.inject({
+        method: 'POST',
+        url: '/api/reports',
+        headers: authHeader(),
+        payload: { query: 'user/07dc2239' },
+      }),
+      app.inject({
+        method: 'POST',
+        url: '/api/reports',
+        headers: authHeader(),
+        payload: { query: 'user/07dc2239' },
+      }),
+    ]);
+
+    const statusCodes = [first.statusCode, second.statusCode].sort();
+    // Exactly one request should succeed (spends the single credit); the
+    // other must see a zero balance and get 402 — never both succeeding.
+    expect(statusCodes).toEqual([200, 402]);
+
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(0);
   });
 });
 

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import {
@@ -6,7 +7,7 @@ import {
   reportsConfigSchema,
   scoutReportRecordSchema,
 } from '@smash-tracker/shared';
-import type { ReportsConfig, StartggConfig } from '../config/env.js';
+import type { ReportsConfig, StartggConfig, StripeConfig } from '../config/env.js';
 import { StartggApiError } from '../startgg/client.js';
 import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
 import {
@@ -16,10 +17,13 @@ import {
   ReportGenerationError,
   type AnthropicLikeClient,
 } from '../reports/generate.js';
+import { refundCredit, spendCredit } from '../billing/credits.js';
 
 export interface ReportsRoutesOptions {
   config: ReportsConfig | null;
   startggConfig: StartggConfig | null;
+  /** V7-C: Stripe billing config; null disables credit purchases (pre-V7-C 403 behavior for non-allowlisted uids). */
+  stripeConfig: StripeConfig | null;
   /** Overridable Anthropic client (tests) — a real client is built when omitted. */
   client?: AnthropicLikeClient;
   /** Overridable fetch for the start.gg GraphQL calls (tests). */
@@ -41,10 +45,24 @@ const reportIdParamsSchema = z.object({
  * because report generation spends real Claude API tokens per request — this
  * is a paid feature, not a general one. `/reports/config` never 403s (it's
  * how the web app decides whether to show the "Generate AI report" button at
- * all); every other route 403s for a signed-in-but-not-allowlisted uid.
+ * all); every other route 403s for a signed-in-but-not-allowlisted uid
+ * UNLESS a signed-in-but-not-allowlisted uid has both Stripe configured
+ * (V7-C) on this deployment AND spendable credits.
+ *
+ * V7-C billing: allowlisted uids (`config.allowedUids`) stay free/unlimited,
+ * unchanged from V7-B — the paywall exists purely to cover the OWNER's own
+ * Anthropic API costs from everyone else's usage. For a non-allowlisted uid:
+ * when `stripeConfig` is null (Stripe not configured on this deployment),
+ * behavior is EXACTLY the pre-V7-C 403 (no behavior change); when
+ * `stripeConfig` is present, `POST /reports` spends one credit up front
+ * (`spendCredit`, RTDB-transaction-safe against concurrent requests) and
+ * refunds it (`refundCredit`) on every failure path after that point — a
+ * failed generation must never cost the caller a credit. A zero balance at
+ * spend time answers 402, which is the web app's cue to open the "buy
+ * credits" dialog.
  */
 const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, options) => {
-  const { config, startggConfig } = options;
+  const { config, startggConfig, stripeConfig } = options;
 
   if (!config || !startggConfig) {
     app.all('/reports*', async (_request, reply) => {
@@ -65,7 +83,9 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
   app.addHook('preHandler', app.authenticate);
 
   // GET /api/reports/config — never 403s; tells the web app whether to show
-  // the "Generate AI report" button for the signed-in user.
+  // the "Generate AI report" button for the signed-in user, and (V7-C)
+  // whether billing is available so it can show the credits indicator / buy
+  // dialog for non-allowlisted users.
   app.get(
     '/reports/config',
     {
@@ -76,7 +96,13 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       },
     },
     async (request) => {
-      return { enabled: config.allowedUids.has(request.uid) };
+      const freeAccess = config.allowedUids.has(request.uid);
+      const billingEnabled = stripeConfig !== null;
+      return {
+        enabled: freeAccess || billingEnabled,
+        freeAccess,
+        billingEnabled,
+      };
     },
   );
 
@@ -89,6 +115,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         response: {
           200: scoutReportRecordSchema,
           400: errorResponseSchema,
+          402: errorResponseSchema,
           403: errorResponseSchema,
           404: errorResponseSchema,
           429: errorResponseSchema,
@@ -97,7 +124,9 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       },
     },
     async (request, reply) => {
-      if (!config.allowedUids.has(request.uid)) {
+      const freeAccess = config.allowedUids.has(request.uid);
+
+      if (!freeAccess && !stripeConfig) {
         return reply.code(403).send({
           error: 'Forbidden',
           message: 'AI reports are not enabled for this account',
@@ -119,22 +148,50 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         throw err;
       }
 
+      // V7-C: non-allowlisted uids spend one credit per generation attempt.
+      // Spent up front (before the start.gg/Claude calls) so a concurrent
+      // second request from the same uid can't both observe a positive
+      // balance (spendCredit uses an RTDB transaction) — refunded on any
+      // failure below. `creditRef` ties the spend and a possible refund to
+      // the same request in the ledger.
+      const creditRef = `reports:${request.uid}:${randomUUID()}`;
+      let spent = false;
+      if (!freeAccess) {
+        spent = await spendCredit(app.firebase.database, request.uid, creditRef);
+        if (!spent) {
+          return reply.code(402).send({
+            error: 'Payment Required',
+            message: 'You need report credits — buy a pack to continue',
+            statusCode: 402,
+          });
+        }
+      }
+
+      async function refundIfSpent(): Promise<void> {
+        if (spent) {
+          await refundCredit(app.firebase.database, request.uid, creditRef);
+        }
+      }
+
       let scout;
       try {
         scout = await scoutPlayer(startggConfig.apiToken, input, fetchImpl, scoutCache);
       } catch (err) {
         if (err instanceof StartggApiError && err.status === 429) {
+          await refundIfSpent();
           return reply.code(429).send({
             error: 'Too Many Requests',
             message: 'start.gg is rate-limiting requests right now — try again shortly',
             statusCode: 429,
           });
         }
+        await refundIfSpent();
         request.log.error({ err }, 'start.gg scout lookup failed during report generation');
         throw err;
       }
 
       if (!scout) {
+        await refundIfSpent();
         return reply.code(404).send({
           error: 'Not Found',
           message: 'No start.gg player found for that query',
@@ -149,6 +206,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         report = await generateScoutReport(client, payload);
       } catch (err) {
         if (err instanceof ReportGenerationError) {
+          await refundIfSpent();
           const message =
             err.reason === 'refusal'
               ? 'The model declined to generate a report for this request'
@@ -162,6 +220,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
           });
         }
         if (err instanceof Anthropic.RateLimitError) {
+          await refundIfSpent();
           return reply.code(429).send({
             error: 'Too Many Requests',
             message: 'Claude is rate-limiting requests right now — try again shortly',
@@ -169,6 +228,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
           });
         }
         if (err instanceof Anthropic.APIError) {
+          await refundIfSpent();
           request.log.error({ err }, 'Claude report generation failed');
           return reply.code(502).send({
             error: 'Bad Gateway',
@@ -176,6 +236,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
             statusCode: 502,
           });
         }
+        await refundIfSpent();
         throw err;
       }
 
@@ -186,10 +247,18 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         player: scout.player,
         report,
       };
-      await ref.set(record);
+      try {
+        await ref.set(record);
+      } catch (err) {
+        await refundIfSpent();
+        throw err;
+      }
 
       const id = ref.key;
       if (!id) {
+        // The report was generated and stored — this is a server bug (push()
+        // failing to yield a key), not a failed generation, so the spent
+        // credit is NOT refunded here.
         throw new Error('Failed to generate a push key for the new scout report');
       }
 

--- a/apps/api/src/test-support/fakeDatabase.ts
+++ b/apps/api/src/test-support/fakeDatabase.ts
@@ -9,6 +9,11 @@
  * - `.push()` generates a unique string key and returns a ref-like object
  *   whose `.key` is available synchronously (as real RTDB's push() does).
  * - `DataSnapshot.exists()`/`val()` reflect the current in-memory tree.
+ * - `.transaction(updateFn)` runs synchronously against the in-memory tree
+ *   (there's no concurrent access in tests, so every attempt "wins" on the
+ *   first try) and mirrors the real SDK's `{ committed, snapshot }` result —
+ *   `updateFn` returning `undefined` aborts the transaction without writing,
+ *   matching real RTDB semantics.
  */
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
@@ -18,6 +23,11 @@ export interface FakeSnapshot {
   val(): unknown;
 }
 
+export interface FakeTransactionResult {
+  committed: boolean;
+  snapshot: FakeSnapshot;
+}
+
 export interface FakeReference {
   key: string | null;
   get(): Promise<FakeSnapshot>;
@@ -25,6 +35,7 @@ export interface FakeReference {
   update(value: Record<string, unknown>): Promise<void>;
   remove(): Promise<void>;
   push(value?: unknown): FakeReference & { key: string };
+  transaction(updateFn: (current: unknown) => unknown): Promise<FakeTransactionResult>;
 }
 
 function makeSnapshot(value: unknown): FakeSnapshot {
@@ -143,6 +154,15 @@ export class FakeDatabase {
           void childRef.set(value);
         }
         return childRef;
+      },
+      transaction: async (updateFn: (current: unknown) => unknown) => {
+        const current = this.getAtPath(segments);
+        const next = updateFn(current);
+        if (next === undefined) {
+          return { committed: false, snapshot: makeSnapshot(current) };
+        }
+        this.setAtPath(segments, next);
+        return { committed: true, snapshot: makeSnapshot(this.getAtPath(segments)) };
       },
     };
 

--- a/apps/api/src/test-support/testApp.ts
+++ b/apps/api/src/test-support/testApp.ts
@@ -11,7 +11,13 @@ export const TEST_TOKEN = 'valid-test-token';
 export function buildTestApp(
   options: Pick<
     Parameters<typeof buildApp>[0],
-    'startgg' | 'startggFetch' | 'reports' | 'reportsClient'
+    | 'startgg'
+    | 'startggFetch'
+    | 'reports'
+    | 'reportsClient'
+    | 'stripe'
+    | 'webBaseUrl'
+    | 'stripeClient'
   > = {},
 ) {
   const database = new FakeDatabase();

--- a/apps/web/src/hooks/useBilling.test.tsx
+++ b/apps/web/src/hooks/useBilling.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useCheckout, useCredits } from './useBilling';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+import { AuthProvider } from '@/context/AuthContext';
+
+const billingCredits = vi.fn();
+const billingCheckout = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    billing: {
+      credits: (...args: unknown[]) => billingCredits(...args),
+      checkout: (...args: unknown[]) => billingCheckout(...args),
+    },
+  },
+}));
+
+const CREDITS_STATUS = {
+  freeAccess: false,
+  balance: 4,
+  packs: [
+    { id: 'pack5', credits: 5, amountCents: 800, label: '5 reports' },
+    { id: 'pack15', credits: 15, amountCents: 2000, label: '15 reports' },
+  ],
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = [new QueryClient({ defaultOptions: { queries: { retry: false } } })];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function CreditsProbe() {
+  const credits = useCredits();
+  if (!credits.isSuccess) {
+    return <div>loading</div>;
+  }
+  return (
+    <div>
+      balance: {credits.data.balance}, freeAccess: {String(credits.data.freeAccess)}, packs:{' '}
+      {credits.data.packs.length}
+    </div>
+  );
+}
+
+function CheckoutProbe() {
+  const checkout = useCheckout();
+  return (
+    <div>
+      <button onClick={() => checkout.mutate('pack5')}>checkout</button>
+      {checkout.isPending && <div>redirecting</div>}
+    </div>
+  );
+}
+
+describe('useBilling', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('useCredits resolves the credits status response', async () => {
+    billingCredits.mockResolvedValue(CREDITS_STATUS);
+
+    render(
+      <Wrapper>
+        <CreditsProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('balance: 4, freeAccess: false, packs: 2')).toBeInTheDocument(),
+    );
+  });
+
+  it('useCheckout posts the packId and redirects the browser to the returned url', async () => {
+    billingCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/session/abc' });
+    const assignSpy = vi.fn();
+    vi.stubGlobal('location', { ...window.location, assign: assignSpy });
+
+    render(
+      <Wrapper>
+        <CheckoutProbe />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByText('checkout'));
+
+    await waitFor(() => expect(billingCheckout).toHaveBeenCalledWith('pack5'));
+    await waitFor(() =>
+      expect(assignSpy).toHaveBeenCalledWith('https://checkout.stripe.com/session/abc'),
+    );
+  });
+});

--- a/apps/web/src/hooks/useBilling.ts
+++ b/apps/web/src/hooks/useBilling.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CreditPackId } from '@smash-tracker/shared';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const creditsQueryKey = ['billing', 'credits'] as const;
+
+/**
+ * GET /api/billing/credits — V7-C: the signed-in user's billing status
+ * (whether they're on the free allowlist, their credit balance, and the
+ * purchasable packs). Short `staleTime` (unlike `useReportsConfig`) because
+ * the balance changes with usage and purchases within a session — the Scout
+ * page also polls this after a Stripe Checkout redirect back (webhook
+ * delivery can lag the redirect).
+ */
+export function useCredits() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: creditsQueryKey,
+    queryFn: () => api.billing.credits(),
+    enabled: Boolean(user),
+    staleTime: 30 * 1000,
+  });
+}
+
+/**
+ * POST /api/billing/checkout — creates a Stripe Checkout Session for a pack
+ * and redirects the browser to Stripe's hosted page on success. This is a
+ * full-page navigation (not an XHR-driven UI update), matching the
+ * start.gg OAuth connect flow elsewhere in the app.
+ */
+export function useCheckout() {
+  return useMutation({
+    mutationFn: (packId: CreditPackId) => api.billing.checkout(packId),
+    onSuccess: ({ url }) => {
+      window.location.assign(url);
+    },
+  });
+}
+
+/** Invalidates the credits query — call after a purchase return-trip to refetch the balance. */
+export function useInvalidateCredits() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: creditsQueryKey });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,9 @@
 import type { z } from 'zod';
 import {
+  checkoutRequestSchema,
+  checkoutResponseSchema,
   createGroupRequestSchema,
+  creditsStatusSchema,
   errorResponseSchema,
   fighterSelectionSchema,
   generateReportRequestSchema,
@@ -22,6 +25,7 @@ import {
   tournamentEntryListSchema,
   userProfileSchema,
   type CreateMatchInput,
+  type CreditPackId,
   type FighterSelectionInput,
   type Match,
   type ScoutQuery,
@@ -305,6 +309,16 @@ export const api = {
     /** DELETE /api/groups/:id — owner only. */
     remove: (id: string) =>
       apiRequest<void>(`/api/groups/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+  },
+  billing: {
+    /** GET /api/billing/credits — the signed-in user's free-access flag, credit balance, and the available packs. */
+    credits: () => apiRequestParsed('/api/billing/credits', creditsStatusSchema),
+    /** POST /api/billing/checkout — creates a Stripe Checkout Session for a credit pack; returns the URL to redirect to. */
+    checkout: (packId: CreditPackId) =>
+      apiRequestParsed('/api/billing/checkout', checkoutResponseSchema, {
+        method: 'POST',
+        body: checkoutRequestSchema.parse({ packId }),
+      }),
   },
 };
 

--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -7,6 +7,14 @@ import { AuthProvider } from '@/context/AuthContext';
 import { ScoutPage } from './ScoutPage';
 import { ApiError } from '@/lib/api';
 import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+const toastSuccess = vi.fn();
+const toastPlain = vi.fn();
+vi.mock('sonner', () => ({
+  toast: Object.assign((...args: unknown[]) => toastPlain(...args), {
+    success: (...args: unknown[]) => toastSuccess(...args),
+  }),
+}));
 
 vi.mock('firebase/auth', async () => {
   const mock = await import('@/test/mockAuth');
@@ -32,6 +40,8 @@ const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@examp
 const reportsConfig = vi.fn().mockResolvedValue({ enabled: false });
 const reportsGenerate = vi.fn();
 const reportsList = vi.fn().mockResolvedValue([]);
+const billingCredits = vi.fn().mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
+const billingCheckout = vi.fn();
 
 vi.mock('@/lib/api', () => {
   class MockApiError extends Error {
@@ -52,16 +62,20 @@ vi.mock('@/lib/api', () => {
         generate: (...args: unknown[]) => reportsGenerate(...args),
         list: (...args: unknown[]) => reportsList(...args),
       },
+      billing: {
+        credits: (...args: unknown[]) => billingCredits(...args),
+        checkout: (...args: unknown[]) => billingCheckout(...args),
+      },
     },
     ApiError: MockApiError,
   };
 });
 
-function renderPage() {
+function renderPage(initialEntry = '/scout') {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/scout']}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <AuthProvider>
           <Routes>
             <Route path="/scout" element={<ScoutPage />} />
@@ -97,6 +111,7 @@ describe('ScoutPage', () => {
     matchesList.mockResolvedValue([]);
     reportsConfig.mockResolvedValue({ enabled: false });
     reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
     setMockUser(makeMockUser());
   });
 
@@ -257,6 +272,7 @@ describe('ScoutPage — AI reports feature disabled', () => {
     matchesList.mockResolvedValue([]);
     reportsConfig.mockResolvedValue({ enabled: false });
     reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
     setMockUser(makeMockUser());
   });
 
@@ -293,6 +309,7 @@ describe('ScoutPage — AI reports feature enabled', () => {
     matchesList.mockResolvedValue([]);
     reportsConfig.mockResolvedValue({ enabled: true });
     reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
     setMockUser(makeMockUser());
   });
 
@@ -408,6 +425,7 @@ describe('ScoutPage — V7-B.1 persistence across refresh / re-scout', () => {
     matchesList.mockResolvedValue([]);
     reportsConfig.mockResolvedValue({ enabled: true });
     reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
     setMockUser(makeMockUser());
   });
 
@@ -494,5 +512,142 @@ describe('ScoutPage — V7-B.1 persistence across refresh / re-scout', () => {
     expect(await screen.findByText('Past AI Reports')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /PowPow/ })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Pandem1c/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('ScoutPage — V7-C billing (free access)', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: true, freeAccess: true, billingEnabled: true });
+    reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({ freeAccess: true, balance: 0, packs: [] });
+    setMockUser(makeMockUser());
+  });
+
+  it('shows "Free access" and no "Buy credits" affordance for an allowlisted uid', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    expect(screen.getByText('Free access')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Buy credits' })).not.toBeInTheDocument();
+  });
+});
+
+describe('ScoutPage — V7-C billing (paid, non-allowlisted)', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: true, freeAccess: false, billingEnabled: true });
+    reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({
+      freeAccess: false,
+      balance: 3,
+      packs: [
+        { id: 'pack5', credits: 5, amountCents: 800, label: '5 reports' },
+        { id: 'pack15', credits: 15, amountCents: 2000, label: '15 reports' },
+      ],
+    });
+    setMockUser(makeMockUser());
+  });
+
+  it('shows the credit balance and a "Buy credits" affordance', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    expect(await screen.findByText('3 credits')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Buy credits' })).toBeInTheDocument();
+  });
+
+  it('clicking "Buy credits" opens the BuyCreditsDialog', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: 'Buy credits' }));
+
+    expect(await screen.findByText('Buy report credits')).toBeInTheDocument();
+  });
+
+  it('a 402 from generation opens the BuyCreditsDialog automatically', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsGenerate.mockRejectedValue(
+      new ApiError(402, 'You need report credits — buy a pack to continue'),
+    );
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: 'Generate AI report' }));
+
+    expect(await screen.findByText('Buy report credits')).toBeInTheDocument();
+    // The generic destructive error alert is suppressed for a 402 — the
+    // dialog itself is the feedback.
+    expect(
+      screen.queryByText('You need report credits — buy a pack to continue'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('ScoutPage — V7-C Stripe Checkout return trip', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    matchesList.mockResolvedValue([]);
+    reportsConfig.mockResolvedValue({ enabled: true, freeAccess: false, billingEnabled: true });
+    reportsList.mockResolvedValue([]);
+    billingCredits.mockResolvedValue({
+      freeAccess: false,
+      balance: 5,
+      packs: [{ id: 'pack5', credits: 5, amountCents: 800, label: '5 reports' }],
+    });
+    setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a success toast and re-polls credits on ?billing=success, then strips the param', async () => {
+    renderPage('/scout?billing=success');
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/credits/i)),
+    );
+    await waitFor(() => expect(billingCredits).toHaveBeenCalled());
+  });
+
+  it('shows a neutral toast on ?billing=cancelled', async () => {
+    renderPage('/scout?billing=cancelled');
+
+    await waitFor(() =>
+      expect(toastPlain).toHaveBeenCalledWith(expect.stringMatching(/cancelled/i)),
+    );
+  });
+
+  it('does not show any billing toast without a billing query param', () => {
+    renderPage('/scout');
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastPlain).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -1,10 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router';
 import { Sparkles } from 'lucide-react';
+import { toast } from 'sonner';
 import type { ScoutReportData, ScoutReportRecord } from '@smash-tracker/shared';
 import { ApiError } from '@/lib/api';
 import { useScoutPlayer } from '@/hooks/useScoutPlayer';
 import { useMatches } from '@/hooks/useMatches';
 import { useGenerateReport, useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
+import { useCredits } from '@/hooks/useBilling';
 import { getOpponentProfile } from '@/lib/stats';
 import { Button } from '@/components/ui/button';
 import { ScoutSearchForm } from './components/ScoutSearchForm';
@@ -16,6 +19,7 @@ import { ScoutCommonOpponentsCard } from './components/ScoutCommonOpponentsCard'
 import { YourHistoryStrip } from './components/YourHistoryStrip';
 import { ScoutAiReportCard } from './components/ScoutAiReportCard';
 import { ScoutPastReportsCard } from './components/ScoutPastReportsCard';
+import { BuyCreditsDialog } from './components/BuyCreditsDialog';
 
 function describeError(error: unknown, fallback: string): string {
   if (error instanceof ApiError) {
@@ -32,6 +36,10 @@ function describeError(error: unknown, fallback: string): string {
   }
   return fallback;
 }
+
+/** How many times to re-poll `useCredits` after a successful checkout return (webhook delivery can lag the redirect). */
+const CREDITS_POLL_ATTEMPTS = 5;
+const CREDITS_POLL_INTERVAL_MS = 2000;
 
 /**
  * `/scout` — "opponent research before bracket": scout ANY start.gg player
@@ -58,6 +66,15 @@ function describeError(error: unknown, fallback: string): string {
  * automatically with no click needed, and the generate button becomes
  * "Regenerate report". The past-reports card excludes this player's own
  * reports (they're already shown above) and only lists OTHER players'.
+ *
+ * V7-C: report generation costs one credit for everyone except allowlisted
+ * uids (`reportsConfig.freeAccess`). A small indicator next to the
+ * generate/regenerate button shows "Free access" or "N credits"; a "Buy
+ * credits" affordance opens `BuyCreditsDialog` for non-free users, which also
+ * opens automatically when generation answers 402. On return from Stripe
+ * Checkout (`?billing=success`/`?billing=cancelled`), a banner surfaces the
+ * outcome and — on success — the credits query is re-polled for a few
+ * seconds since webhook delivery can lag the redirect.
  */
 export function ScoutPage() {
   const scout = useScoutPlayer();
@@ -65,12 +82,43 @@ export function ScoutPage() {
   const reportsConfig = useReportsConfig();
   const generateReport = useGenerateReport();
   const pastReports = useScoutReportsList();
+  const credits = useCredits();
 
   const [lastQuery, setLastQuery] = useState<string | null>(null);
   const [selectedRecord, setSelectedRecord] = useState<ScoutReportRecord | null>(null);
+  const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
 
   const report: ScoutReportData | undefined = scout.data;
   const aiReportsEnabled = reportsConfig.data?.enabled ?? false;
+  const freeAccess = reportsConfig.data?.freeAccess ?? false;
+  const billingEnabled = reportsConfig.data?.billingEnabled ?? false;
+
+  // Surface the Stripe Checkout return trip (the API redirects back with a
+  // `billing` query param) and strip it from the URL once handled.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const announcedBilling = useRef(false);
+  useEffect(() => {
+    const outcome = searchParams.get('billing');
+    if (!outcome || announcedBilling.current) {
+      return;
+    }
+    announcedBilling.current = true;
+    if (outcome === 'success') {
+      toast.success("Payment received — your credits will land shortly if they haven't already.");
+      let attempts = 0;
+      const poll = setInterval(() => {
+        attempts += 1;
+        void credits.refetch();
+        if (attempts >= CREDITS_POLL_ATTEMPTS) {
+          clearInterval(poll);
+        }
+      }, CREDITS_POLL_INTERVAL_MS);
+    } else if (outcome === 'cancelled') {
+      toast('Checkout cancelled — no charge was made.');
+    }
+    setSearchParams({}, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- credits.refetch is stable per render but not a dep we want to re-trigger this effect on
+  }, [searchParams, setSearchParams]);
 
   const yourHistory = useMemo(() => {
     if (!report) {
@@ -105,7 +153,16 @@ export function ScoutPage() {
       return;
     }
     setSelectedRecord(null);
-    generateReport.mutate(lastQuery);
+    generateReport.mutate(lastQuery, {
+      onError: (error) => {
+        if (error instanceof ApiError && error.status === 402) {
+          setBuyCreditsOpen(true);
+        }
+      },
+      onSuccess: () => {
+        void credits.refetch();
+      },
+    });
   };
 
   // The record to actually render: a freshly generated report takes priority
@@ -141,31 +198,52 @@ export function ScoutPage() {
 
           {aiReportsEnabled && (
             <div className="flex flex-col gap-2">
-              <Button
-                onClick={handleGenerateReport}
-                disabled={generateReport.isPending}
-                className="w-fit"
-              >
-                <Sparkles className={generateReport.isPending ? 'animate-spin' : ''} />
-                {generateReport.isPending
-                  ? 'Generating report…'
-                  : displayedRecord
-                    ? 'Regenerate report'
-                    : 'Generate AI report'}
-              </Button>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  onClick={handleGenerateReport}
+                  disabled={generateReport.isPending}
+                  className="w-fit"
+                >
+                  <Sparkles className={generateReport.isPending ? 'animate-spin' : ''} />
+                  {generateReport.isPending
+                    ? 'Generating report…'
+                    : displayedRecord
+                      ? 'Regenerate report'
+                      : 'Generate AI report'}
+                </Button>
+
+                {(freeAccess || billingEnabled) && (
+                  <span className="text-sm text-muted-foreground">
+                    {freeAccess ? 'Free access' : `${credits.data?.balance ?? 0} credits`}
+                  </span>
+                )}
+                {!freeAccess && billingEnabled && (
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0 text-sm"
+                    onClick={() => setBuyCreditsOpen(true)}
+                  >
+                    Buy credits
+                  </Button>
+                )}
+              </div>
               {generateReport.isPending && (
                 <p className="text-sm text-muted-foreground">
                   Generating report — this usually takes a minute or two.
                 </p>
               )}
-              {generateReport.isError && (
-                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-                  {describeError(
-                    generateReport.error,
-                    'Something went wrong while generating the report.',
-                  )}
-                </div>
-              )}
+              {generateReport.isError &&
+                !(
+                  generateReport.error instanceof ApiError && generateReport.error.status === 402
+                ) && (
+                  <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                    {describeError(
+                      generateReport.error,
+                      'Something went wrong while generating the report.',
+                    )}
+                  </div>
+                )}
             </div>
           )}
 
@@ -194,6 +272,14 @@ export function ScoutPage() {
           Paste a start.gg profile URL, slug, or player id above to pull up their public tournament
           history.
         </div>
+      )}
+
+      {billingEnabled && !freeAccess && (
+        <BuyCreditsDialog
+          open={buyCreditsOpen}
+          onOpenChange={setBuyCreditsOpen}
+          packs={credits.data?.packs ?? []}
+        />
       )}
     </div>
   );

--- a/apps/web/src/pages/Scout/components/BuyCreditsDialog.test.tsx
+++ b/apps/web/src/pages/Scout/components/BuyCreditsDialog.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BuyCreditsDialog } from './BuyCreditsDialog';
+
+const billingCheckout = vi.fn();
+
+vi.mock('@/lib/api', () => {
+  class MockApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  }
+  return {
+    api: {
+      billing: {
+        checkout: (...args: unknown[]) => billingCheckout(...args),
+      },
+    },
+    ApiError: MockApiError,
+  };
+});
+
+const PACKS = [
+  { id: 'pack5' as const, credits: 5, amountCents: 800, label: '5 reports' },
+  { id: 'pack15' as const, credits: 15, amountCents: 2000, label: '15 reports' },
+];
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <BuyCreditsDialog open onOpenChange={onOpenChange} packs={PACKS} />
+    </QueryClientProvider>,
+  );
+  return { onOpenChange };
+}
+
+describe('BuyCreditsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders both packs with price and per-report math', () => {
+    renderDialog();
+
+    expect(screen.getByText('5 reports')).toBeInTheDocument();
+    expect(screen.getByText('15 reports')).toBeInTheDocument();
+    expect(screen.getByText('$8.00')).toBeInTheDocument();
+    expect(screen.getByText('$20.00')).toBeInTheDocument();
+    expect(screen.getByText('$1.60 per report')).toBeInTheDocument();
+    expect(screen.getByText(/\$1\.33/)).toBeInTheDocument();
+  });
+
+  it('defaults to the first pack selected', () => {
+    renderDialog();
+    const firstCard = screen.getByRole('button', { name: /^5 reports/ });
+    expect(firstCard).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('selecting a pack updates which card is pressed', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const secondCard = screen.getByRole('button', { name: /15 reports/ });
+    await user.click(secondCard);
+
+    expect(secondCard).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /^5 reports/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('continuing to checkout calls the checkout mutation with the selected pack', async () => {
+    const user = userEvent.setup();
+    billingCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/session/abc' });
+    vi.stubGlobal('location', { ...window.location, assign: vi.fn() });
+
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: /15 reports/ }));
+    await user.click(screen.getByRole('button', { name: 'Continue to checkout' }));
+
+    await waitFor(() => expect(billingCheckout).toHaveBeenCalledWith('pack15'));
+  });
+
+  it('shows an error message when checkout fails', async () => {
+    const user = userEvent.setup();
+    const { ApiError } = await import('@/lib/api');
+    billingCheckout.mockRejectedValue(new ApiError(500, 'Something broke upstream'));
+
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: 'Continue to checkout' }));
+
+    expect(await screen.findByText('Something broke upstream')).toBeInTheDocument();
+  });
+
+  it('cancel calls onOpenChange(false)', async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/pages/Scout/components/BuyCreditsDialog.tsx
+++ b/apps/web/src/pages/Scout/components/BuyCreditsDialog.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import type { CreditPackId, CreditsStatus } from '@smash-tracker/shared';
+import { ApiError } from '@/lib/api';
+import { useCheckout } from '@/hooks/useBilling';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+function formatUsd(amountCents: number): string {
+  return (amountCents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+}
+
+function perReportUsd(amountCents: number, credits: number): string {
+  return (amountCents / 100 / credits).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+}
+
+/**
+ * V7-C: "Buy credits" dialog — the two credit packs (`CREDIT_PACKS`, fetched
+ * from `GET /api/billing/credits` so pricing never gets hardcoded in the
+ * client) as selectable cards, then "Continue to checkout" creates a Stripe
+ * Checkout Session and redirects the browser to Stripe's hosted page.
+ *
+ * Controlled (`open`/`onOpenChange`) rather than owning its own trigger,
+ * because it needs to open from two places on the Scout page: automatically
+ * when generation returns 402, and manually via a "Buy credits" affordance.
+ */
+export function BuyCreditsDialog({
+  open,
+  onOpenChange,
+  packs,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  packs: CreditsStatus['packs'];
+}) {
+  const [selectedPackId, setSelectedPackId] = useState<CreditPackId | null>(packs[0]?.id ?? null);
+  const checkout = useCheckout();
+
+  function handleOpenChange(next: boolean) {
+    onOpenChange(next);
+    if (!next) {
+      checkout.reset();
+    }
+  }
+
+  function handleContinue() {
+    if (!selectedPackId) {
+      return;
+    }
+    checkout.mutate(selectedPackId);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Buy report credits</DialogTitle>
+          <DialogDescription>
+            Each AI scouting report costs one credit. Pick a pack — you'll be redirected to Stripe
+            to complete the purchase.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3 py-2">
+          {packs.map((pack) => {
+            const selected = pack.id === selectedPackId;
+            return (
+              <button
+                key={pack.id}
+                type="button"
+                onClick={() => setSelectedPackId(pack.id)}
+                aria-pressed={selected}
+                className={cn(
+                  'flex items-center justify-between rounded-lg border p-4 text-left transition-colors',
+                  selected ? 'border-primary bg-primary/5' : 'border-border hover:bg-accent/50',
+                )}
+              >
+                <div>
+                  <p className="font-medium">{pack.label}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {perReportUsd(pack.amountCents, pack.credits)} per report
+                  </p>
+                </div>
+                <p className="text-lg font-semibold">{formatUsd(pack.amountCents)}</p>
+              </button>
+            );
+          })}
+        </div>
+
+        {checkout.isError && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+            {checkout.error instanceof ApiError
+              ? checkout.error.message
+              : 'Something went wrong starting checkout. Please try again.'}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleContinue}
+            disabled={!selectedPackId || checkout.isPending}
+          >
+            {checkout.isPending ? 'Redirecting…' : 'Continue to checkout'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+/**
+ * V7-C: Stripe-powered credit packs that gate AI report generation
+ * (`packages/shared`'s `generatedScoutReportSchema` / apps/api's
+ * `POST /api/reports`) for everyone EXCEPT allowlisted uids
+ * (`REPORTS_ALLOWED_UIDS`, unchanged from V7-B — those stay free/unlimited,
+ * covering the owner's own usage). Everyone else spends one credit per
+ * generation and buys more via Stripe Checkout.
+ *
+ * RTDB layout (see apps/api's `billing/credits.ts` for the read/write layer):
+ * - `credits/{uid}/balance`         -> number (int, >= 0)
+ * - `creditLedger/{uid}/{pushKey}`  -> creditLedgerEntrySchema
+ * - `processedStripeEvents/{eventId}` -> number (epoch ms, webhook idempotency guard)
+ *
+ * Pack constants live here (not buried in a route) specifically so prices/
+ * credit counts are a one-line edit away from a future price change —
+ * nothing else in the codebase should hardcode a pack's credits or price.
+ */
+export const CREDIT_PACKS = [
+  { id: 'pack5', credits: 5, amountCents: 800, label: '5 reports' },
+  { id: 'pack15', credits: 15, amountCents: 2000, label: '15 reports' },
+] as const;
+
+export type CreditPack = (typeof CREDIT_PACKS)[number];
+export type CreditPackId = CreditPack['id'];
+
+/** Enum of valid pack ids, derived from `CREDIT_PACKS` so the two can't drift. */
+export const creditPackIdSchema = z.enum(
+  CREDIT_PACKS.map((pack) => pack.id) as [CreditPackId, ...CreditPackId[]],
+);
+
+const creditPackSchema = z.object({
+  id: creditPackIdSchema,
+  credits: z.number().int().positive(),
+  amountCents: z.number().int().positive(),
+  label: z.string().min(1),
+});
+
+/**
+ * GET /api/billing/credits response. `freeAccess` mirrors `reportsConfigSchema`'s
+ * allowlist check (true = unlimited, `balance` is irrelevant); `packs` is
+ * always the full `CREDIT_PACKS` list so the client never hardcodes pricing.
+ */
+export const creditsStatusSchema = z.object({
+  freeAccess: z.boolean(),
+  balance: z.number().int().min(0),
+  packs: z.array(creditPackSchema),
+});
+export type CreditsStatus = z.infer<typeof creditsStatusSchema>;
+
+/** POST /api/billing/checkout request body. */
+export const checkoutRequestSchema = z.object({
+  packId: creditPackIdSchema,
+});
+export type CheckoutRequest = z.infer<typeof checkoutRequestSchema>;
+
+/** POST /api/billing/checkout response — the Stripe-hosted Checkout Session URL to redirect to. */
+export const checkoutResponseSchema = z.object({
+  url: z.string(),
+});
+export type CheckoutResponse = z.infer<typeof checkoutResponseSchema>;
+
+/**
+ * `creditLedger/{uid}/{pushKey}` — an audit trail entry for every credit
+ * mutation. `ref` is the Stripe checkout session id for `purchase` entries,
+ * or the report/request id for `spend`/`refund` entries (so a refund can be
+ * traced back to the spend it reverses).
+ */
+export const creditLedgerEntrySchema = z.object({
+  type: z.enum(['purchase', 'spend', 'refund']),
+  /** Positive for purchase/refund, negative for spend. */
+  amount: z.number().int(),
+  /** Epoch ms. */
+  createdAt: z.number(),
+  ref: z.string(),
+});
+export type CreditLedgerEntry = z.infer<typeof creditLedgerEntrySchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,3 +32,4 @@ export * from './stageData.js';
 export * from './reports.js';
 export * from './glicko.js';
 export * from './groups.js';
+export * from './billing.js';

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -93,8 +93,20 @@ export const generateReportRequestSchema = z.object({
 });
 export type GenerateReportRequest = z.infer<typeof generateReportRequestSchema>;
 
-/** GET /api/reports/config response — whether the signed-in caller can generate AI reports. */
+/**
+ * GET /api/reports/config response — whether the signed-in caller can
+ * generate AI reports. `enabled` is true when the caller is allowlisted
+ * (`REPORTS_ALLOWED_UIDS`, free/unlimited) OR when Stripe billing (V7-C) is
+ * configured on this deployment (meaning anyone can buy credits and
+ * generate) — kept for back-compat with pre-V7-C clients that only look at
+ * `enabled`. `freeAccess`/`billingEnabled` are additive and OPTIONAL so old
+ * clients (and old cached responses) parsing this shape don't break.
+ */
 export const reportsConfigSchema = z.object({
   enabled: z.boolean(),
+  /** True when the caller is on `REPORTS_ALLOWED_UIDS` — free/unlimited generation. */
+  freeAccess: z.boolean().optional(),
+  /** True when this deployment has Stripe configured, i.e. non-allowlisted callers can buy credits. */
+  billingEnabled: z.boolean().optional(),
 });
 export type ReportsConfig = z.infer<typeof reportsConfigSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       firebase-admin:
         specifier: ^14.1.0
         version: 14.1.0
+      stripe:
+        specifier: ^22.3.0
+        version: 22.3.0(@types/node@24.13.2)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3445,6 +3448,15 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  stripe@22.3.0:
+    resolution: {integrity: sha512-ypO6xjVrMWs9SmIMeHr8naCx3dAQ0clxMdUTxn7Ejd7hmY9meBGfE+N4pVHkf9sUNebAHp6uJo6mV3GxDIc2cA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
@@ -7372,6 +7384,10 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  stripe@22.3.0(@types/node@24.13.2):
+    optionalDependencies:
+      '@types/node': 24.13.2
 
   strnum@2.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Gates AI scouting-report generation (`POST /api/reports`) behind Stripe-purchased credit packs for everyone except `REPORTS_ALLOWED_UIDS`, who stay free/unlimited (the paywall exists purely to cover the owner's own Anthropic API costs).
- Deployments without `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` configured see **no behavior change** — non-allowlisted uids still get a plain `403`, exactly as before this PR.
- New `packages/shared/src/billing.ts`: `CREDIT_PACKS` constants (`pack5` = 5 credits / $8.00, `pack15` = 15 credits / $20.00) + Zod schemas for checkout/credits-status/webhook ledger entries.
- New `apps/api/src/billing/credits.ts`: RTDB credit ledger (`credits/{uid}/balance`, `creditLedger/{uid}/{pushKey}`). `spendCredit` uses an RTDB `transaction()` on the balance node so concurrent report-generation requests can't double-spend; `addCredits`/`refundCredit` are plain read-then-write (single-writer paths); `markStripeEventProcessed` is the webhook idempotency guard (`processedStripeEvents/{eventId}`).
- New `apps/api/src/routes/billing.ts`: `GET /billing/credits`, `POST /billing/checkout` (server-side pack lookup — never trusts a client-supplied amount), `POST /billing/webhook` (public, signature-verified, raw-body content-type parser scoped to a nested plugin registration so it never leaks to sibling JSON routes).
- `apps/api/src/routes/reports.ts`: non-allowlisted + Stripe-configured callers spend a credit up front and get refunded on every failure path after the spend (scout 404/429, `ReportGenerationError`, Anthropic errors, RTDB write failure). Zero balance → `402`.
- `apps/web`: `useBilling` hooks (`useCredits`, `useCheckout`), `BuyCreditsDialog` (selectable pack cards → Stripe Checkout redirect), Scout page credits indicator + "Buy credits" affordance + automatic dialog open on `402` + Stripe Checkout return-trip banner (`?billing=success`/`?billing=cancelled`, with credits re-polled for ~10s since webhook delivery can lag the redirect).
- Extended the test-support `FakeDatabase` with a synchronous `transaction()` so the concurrent-spend path is covered without a real emulator.
- README: Stripe env vars, webhook endpoint URL shape, and where to edit pack pricing.

## Test plan

- [x] `pnpm lint` — 0 errors (33 pre-existing warnings, unrelated to this change)
- [x] `pnpm typecheck` — clean across `packages/shared`, `apps/api`, `apps/web`
- [x] `pnpm test` — 1075 tests passing (69 shared + 289 api + 717 web), including:
  - `apps/api/src/routes/billing.test.ts` (new): 503 unconfigured, checkout server-side pack lookup + session params, webhook bad signature → 400, `checkout.session.completed` credits balance + ledger, replayed event id doesn't double-credit, credits endpoint free/paid variants, raw-body parser scoping isolation test
  - `apps/api/src/routes/reports.test.ts` additions: pre-V7-C 403 unchanged when Stripe absent, 402 at zero balance, spend-on-success, refund on scout 404/429/generation failure, allowlist bypass untouched, concurrent-spend safety via the fake DB's new `transaction()`
  - `apps/web/src/hooks/useBilling.test.tsx`, `apps/web/src/pages/Scout/components/BuyCreditsDialog.test.tsx`, and `ScoutPage.test.tsx` additions for the indicator, 402→dialog flow, and success/cancelled return handling
- [x] `pnpm build` — all three workspaces build
- [x] `pnpm format:check` — clean

Not merging per instructions — this needs Stripe dashboard setup (webhook registration) before it should go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)