### PR TITLE
Fix: copy patches/ into Docker deps stage (V8-A deploy failure)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/web/package.json ./apps/web/package.json
 COPY packages/shared/package.json ./packages/shared/package.json
+# pnpm-workspace.yaml's patchedDependencies reference files in patches/;
+# install fails with ENOENT if they aren't present alongside the manifests.
+COPY patches ./patches
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The V8-A Cloud Run build failed: `pnpm install --frozen-lockfile` in the deps stage hit `ENOENT: /repo/patches/@parry-gg__client@1.0.12.patch` because `pnpm-workspace.yaml` now declares `patchedDependencies` but the Dockerfile only copied the manifests. One-line `COPY patches ./patches` before install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)