### PR TITLE
V9-C: Trends redesign, Glicko-2 explainer, anchored sidebar footer

### DIFF
--- a/apps/web/src/components/GlickoExplainer.test.tsx
+++ b/apps/web/src/components/GlickoExplainer.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GlickoExplainer } from './GlickoExplainer';
+
+describe('GlickoExplainer', () => {
+  it('renders an accessible info trigger that is closed by default', () => {
+    render(<GlickoExplainer />);
+
+    expect(screen.getByRole('button', { name: 'What is Glicko-2?' })).toBeInTheDocument();
+    expect(screen.queryByText(/who you beat and how surprising/i)).not.toBeInTheDocument();
+  });
+
+  it('opens the popover with the explainer copy when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    render(<GlickoExplainer />);
+
+    await user.click(screen.getByRole('button', { name: 'What is Glicko-2?' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.textContent).toMatch(/Glicko-2 is the rating system/i);
+    expect(dialog.textContent).toMatch(/who you beat and how surprising/i);
+    expect(dialog.textContent).toMatch(/±number \(RD\)/i);
+    expect(dialog.textContent).toMatch(/bracket play is bursty/i);
+  });
+});

--- a/apps/web/src/components/GlickoExplainer.tsx
+++ b/apps/web/src/components/GlickoExplainer.tsx
@@ -1,0 +1,54 @@
+import { Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+/**
+ * Shared plain-English explainer for the Glicko-2 rating system, rendered
+ * identically from both the Dashboard Rating card and the Trends Rating
+ * Curve header (V9-C) so the two call sites never drift out of sync. An
+ * `Info` icon trigger opens a Popover (chosen over Tooltip per house
+ * precedent — this much copy reads poorly in a hover-only tooltip).
+ */
+export function GlickoExplainer() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="What is Glicko-2?"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <Info className="size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 text-sm">
+        <PopoverHeader>
+          <PopoverTitle>What is Glicko-2?</PopoverTitle>
+          <p>
+            <strong>Glicko-2</strong> is the rating system used in chess and by many competitive
+            ladders. Unlike a raw win rate, it weighs <em>who</em> you beat and how surprising the
+            result was.
+          </p>
+          <p>
+            The <strong>±number (RD)</strong> is uncertainty: it shrinks as you play more and grows
+            when you&apos;re inactive — so a 1500 ±50 player is proven, a 1500 ±300 player is
+            unknown.
+          </p>
+          <p>
+            We use it because bracket play is bursty: Glicko-2 handles long gaps between tournaments
+            and small samples far better than Elo or win-rate alone. Ratings here are unofficial and
+            computed only from your synced/logged games.
+          </p>
+        </PopoverHeader>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/layouts/SidebarContent.test.tsx
+++ b/apps/web/src/layouts/SidebarContent.test.tsx
@@ -51,4 +51,36 @@ describe('SidebarContent', () => {
     expect(profileLink).toHaveAttribute('href', '/profile');
     expect(profileLink).toHaveTextContent('pilot@example.com');
   });
+
+  it('makes the nav region the scrollable area so the footer stays pinned below the fold', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <AuthProvider>
+          <SidebarContent />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(nav.className).toEqual(expect.stringContaining('min-h-0'));
+    expect(nav.className).toEqual(expect.stringContaining('flex-1'));
+    expect(nav.className).toEqual(expect.stringContaining('overflow-y-auto'));
+  });
+
+  it('renders the Training Grounds and Donate footer links outside the scrollable nav', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <AuthProvider>
+          <SidebarContent />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    const trainingGroundsLink = screen.getByRole('link', { name: /Training Grounds/ });
+    const donateLink = screen.getByRole('link', { name: /Donate/ });
+
+    expect(nav).not.toContainElement(trainingGroundsLink);
+    expect(nav).not.toContainElement(donateLink);
+  });
 });

--- a/apps/web/src/layouts/SidebarContent.tsx
+++ b/apps/web/src/layouts/SidebarContent.tsx
@@ -41,7 +41,10 @@ export function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
 
       <Separator />
 
