### PR TITLE
Scouting list sort/filter + user fighters in Set Timeline

### DIFF
--- a/apps/web/src/pages/Opponents/components/OpponentList.test.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentList.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Match } from '@smash-tracker/shared';
+import { OpponentList } from './OpponentList';
+
+function makeMatch(
+  overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win' | 'opponent'>,
+): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 10,
+    map: { id: 1, name: 'Battlefield' },
+    notes: '',
+    matchType: 'offline-tourney',
+    ...overrides,
+  };
+}
+
+/**
+ * alice: 4 games (3-1), most played, oldest activity.
+ * bob:   2 games (0-2), most recent activity, lowest win rate.
+ * cara:  1 game  (1-0), 100% win rate, small sample.
+ */
+const MATCHES: Match[] = [
+  makeMatch({ id: 'a1', time: 100, win: true, opponent: 'alice' }),
+  makeMatch({ id: 'a2', time: 200, win: true, opponent: 'alice' }),
+  makeMatch({ id: 'a3', time: 300, win: true, opponent: 'alice' }),
+  makeMatch({ id: 'a4', time: 400, win: false, opponent: 'alice' }),
+  makeMatch({ id: 'b1', time: 900, win: false, opponent: 'bob' }),
+  makeMatch({ id: 'b2', time: 1000, win: false, opponent: 'bob' }),
+  makeMatch({ id: 'c1', time: 500, win: true, opponent: 'cara' }),
+];
+
+function renderList() {
+  return render(
+    <OpponentList matches={MATCHES} selected={null} onSelect={vi.fn()} onRequestMerge={vi.fn()} />,
+  );
+}
+
+function rowNames(): string[] {
+  const list = screen.getByRole('list', { name: 'Opponents' });
+  return within(list)
+    .getAllByRole('listitem')
+    .map((li) => within(li).getByTitle(/.+/).textContent ?? '');
+}
+
+describe('OpponentList sorting and filtering', () => {
+  it('defaults to most played', () => {
+    renderList();
+    expect(rowNames()).toEqual(['alice', 'bob', 'cara']);
+  });
+
+  it('sorts by most recent activity', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await user.click(screen.getByRole('combobox', { name: 'Sort opponents' }));
+    await user.click(screen.getByRole('option', { name: 'Recently played' }));
+    expect(rowNames()).toEqual(['bob', 'cara', 'alice']);
+  });
+
+  it('sorts by highest and lowest win rate', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await user.click(screen.getByRole('combobox', { name: 'Sort opponents' }));
+    await user.click(screen.getByRole('option', { name: 'Highest win rate' }));
+    expect(rowNames()).toEqual(['cara', 'alice', 'bob']);
+
+    await user.click(screen.getByRole('combobox', { name: 'Sort opponents' }));
+    await user.click(screen.getByRole('option', { name: 'Lowest win rate' }));
+    expect(rowNames()).toEqual(['bob', 'alice', 'cara']);
+  });
+
+  it('sorts alphabetically', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await user.click(screen.getByRole('combobox', { name: 'Sort opponents' }));
+    await user.click(screen.getByRole('option', { name: 'A → Z' }));
+    expect(rowNames()).toEqual(['alice', 'bob', 'cara']);
+  });
+
+  it('the 3+ games toggle hides small samples', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await user.click(
+      screen.getByRole('button', { name: 'Only show opponents with 3 or more games' }),
+    );
+    expect(rowNames()).toEqual(['alice']);
+    // The header count still reflects everyone faced, not the filtered view.
+    expect(screen.getByText('3 opponents faced')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Opponents/components/OpponentList.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentList.tsx
@@ -10,6 +10,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Toggle } from '@/components/ui/toggle';
 import { getOpponentRecords, type OpponentRecord } from '@/lib/stats';
 import { getOpponentSources, type OpponentSource } from '@/hooks/useFilteredMatches';
 import { OpponentSourceBadge } from './OpponentSourceBadge';
@@ -22,29 +30,88 @@ export interface OpponentListProps {
   onRequestMerge: (opponent: string) => void;
 }
 
+/** Sort orders for the opponent list. */
+export type OpponentSort = 'most-played' | 'recent' | 'best-rate' | 'worst-rate' | 'alphabetical';
+
+const SORT_LABELS: Record<OpponentSort, string> = {
+  'most-played': 'Most played',
+  recent: 'Recently played',
+  'best-rate': 'Highest win rate',
+  'worst-rate': 'Lowest win rate',
+  alphabetical: 'A → Z',
+};
+
+/** Games threshold applied by the "3+ games" small-sample toggle. */
+const MIN_GAMES = 3;
+
+function sortOpponents(
+  opponents: OpponentRecord[],
+  sort: OpponentSort,
+  lastPlayed: Map<string, number>,
+): OpponentRecord[] {
+  const sorted = [...opponents];
+  switch (sort) {
+    case 'recent':
+      sorted.sort((a, b) => (lastPlayed.get(b.opponent) ?? 0) - (lastPlayed.get(a.opponent) ?? 0));
+      break;
+    case 'best-rate':
+      sorted.sort((a, b) => b.winRate - a.winRate || b.total - a.total);
+      break;
+    case 'worst-rate':
+      sorted.sort((a, b) => a.winRate - b.winRate || b.total - a.total);
+      break;
+    case 'alphabetical':
+      sorted.sort((a, b) => a.opponent.localeCompare(b.opponent));
+      break;
+    case 'most-played':
+    default:
+      sorted.sort((a, b) => b.total - a.total);
+      break;
+  }
+  return sorted;
+}
+
 /**
  * Left-column opponent list for the Scouting page: every human opponent
- * faced (`getOpponentRecords`), ranked by games played descending, with a
- * substring search filter. Selecting a row calls `onSelect`. Each row shows
- * a source badge (start.gg-verified / manual / mixed) and a kebab menu with
- * a "Merge into..." action.
+ * faced (`getOpponentRecords`), with a substring search filter, a sort
+ * selector (most played / recently played / highest / lowest win rate /
+ * alphabetical), and a "3+ games" toggle that hides small samples.
+ * Selecting a row calls `onSelect`. Each row shows a source badge and a
+ * kebab menu with a "Merge into..." action.
  */
 export function OpponentList({ matches, selected, onSelect, onRequestMerge }: OpponentListProps) {
   const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<OpponentSort>('most-played');
+  const [minGamesOnly, setMinGamesOnly] = useState(false);
 
-  const opponents = useMemo(() => {
-    return [...getOpponentRecords(matches)].sort((a, b) => b.total - a.total);
-  }, [matches]);
+  const opponents = useMemo(() => getOpponentRecords(matches), [matches]);
 
   const sources = useMemo(() => getOpponentSources(matches), [matches]);
 
+  // Most recent match time per opponent name — drives the "Recently played"
+  // sort. Matches arrive already alias-canonicalized upstream.
+  const lastPlayed = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const match of matches) {
+      if (!match.opponent) {
+        continue;
+      }
+      const prev = map.get(match.opponent) ?? 0;
+      if (match.time > prev) {
+        map.set(match.opponent, match.time);
+      }
+    }
+    return map;
+  }, [matches]);
+
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) {
-      return opponents;
-    }
-    return opponents.filter((o) => o.opponent.toLowerCase().includes(needle));
-  }, [opponents, query]);
+    const searched = needle
+      ? opponents.filter((o) => o.opponent.toLowerCase().includes(needle))
+      : opponents;
+    const thresholded = minGamesOnly ? searched.filter((o) => o.total >= MIN_GAMES) : searched;
+    return sortOpponents(thresholded, sort, lastPlayed);
+  }, [opponents, query, sort, minGamesOnly, lastPlayed]);
 
   return (
     <Card className="flex h-full flex-col">
@@ -65,11 +132,36 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
             className="pl-8"
           />
         </div>
+        <div className="flex items-center gap-2">
+          <Select value={sort} onValueChange={(value) => setSort(value as OpponentSort)}>
+            <SelectTrigger className="h-8 flex-1" aria-label="Sort opponents">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(SORT_LABELS) as OpponentSort[]).map((key) => (
+                <SelectItem key={key} value={key}>
+                  {SORT_LABELS[key]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Toggle
+            size="sm"
+            variant="outline"
+            pressed={minGamesOnly}
+            onPressedChange={setMinGamesOnly}
+            aria-label="Only show opponents with 3 or more games"
+          >
+            3+ games
+          </Toggle>
+        </div>
       </CardHeader>
       <CardContent className="flex-1">
         {filtered.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            {opponents.length === 0 ? 'No opponents faced yet.' : 'No opponents match your search.'}
+            {opponents.length === 0
+              ? 'No opponents faced yet.'
+              : 'No opponents match your filters.'}
           </p>
         ) : (
           <ul className="flex flex-col gap-1" role="list" aria-label="Opponents">
@@ -79,6 +171,7 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
                 opponent={opponent}
                 selected={opponent.opponent === selected}
                 source={sources.get(opponent.opponent) ?? 'manual'}
+                lastPlayedAt={sort === 'recent' ? lastPlayed.get(opponent.opponent) : undefined}
                 onSelect={onSelect}
                 onRequestMerge={onRequestMerge}
               />
@@ -94,12 +187,15 @@ function OpponentRow({
   opponent,
   selected,
   source,
+  lastPlayedAt,
   onSelect,
   onRequestMerge,
 }: {
   opponent: OpponentRecord;
   selected: boolean;
   source: OpponentSource;
+  /** Set only under the "Recently played" sort — renders a date hint. */
+  lastPlayedAt?: number;
   onSelect: (opponent: string) => void;
   onRequestMerge: (opponent: string) => void;
 }) {
@@ -128,6 +224,11 @@ function OpponentRow({
           <span className="text-xs text-muted-foreground">
             {opponent.total} game{opponent.total === 1 ? '' : 's'}
           </span>
+          {lastPlayedAt != null && (
+            <span className="text-xs text-muted-foreground">
+              {new Date(lastPlayedAt).toLocaleDateString()}
+            </span>
+          )}
         </span>
       </button>
       <DropdownMenu>

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.test.tsx
@@ -132,7 +132,19 @@ describe('SetTimeline', () => {
       makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', opponent: 'rival' }),
     ];
     renderTimeline(matches);
-    expect(screen.getByText(/vs rival/)).toBeInTheDocument();
+    expect(screen.getByText(/rival/)).toBeInTheDocument();
+  });
+
+  it("shows the user's fighter(s) alongside the opponent's for a set", () => {
+    const matches = [
+      makeMatch({ id: 'g1', time: 100, win: true, externalId: 'sgg:1:g1', opponent: 'rival' }),
+    ];
+    renderTimeline(matches);
+    const userTags = screen.getByLabelText('Your fighters');
+    expect(within(userTags).getByAltText(mario.name)).toBeInTheDocument();
+    const opponentTags = screen.getByLabelText('Opponent fighters');
+    expect(within(opponentTags).getByAltText(luigi.name)).toBeInTheDocument();
+    expect(screen.getByText('vs')).toBeInTheDocument();
   });
 
   it('links the opponent tag to their start.gg profile when opponentUserSlug is present', () => {

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
@@ -20,6 +20,10 @@ function GameChip({ match }: { match: Match }) {
   const stage = stageId !== 0 ? stagesById.get(stageId) : undefined;
   const stageName = stage?.name ?? match.map?.name ?? 'unknown';
   const abbreviation = stage ? stageAbbreviation(stage.name) : '??';
+  const userFighter = getFighterById(match.fighter_id);
+  const opponentFighter = getFighterById(match.opponent_id);
+  const matchup =
+    userFighter && opponentFighter ? ` · ${userFighter.name} vs ${opponentFighter.name}` : '';
 
   return (
     <Tooltip>
@@ -35,15 +39,16 @@ function GameChip({ match }: { match: Match }) {
       </TooltipTrigger>
       <TooltipContent>
         {stageName} — {match.win ? 'Win' : 'Loss'}
+        {matchup}
       </TooltipContent>
     </Tooltip>
   );
 }
 
-function OpponentTags({ opponentFighterIds }: { opponentFighterIds: number[] }) {
+function FighterTags({ fighterIds, label }: { fighterIds: number[]; label: string }) {
   return (
-    <div className="flex items-center -space-x-1">
-      {opponentFighterIds.map((id) => {
+    <div className="flex items-center -space-x-1" aria-label={label}>
+      {fighterIds.map((id) => {
         const sprite = getFighterById(id);
         return sprite ? (
           <img
@@ -156,7 +161,7 @@ function OpponentLabel({ set }: { set: TournamentSet }) {
   return (
     <span className="flex items-center gap-1 text-sm text-muted-foreground">
       <span className="inline-flex items-center gap-1">
-        vs {set.opponentName}
+        {set.opponentName}
         {profileUrl && (
           <a
             href={profileUrl}
@@ -186,7 +191,11 @@ function SetRow({ set }: { set: TournamentSet }) {
     >
       <div className="flex flex-wrap items-center gap-3">
         <span className="min-w-32 text-sm font-medium">{set.roundText ?? `Set ${set.setId}`}</span>
-        <OpponentTags opponentFighterIds={set.opponentFighterIds} />
+        <div className="flex items-center gap-1.5">
+          <FighterTags fighterIds={set.userFighterIds} label="Your fighters" />
+          <span className="text-xs text-muted-foreground">vs</span>
+          <FighterTags fighterIds={set.opponentFighterIds} label="Opponent fighters" />
+        </div>
         <OpponentLabel set={set} />
         <div className="flex items-center gap-1">
           {set.games.map((g) => (
@@ -248,6 +257,7 @@ export function SetTimeline({
                 </h3>
                 <ul className="flex flex-col gap-2" aria-label="Other matches during this event">
                   {otherMatches.map((match) => {
+                    const userSprite = getFighterById(match.fighter_id);
                     const opponentSprite = getFighterById(match.opponent_id);
                     return (
                       <li
@@ -258,13 +268,27 @@ export function SetTimeline({
                           <span className="text-sm text-muted-foreground">
                             {new Date(match.time).toLocaleDateString()}
                           </span>
-                          {opponentSprite && (
-                            <img
-                              src={opponentSprite.url}
-                              alt={opponentSprite.name}
-                              className="size-6 object-contain"
-                            />
-                          )}
+                          <span className="flex items-center gap-1.5">
+                            {userSprite && (
+                              <img
+                                src={userSprite.url}
+                                alt={userSprite.name}
+                                title={userSprite.name}
+                                className="size-6 object-contain"
+                              />
+                            )}
+                            {(userSprite || opponentSprite) && (
+                              <span className="text-xs text-muted-foreground">vs</span>
+                            )}
+                            {opponentSprite && (
+                              <img
+                                src={opponentSprite.url}
+                                alt={opponentSprite.name}
+                                title={opponentSprite.name}
+                                className="size-6 object-contain"
+                              />
+                            )}
+                          </span>
                           <GameChip match={match} />
                         </div>
                         <Badge variant={match.win ? 'success' : 'destructive'}>

--- a/apps/web/src/pages/Tournaments/lib/setTimeline.ts
+++ b/apps/web/src/pages/Tournaments/lib/setTimeline.ts
@@ -37,6 +37,8 @@ export interface TournamentSet {
   roundText: string | undefined;
   /** start.gg's signed round integer; negative = losers side. */
   bracketRound: number | undefined;
+  /** The tracked user's fighter id(s) played across this set's games, in first-seen order. */
+  userFighterIds: number[];
   /** The opponent's fighter id(s) faced across this set's games, in first-seen order. */
   opponentFighterIds: number[];
   /** The human opponent's free-text tag for this set, when any game carries one. */
@@ -96,8 +98,12 @@ export function buildSetTimeline(entryMatches: Match[]): SetTimeline {
     const gamesWon = ordered.filter((g) => g.match.win).length;
     const gamesLost = ordered.length - gamesWon;
 
+    const userFighterIds: number[] = [];
     const opponentFighterIds: number[] = [];
     for (const g of ordered) {
+      if (!userFighterIds.includes(g.match.fighter_id)) {
+        userFighterIds.push(g.match.fighter_id);
+      }
       if (!opponentFighterIds.includes(g.match.opponent_id)) {
         opponentFighterIds.push(g.match.opponent_id);
       }
@@ -108,6 +114,7 @@ export function buildSetTimeline(entryMatches: Match[]): SetTimeline {
       time: Math.min(...ordered.map((g) => g.match.time)),
       roundText: ordered.map((g) => g.match.roundText).find((r) => r != null),
       bracketRound: ordered.map((g) => g.match.bracketRound).find((r) => r != null),
+      userFighterIds,
       opponentFighterIds,
       opponentName: ordered.map((g) => g.match.opponent).find((r) => r != null),
       opponentSeed: ordered.map((g) => g.match.opponentSeed).find((r) => r != null),


### PR DESCRIPTION
Two quick features:

**Scouting page** — sort selector for the opponent list (Most played / Recently played / Highest win rate / Lowest win rate / A→Z) plus a **3+ games** toggle that hides one-off opponents; the recently-played sort adds a last-played date per row.

**Set Timeline** — sets now show *your* fighter(s) next to the opponent's (`[you] vs [them]`), game-chip tooltips include the character matchup ("Battlefield — Win · Falco vs Jigglypuff"), and ungrouped matches show both sprites.

6 new tests; 781 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)