### PR TITLE
Fix: parry.gg config never wired into production entrypoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { buildApp } from './app.js';
 import {
+  getParryggConfig,
   getReportsConfig,
   getStartggConfig,
   getStripeConfig,
@@ -24,6 +25,7 @@ const app = buildApp({
   startgg: getStartggConfig(env),
   reports: getReportsConfig(env),
   stripe: getStripeConfig(env),
+  parrygg: getParryggConfig(env),
   webBaseUrl: env.WEB_BASE_URL,
 });
 


### PR DESCRIPTION
V8-A's routes registered with `options.parrygg ?? null` but `index.ts` never passed `parrygg: getParryggConfig(env)`, so production 503'd 'not configured' despite the env var being set (service rev 00016 verified carrying the key). Two-line fix. Tests couldn't catch it — the harness constructs `buildApp` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)