-      <nav className="flex flex-1 flex-col gap-1" aria-label="Main navigation">
+      <nav
+        className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto py-0.5"
+        aria-label="Main navigation"
+      >
         {navItems.map((item) => (
           <NavLink
             key={item.href}

--- a/apps/web/src/lib/chartTheme.ts
+++ b/apps/web/src/lib/chartTheme.ts
@@ -36,9 +36,23 @@ export function redLineDataset() {
   };
 }
 
-/** Scale/legend/tooltip styling legible on the dark background. */
-export function darkChartOptions(): Pick<ChartOptions<'line'>, 'scales' | 'plugins'> {
+/**
+ * Scale/legend/tooltip styling legible on the dark background, plus the
+ * `responsive`/`maintainAspectRatio` pair every chart on this dashboard
+ * needs (V9-C): chart.js defaults `maintainAspectRatio` to `true`, which
+ * locks the canvas to its intrinsic aspect ratio instead of filling a wide
+ * flex/grid card — the cause of the "tiny chart in a huge card" bug on
+ * Trends. Callers still need a fixed-height wrapper div (see
+ * FighterAnalysis/RatingCurve/MonthlyPerformance) since `maintainAspectRatio:
+ * false` alone doesn't give the canvas a height to fill.
+ */
+export function darkChartOptions(): Pick<
+  ChartOptions<'line'>,
+  'responsive' | 'maintainAspectRatio' | 'scales' | 'plugins'
+> {
   return {
+    responsive: true,
+    maintainAspectRatio: false,
     scales: {
       x: {
         grid: { color: chartColors.grid },

--- a/apps/web/src/pages/Dashboard/components/HeroStats.tsx
+++ b/apps/web/src/pages/Dashboard/components/HeroStats.tsx
@@ -1,6 +1,7 @@
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WinLossPips } from '@/components/WinLossPips';
+import { GlickoExplainer } from '@/components/GlickoExplainer';
 import {
   getOnlineOfflineSplit,
   getStreakSummary,
@@ -194,7 +195,10 @@ function RatingCard({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Rating</CardTitle>
+        <CardTitle className="flex items-center gap-1.5">
+          Rating
+          <GlickoExplainer />
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-1">
         {hasEnoughGames && current ? (

--- a/apps/web/src/pages/Dashboard/components/LastMatchesChart.tsx
+++ b/apps/web/src/pages/Dashboard/components/LastMatchesChart.tsx
@@ -83,7 +83,9 @@ export function LastMatchesChart({ matches }: { matches: Match[] }) {
         {series.length === 0 ? (
           <p className="text-sm text-muted-foreground">Submit a match to see the match chart.</p>
         ) : (
-          <Line data={buildData(series)} options={buildOptions(series)} />
+          <div className="h-64">
+            <Line data={buildData(series)} options={buildOptions(series)} />
+          </div>
         )}
       </CardContent>
     </Card>
@@ -115,6 +117,8 @@ function buildData(series: SeriesPoint[]) {
 function buildOptions(series: SeriesPoint[]): ChartOptions<'line'> {
   const theme = darkChartOptions();
   return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
     scales: {
       x: theme.scales?.x,
       y: {

--- a/apps/web/src/pages/Trends/TrendsPage.tsx
+++ b/apps/web/src/pages/Trends/TrendsPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { useFilteredMatches } from '@/hooks/useFilteredMatches';
 import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
+import { TrendsHero } from './components/TrendsHero';
 import { MonthlyPerformance } from './components/MonthlyPerformance';
 import { SessionsAndTilt } from './components/SessionsAndTilt';
 import { SettingComparison } from './components/SettingComparison';
@@ -40,12 +41,21 @@ export function TrendsPage() {
     <div className="flex flex-col gap-6">
       {filterActive && matches.length === 0 && <FilteredEmptyNotice />}
 
+      <TrendsHero matches={matches} />
+
       <MonthlyPerformance matches={matches} />
+
       <RatingCurve matches={matches} />
-      <SessionsAndTilt matches={matches} />
-      <SettingComparison matches={matches} />
-      <Tournaments matches={matches} />
-      <MatchTypeMix matches={matches} />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <SessionsAndTilt matches={matches} />
+        <SettingComparison matches={matches} />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Tournaments matches={matches} />
+        <MatchTypeMix matches={matches} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
+++ b/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
@@ -88,6 +88,8 @@ function buildChartData(mix: MonthlyMatchTypeMix[]) {
 function buildChartOptions(): ChartOptions<'bar'> {
   const theme = darkChartOptions();
   return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
     scales: {
       x: { ...theme.scales?.x, stacked: true },
       y: { ...theme.scales?.y, stacked: true, beginAtZero: true },
@@ -112,7 +114,7 @@ export function MatchTypeMix({ matches }: { matches: Match[] }) {
   const mix = buildMonthlyMatchTypeMix(matches);
 
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle>Match-Type Mix Over Time</CardTitle>
       </CardHeader>

--- a/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
+++ b/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
@@ -63,6 +63,8 @@ export function buildMonthlyChartData(records: MonthlyRecord[]) {
 function buildMonthlyChartOptions(records: MonthlyRecord[]): ChartOptions<'bar'> {
   const theme = darkChartOptions();
   return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
     scales: {
       x: theme.scales?.x,
       y: {
@@ -106,46 +108,52 @@ export function MonthlyPerformance({ matches }: { matches: Match[] }) {
         {records.length === 0 ? (
           <p className="text-sm text-muted-foreground">No match data to report yet.</p>
         ) : (
-          <>
-            <div className="h-64">
-              <Bar
-                data={buildMonthlyChartData(records)}
-                options={buildMonthlyChartOptions(records)}
-              />
+          <div className="flex flex-col gap-4 lg:flex-row">
+            <div className="flex flex-col gap-2 lg:w-3/5">
+              <div className="h-64">
+                <Bar
+                  data={buildMonthlyChartData(records)}
+                  options={buildMonthlyChartOptions(records)}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Faded bars mark months with fewer than {SMALL_SAMPLE_THRESHOLD} games — small
+                sample, read with caution.
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Faded bars mark months with fewer than {SMALL_SAMPLE_THRESHOLD} games — small sample,
-              read with caution.
-            </p>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Month</TableHead>
-                  <TableHead>W-L</TableHead>
-                  <TableHead>Rate</TableHead>
-                  <TableHead>Games</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {[...records].reverse().map((record) => (
-                  <TableRow key={record.month}>
-                    <TableCell>{formatMonthLabel(record.month)}</TableCell>
-                    <TableCell>
-                      {record.wins}-{record.losses}
-                    </TableCell>
-                    <TableCell>{record.winRate}%</TableCell>
-                    <TableCell
-                      className={
-                        record.total < SMALL_SAMPLE_THRESHOLD ? 'text-muted-foreground' : undefined
-                      }
-                    >
-                      {record.total}
-                    </TableCell>
+            <div className="max-h-72 overflow-y-auto lg:w-2/5">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Month</TableHead>
+                    <TableHead>W-L</TableHead>
+                    <TableHead>Rate</TableHead>
+                    <TableHead>Games</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>
+                </TableHeader>
+                <TableBody>
+                  {[...records].reverse().map((record) => (
+                    <TableRow key={record.month}>
+                      <TableCell>{formatMonthLabel(record.month)}</TableCell>
+                      <TableCell>
+                        {record.wins}-{record.losses}
+                      </TableCell>
+                      <TableCell>{record.winRate}%</TableCell>
+                      <TableCell
+                        className={
+                          record.total < SMALL_SAMPLE_THRESHOLD
+                            ? 'text-muted-foreground'
+                            : undefined
+                        }
+                      >
+                        {record.total}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Trends/components/RatingCurve.tsx
+++ b/apps/web/src/pages/Trends/components/RatingCurve.tsx
@@ -11,6 +11,7 @@ import {
 import { Line } from 'react-chartjs-2';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { GlickoExplainer } from '@/components/GlickoExplainer';
 import { computeRatingHistory, type RatingPeriodResult } from '@/lib/glicko';
 import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
 
@@ -73,6 +74,8 @@ export function buildRatingCurveData(periods: RatingPeriodResult[]) {
 function buildRatingCurveOptions(periods: RatingPeriodResult[]): ChartOptions<'line'> {
   const theme = darkChartOptions();
   return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
     scales: {
       x: theme.scales?.x,
       y: {
@@ -122,7 +125,10 @@ export function RatingCurve({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Rating Curve</CardTitle>
+        <CardTitle className="flex items-center gap-1.5">
+          Rating Curve
+          <GlickoExplainer />
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {hasEnoughGames && current && periods.length > 0 ? (

--- a/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
+++ b/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
@@ -85,7 +85,7 @@ export function SessionsAndTilt({ matches }: { matches: Match[] }) {
   const recentSessions = [...sessions].reverse().slice(0, RECENT_SESSION_LIMIT);
 
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle>Sessions &amp; Tilt</CardTitle>
       </CardHeader>

--- a/apps/web/src/pages/Trends/components/SettingComparison.tsx
+++ b/apps/web/src/pages/Trends/components/SettingComparison.tsx
@@ -42,7 +42,7 @@ export function SettingComparison({ matches }: { matches: Match[] }) {
   const hasAny = split.online.total > 0 || split.offline.total > 0 || split.unspecified.total > 0;
 
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle>Setting Comparison</CardTitle>
       </CardHeader>

--- a/apps/web/src/pages/Trends/components/Tournaments.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.tsx
@@ -74,7 +74,7 @@ export function Tournaments({ matches }: { matches: Match[] }) {
   const rows = buildTournamentEntryRows(entries ?? [], matches);
 
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle>Tournaments</CardTitle>
       </CardHeader>

--- a/apps/web/src/pages/Trends/components/TrendsHero.test.tsx
+++ b/apps/web/src/pages/Trends/components/TrendsHero.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match } from '@smash-tracker/shared';
+import { TrendsHero } from './TrendsHero';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('TrendsHero', () => {
+  it('shows the not-enough-games / no-data placeholders with no match history', () => {
+    render(<TrendsHero matches={[]} />);
+
+    expect(screen.getByText('Current Rating')).toBeInTheDocument();
+    expect(screen.getByText('Peak Rating')).toBeInTheDocument();
+    expect(screen.getByText('Best Month')).toBeInTheDocument();
+    expect(screen.getByText('Current Form')).toBeInTheDocument();
+    expect(screen.getAllByText('Not enough games yet').length).toBe(2);
+    expect(screen.getByText('No match data to report yet.')).toBeInTheDocument();
+  });
+
+  it('renders current rating, peak rating, best month, and current form once there is history', () => {
+    const matches = [
+      // Jan 2021: 5 games, 100% win rate -> best month.
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeMatch({ id: `jan-${i}`, time: Date.UTC(2021, 0, i + 1), win: true }),
+      ),
+      // Feb 2021: 5 games, 0% win rate.
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeMatch({ id: `feb-${i}`, time: Date.UTC(2021, 1, i + 1), win: false }),
+      ),
+    ];
+
+    render(<TrendsHero matches={matches} />);
+
+    expect(screen.getByText('Glicko-2 rating')).toBeInTheDocument();
+    expect(screen.getByText('Best session rating')).toBeInTheDocument();
+    expect(screen.getByText(/Jan 2021/)).toBeInTheDocument();
+    expect(screen.getByText(/Last 10 of 20 games/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Trends/components/TrendsHero.tsx
+++ b/apps/web/src/pages/Trends/components/TrendsHero.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react';
+import type { Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatMonthLabel } from './MonthlyPerformance';
+import { BEST_MONTH_MIN_GAMES, CURRENT_FORM_WINDOW, buildTrendsHero } from '../lib/trendsHero';
+
+/**
+ * Trends hero stat row (V9-C): current rating ±RD, peak rating, best month,
+ * and current form — mirroring Fighter Analysis's hero-stat treatment so
+ * Trends opens with the same "at a glance" summary instead of jumping
+ * straight into cards. Computed entirely from `buildTrendsHero`, itself
+ * derived from data the rest of the page already has (no new API calls).
+ */
+export function TrendsHero({ matches }: { matches: Match[] }) {
+  const hero = buildTrendsHero(matches);
+
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <HeroCard label="Current Rating">
+        {hero.currentRating ? (
+          <>
+            <span className="text-3xl font-bold">
+              {hero.currentRating.rating}{' '}
+              <span className="text-lg font-normal">&plusmn;{hero.currentRating.rd}</span>
+            </span>
+            <p className="text-sm text-muted-foreground">Glicko-2 rating</p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">Not enough games yet</p>
+        )}
+      </HeroCard>
+
+      <HeroCard label="Peak Rating">
+        {hero.peakRating != null ? (
+          <>
+            <span className="text-3xl font-bold">{hero.peakRating}</span>
+            <p className="text-sm text-muted-foreground">Best session rating</p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">Not enough games yet</p>
+        )}
+      </HeroCard>
+
+      <HeroCard label="Best Month">
+        {hero.bestMonth ? (
+          <>
+            <span className="text-3xl font-bold">{hero.bestMonth.winRate}%</span>
+            <p className="text-sm text-muted-foreground">
+              {formatMonthLabel(hero.bestMonth.month)} &middot; {hero.bestMonth.wins}-
+              {hero.bestMonth.losses} ({hero.bestMonth.total} games)
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Needs a month with {BEST_MONTH_MIN_GAMES}+ games
+          </p>
+        )}
+      </HeroCard>
+
+      <HeroCard label="Current Form">
+        {hero.currentFormGames > 0 ? (
+          <>
+            <span className="text-3xl font-bold">{hero.currentFormWinRate}%</span>
+            <p className="text-sm text-muted-foreground">
+              Last {hero.currentFormGames} of {CURRENT_FORM_WINDOW} games
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+        )}
+      </HeroCard>
+    </div>
+  );
+}
+
+function HeroCard({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1">{children}</CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Trends/lib/trendsHero.test.ts
+++ b/apps/web/src/pages/Trends/lib/trendsHero.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@smash-tracker/shared';
+import { BEST_MONTH_MIN_GAMES, CURRENT_FORM_WINDOW, buildTrendsHero } from './trendsHero';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    ...overrides,
+  };
+}
+
+describe('buildTrendsHero', () => {
+  it('returns nulls and zeroed form for no matches', () => {
+    const hero = buildTrendsHero([]);
+    expect(hero.currentRating).toBeNull();
+    expect(hero.peakRating).toBeNull();
+    expect(hero.bestMonth).toBeNull();
+    expect(hero.currentFormWinRate).toBe(100);
+    expect(hero.currentFormGames).toBe(0);
+  });
+
+  it('reports the current rating +/- RD once the rating history has periods', () => {
+    const matches = Array.from({ length: 6 }, (_, i) =>
+      makeMatch({ id: `${i}`, time: i * 1000, win: true }),
+    );
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.currentRating).not.toBeNull();
+    expect(typeof hero.currentRating?.rating).toBe('number');
+    expect(typeof hero.currentRating?.rd).toBe('number');
+  });
+
+  it('computes peak rating as the max across all rating periods', () => {
+    const HOUR_MS = 60 * 60 * 1000;
+    const matches = [
+      // Session 1
+      makeMatch({ id: '1', time: 0, win: true }),
+      makeMatch({ id: '2', time: HOUR_MS, win: true }),
+      makeMatch({ id: '3', time: 2 * HOUR_MS, win: true }),
+      // Gap > 3h default -> new session, all losses drags rating down.
+      makeMatch({ id: '4', time: 10 * HOUR_MS, win: false }),
+      makeMatch({ id: '5', time: 11 * HOUR_MS, win: false }),
+      makeMatch({ id: '6', time: 12 * HOUR_MS, win: false }),
+    ];
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.peakRating).not.toBeNull();
+    expect(hero.currentRating).not.toBeNull();
+    // Peak should be at least as high as the current (post-losing-streak) rating.
+    expect(hero.peakRating as number).toBeGreaterThanOrEqual(hero.currentRating!.rating);
+  });
+
+  it('picks the highest win-rate month among months meeting the minimum sample', () => {
+    const matches = [
+      // Jan 2021: 2 games, 100% win rate but below the minimum sample -> excluded.
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 0, 2), win: true }),
+      // Feb 2021: 5 games, 80% win rate -> eligible.
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeMatch({ id: `feb-${i}`, time: Date.UTC(2021, 1, i + 1), win: i !== 0 }),
+      ),
+      // Mar 2021: 5 games, 40% win rate -> eligible but worse.
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeMatch({ id: `mar-${i}`, time: Date.UTC(2021, 2, i + 1), win: i < 2 }),
+      ),
+    ];
+    expect(BEST_MONTH_MIN_GAMES).toBe(5);
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.bestMonth?.month).toBe('2021-02');
+    expect(hero.bestMonth?.winRate).toBe(80);
+  });
+
+  it('returns null best month when no month has the minimum sample', () => {
+    const matches = [
+      makeMatch({ id: '1', time: Date.UTC(2021, 0, 1), win: true }),
+      makeMatch({ id: '2', time: Date.UTC(2021, 0, 2), win: true }),
+    ];
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.bestMonth).toBeNull();
+  });
+
+  it('computes current form over the last CURRENT_FORM_WINDOW games only', () => {
+    expect(CURRENT_FORM_WINDOW).toBe(20);
+    // 15 losses followed by 20 wins -> last-20 window should be all wins (100%),
+    // even though the account's all-time record is much worse.
+    const matches = [
+      ...Array.from({ length: 15 }, (_, i) => makeMatch({ id: `l${i}`, time: i, win: false })),
+      ...Array.from({ length: 20 }, (_, i) =>
+        makeMatch({ id: `w${i}`, time: 1000 + i, win: true }),
+      ),
+    ];
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.currentFormGames).toBe(20);
+    expect(hero.currentFormWinRate).toBe(100);
+  });
+
+  it('uses fewer than CURRENT_FORM_WINDOW games when the account has less history', () => {
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true }),
+      makeMatch({ id: '2', time: 2, win: false }),
+      makeMatch({ id: '3', time: 3, win: true }),
+    ];
+
+    const hero = buildTrendsHero(matches);
+
+    expect(hero.currentFormGames).toBe(3);
+    expect(hero.currentFormWinRate).toBe(67);
+  });
+});

--- a/apps/web/src/pages/Trends/lib/trendsHero.ts
+++ b/apps/web/src/pages/Trends/lib/trendsHero.ts
@@ -1,0 +1,58 @@
+import type { Match } from '@smash-tracker/shared';
+import { computeRatingHistory, type RatingHistory } from '@/lib/glicko';
+import {
+  getLastNMatches,
+  getMonthlyRecords,
+  getWinLossRecord,
+  type MonthlyRecord,
+} from '@/lib/stats';
+
+/** Minimum games in a month before it's eligible to be called out as the "best month" — mirrors `MonthlyPerformance`'s small-sample threshold intent, kept as its own constant since the hero row's bar is slightly stricter. */
+export const BEST_MONTH_MIN_GAMES = 5;
+
+/** Window size for the "current form" win rate in the hero row. */
+export const CURRENT_FORM_WINDOW = 20;
+
+export interface TrendsHeroData {
+  /** Current Glicko-2 rating ± RD, or null before the rating curve unlocks (fewer than 5 games). */
+  currentRating: { rating: number; rd: number } | null;
+  /** Peak rating across the account's full rating history (max across all periods, including the current one), or null with no periods yet. */
+  peakRating: number | null;
+  /** The calendar month with the highest win rate among months with at least `BEST_MONTH_MIN_GAMES` games, or null if no month qualifies. */
+  bestMonth: MonthlyRecord | null;
+  /** Win rate (0-100) over the last `CURRENT_FORM_WINDOW` games (fewer if the account has less history). */
+  currentFormWinRate: number;
+  /** How many games the current-form win rate is actually computed over (min(matches.length, CURRENT_FORM_WINDOW)). */
+  currentFormGames: number;
+}
+
+/**
+ * Pure computations backing the Trends hero stat row (V9-C): current rating
+ * ±RD, peak rating, best month (win-rate leader with a minimum sample), and
+ * current form. Derived entirely from data the page already fetches/computes
+ * (rating history + monthly records) — no additional API calls, mirroring
+ * FighterAnalysis's `buildFighterHero` pattern.
+ */
+export function buildTrendsHero(matches: Match[]): TrendsHeroData {
+  const { periods, current }: RatingHistory = computeRatingHistory(matches);
+  const currentRating = current ? { rating: current.rating, rd: current.rd } : null;
+  const peakRating = periods.length > 0 ? Math.max(...periods.map((p) => p.rating)) : null;
+
+  const monthlyRecords = getMonthlyRecords(matches);
+  const eligibleMonths = monthlyRecords.filter((r) => r.total >= BEST_MONTH_MIN_GAMES);
+  const bestMonth =
+    eligibleMonths.length > 0
+      ? eligibleMonths.reduce((best, r) => (r.winRate > best.winRate ? r : best))
+      : null;
+
+  const recentMatches = getLastNMatches(matches, CURRENT_FORM_WINDOW);
+  const { winRate: currentFormWinRate } = getWinLossRecord(recentMatches);
+
+  return {
+    currentRating,
+    peakRating,
+    bestMonth,
+    currentFormWinRate,
+    currentFormGames: recentMatches.length,
+  };
+}


### PR DESCRIPTION
## Summary

**1. Trends page redesign** (brings it up to Fighter Analysis quality per user feedback):
- Added a `TrendsHero` stat row at the top: current rating ±RD, peak rating (max across rating history), best month (highest win rate with ≥5 games), current form (win rate over the last 20 games) — all computed from data already on the page (`lib/trendsHero.ts`, pure + unit-tested), no new API calls.
- Fixed the core chart-sizing bug: `chartTheme.ts`'s `darkChartOptions()` now returns `responsive: true, maintainAspectRatio: false` (chart.js defaults `maintainAspectRatio` to `true`, which was locking Rating Curve / Monthly Performance / the Dashboard Form Curve to a small intrinsic canvas size instead of filling their card). Each chart's options builder now threads those two fields through, matching how `FighterHero`'s sparkline already did it locally.
- Monthly Performance: chart and table now sit side by side on `lg+` (chart ~60%, table ~40% with `max-h-72 overflow-y-auto` for long histories), stacking to a single column on mobile — instead of a small chart above a full-width table.
- Rebalanced the remaining cards into a two-column grid on `lg+` (Sessions & Tilt + Setting Comparison; Tournaments + Match-Type Mix), each paired card set to `h-full` so heights match, mirroring Fighter Analysis's `MatchupCoverage`/`PracticeRecommendations` pairing.
- All existing Trends features/tests preserved; extended `MonthlyPerformance.test.tsx`-adjacent behavior stayed intact (no test changes needed there — markup selectors were unaffected).

**2. Glicko-2 explainer**: new shared `components/GlickoExplainer.tsx` — a lucide `Info` icon trigger opening a shadcn Popover with plain-English copy (what Glicko-2 is, what ±RD means, why bracket play needs it over Elo/win-rate). Rendered identically from the Dashboard `HeroStats` Rating card and the Trends `RatingCurve` header so both call sites can't drift. Accessible (`aria-label="What is Glicko-2?"`) and covered by `GlickoExplainer.test.tsx`.

**3. Sidebar footer always visible**: `SidebarContent`'s `<nav>` is now the scrollable region (`min-h-0 flex-1 overflow-y-auto`) instead of the whole sidebar scrolling as one block, so the profile block and the Training Grounds/Donate footer stay pinned regardless of viewport height — fixes the reported Firefox/macOS issue where Donate sat below the fold. Verified the mobile Sheet drawer (same `SidebarContent`, mounted via `Topbar`) still passes its existing tests. Extended `SidebarContent.test.tsx` with two new tests: one asserting the nav carries the scroll classes, one asserting the footer links render outside the nav.

## Deviations
- `lib/chartTheme.ts` isn't in the explicitly-listed touchable file set, but the task explicitly asked to "fix chart.js sizing" and pointed at this exact shared helper as the mechanism (`darkChartOptions`) other charts already partially used — fixing it in one place (with each Trends/Dashboard chart file also updated to thread the new fields through their own options builders, since none of them spread `...theme` wholesale) was the minimal, non-duplicative fix. `pages/Opponents/ScoutingTrendChart.tsx` and `pages/Matchups/MatchupChart.tsx` also call `darkChartOptions()` but were left untouched (out of bounds) — they're unaffected either way since neither destructures the new fields.
- `Sidebar.tsx` (the desktop wrapper) was left untouched, per the file-boundary list only naming `SidebarContent.tsx`. Its `h-svh overflow-y-auto` outer wrapper coexists fine with the new inner nav scroll — the nav now shrinks to fit instead of pushing total content past `h-svh`, so the outer scroll never actually engages in the fixed-footer case.

## Test plan
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1184/1184 passing (775 web + 340 api + 69 shared), including 2 new SidebarContent tests, GlickoExplainer tests, TrendsHero tests, trendsHero.ts unit tests
- [x] `pnpm build` — succeeds
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)