### PR TITLE
Fix: Scout buy-credits affordance never showed + add pack pricing

### DIFF
--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -606,6 +606,40 @@ describe('ScoutPage — V7-C billing (paid, non-allowlisted)', () => {
       screen.queryByText('You need report credits — buy a pack to continue'),
     ).not.toBeInTheDocument();
   });
+
+  it('explains the packs next to the button', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    expect(
+      await screen.findByText(
+        /Each report costs 1 credit\. 5 reports for \$8\.00 · 15 reports for \$20\.00\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the buy affordance from the live credits query even when reportsConfig.billingEnabled is stale-false', async () => {
+    // Regression: the buy UI used to gate on reportsConfig.billingEnabled,
+    // which caches long and lagged Stripe being enabled server-side — leaving
+    // a charged user (402) with no way to buy. It now keys off the credits
+    // query, so a stale/absent billingEnabled must NOT hide the buy path.
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+    reportsConfig.mockResolvedValue({ enabled: true, freeAccess: false, billingEnabled: false });
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    await screen.findByText('Pandem1c');
+
+    expect(await screen.findByText('3 credits')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Buy credits' })).toBeInTheDocument();
+  });
 });
 
 describe('ScoutPage — V7-C Stripe Checkout return trip', () => {

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -41,6 +41,10 @@ function describeError(error: unknown, fallback: string): string {
 const CREDITS_POLL_ATTEMPTS = 5;
 const CREDITS_POLL_INTERVAL_MS = 2000;
 
+function formatUsd(amountCents: number): string {
+  return (amountCents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+}
+
 /**
  * `/scout` — "opponent research before bracket": scout ANY start.gg player
  * (not just linked accounts) by pasting their profile URL, slug, or numeric
@@ -68,13 +72,15 @@ const CREDITS_POLL_INTERVAL_MS = 2000;
  * reports (they're already shown above) and only lists OTHER players'.
  *
  * V7-C: report generation costs one credit for everyone except allowlisted
- * uids (`reportsConfig.freeAccess`). A small indicator next to the
- * generate/regenerate button shows "Free access" or "N credits"; a "Buy
- * credits" affordance opens `BuyCreditsDialog` for non-free users, which also
- * opens automatically when generation answers 402. On return from Stripe
- * Checkout (`?billing=success`/`?billing=cancelled`), a banner surfaces the
- * outcome and — on success — the credits query is re-polled for a few
- * seconds since webhook delivery can lag the redirect.
+ * uids. The billing UI keys off the `GET /api/billing/credits` query (live,
+ * short-TTL) rather than `reportsConfig.billingEnabled` (cached long): a
+ * small indicator shows "Free access" or "N credits", and when the user
+ * isn't free and packs are purchasable a "Buy credits" affordance plus a
+ * pack-pricing line appear next to the button. `BuyCreditsDialog` opens from
+ * that affordance and automatically when generation answers 402. On return
+ * from Stripe Checkout (`?billing=success`/`?billing=cancelled`), a banner
+ * surfaces the outcome and — on success — the credits query is re-polled for
+ * a few seconds since webhook delivery can lag the redirect.
  */
 export function ScoutPage() {
   const scout = useScoutPlayer();
@@ -90,8 +96,18 @@ export function ScoutPage() {
 
   const report: ScoutReportData | undefined = scout.data;
   const aiReportsEnabled = reportsConfig.data?.enabled ?? false;
-  const freeAccess = reportsConfig.data?.freeAccess ?? false;
-  const billingEnabled = reportsConfig.data?.billingEnabled ?? false;
+  // Billing UI keys off the credits query, NOT reportsConfig.billingEnabled:
+  // the credits query (`GET /api/billing/credits`) has a short staleTime and
+  // reflects live Stripe state, whereas reportsConfig is cached long and can
+  // lag behind Stripe being turned on server-side — which would leave a
+  // charged user (402) with no way to buy. `freeAccess` still falls back to
+  // reportsConfig so the owner's indicator renders before credits loads.
+  const creditsData = credits.data;
+  const freeAccess = creditsData?.freeAccess ?? reportsConfig.data?.freeAccess ?? false;
+  const availablePacks = creditsData?.packs ?? [];
+  const canBuyCredits = !freeAccess && availablePacks.length > 0;
+  const lastGenerateWas402 =
+    generateReport.error instanceof ApiError && generateReport.error.status === 402;
 
   // Surface the Stripe Checkout return trip (the API redirects back with a
   // `billing` query param) and strip it from the URL once handled.
@@ -212,12 +228,12 @@ export function ScoutPage() {
                       : 'Generate AI report'}
                 </Button>
 
-                {(freeAccess || billingEnabled) && (
+                {(freeAccess || creditsData) && (
                   <span className="text-sm text-muted-foreground">
-                    {freeAccess ? 'Free access' : `${credits.data?.balance ?? 0} credits`}
+                    {freeAccess ? 'Free access' : `${creditsData?.balance ?? 0} credits`}
                   </span>
                 )}
-                {!freeAccess && billingEnabled && (
+                {canBuyCredits && (
                   <Button
                     type="button"
                     variant="link"
@@ -228,9 +244,36 @@ export function ScoutPage() {
                   </Button>
                 )}
               </div>
+              {/* Explain what a report costs and the available packs, right by
+                  the button, so the pricing is visible before checkout. */}
+              {canBuyCredits && (
+                <p className="text-sm text-muted-foreground">
+                  Each report costs 1 credit.{' '}
+                  {availablePacks
+                    .map((pack) => `${pack.label} for ${formatUsd(pack.amountCents)}`)
+                    .join(' · ')}
+                  .
+                </p>
+              )}
               {generateReport.isPending && (
                 <p className="text-sm text-muted-foreground">
                   Generating report — this usually takes a minute or two.
+                </p>
+              )}
+              {/* A 402 auto-opens the buy dialog; this leaves a persistent cue
+                  after it's dismissed rather than a scary red error. */}
+              {lastGenerateWas402 && canBuyCredits && !generateReport.isPending && (
+                <p className="text-sm text-muted-foreground">
+                  You're out of credits.{' '}
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0 text-sm"
+                    onClick={() => setBuyCreditsOpen(true)}
+                  >
+                    Buy a pack
+                  </Button>{' '}
+                  to generate this report.
                 </p>
               )}
               {generateReport.isError &&
@@ -274,11 +317,11 @@ export function ScoutPage() {
         </div>
       )}
 
-      {billingEnabled && !freeAccess && (
+      {canBuyCredits && (
         <BuyCreditsDialog
           open={buyCreditsOpen}
           onOpenChange={setBuyCreditsOpen}
-          packs={credits.data?.packs ?? []}
+          packs={availablePacks}
         />
       )}
     </div>


### PR DESCRIPTION
## Problem
After enabling Stripe server-side, a non-allowlisted user hit the paywall (402 "You need report credits") but had **no way to buy** — no credits indicator, no Buy credits link, and the `BuyCreditsDialog` wasn't even mounted, so the automatic 402 open was a no-op. Also, no pack pricing was shown near the button.

## Cause
The billing UI gated on `reportsConfig.billingEnabled`, which has a long cache TTL and lagged behind Stripe being turned on (the credits/env vars were set after the config had already been cached as `false`).

## Fix
- Key the billing UI off the live `GET /api/billing/credits` query (short TTL, authoritative) instead of the long-cached config flag.
- Always mount `BuyCreditsDialog` when packs are purchasable, so the 402 auto-open works.
- Add a pack-pricing line next to the button, and a persistent "out of credits → Buy a pack" cue after the dialog is dismissed.

2 new tests (pack explainer; buy affordance shows despite stale `billingEnabled`); 720 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)