### PR TITLE
V9-B: reports library, event links, matchup advisor, parry.gg scouting

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -155,6 +155,8 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(scoutRoutes, {
         config: options.startgg ?? null,
         fetchImpl: options.startggFetch,
+        parryggConfig: options.parrygg ?? null,
+        parryggClients: options.parryggClients,
       });
       await api.register(reportsRoutes, {
         config: options.reports ?? null,
@@ -162,6 +164,8 @@ export function buildApp(options: BuildAppOptions) {
         stripeConfig: options.stripe ?? null,
         client: options.reportsClient,
         fetchImpl: options.startggFetch,
+        parryggConfig: options.parrygg ?? null,
+        parryggClients: options.parryggClients,
       });
       await api.register(billingRoutes, {
         stripeConfig: options.stripe ?? null,

--- a/apps/api/src/parrygg/scout.test.ts
+++ b/apps/api/src/parrygg/scout.test.ts
@@ -1,0 +1,541 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Entrant,
+  EventEntrant,
+  Game,
+  Hierarchy,
+  Match,
+  MatchContext,
+  MatchGame,
+  MatchGameParticipant,
+  MatchGameSlot,
+  MatchState,
+  Path,
+  PathType,
+  Seed,
+  Slot,
+  Character,
+  Stage,
+  User,
+} from '@parry-gg/client';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb.js';
+import { PARRYGG_SSBU_SLUG } from './sync.js';
+import type { ParryggClients, ParryggMatchContext, ParryggUserSummary } from './client.js';
+import {
+  accumulateParryMatchContext,
+  buildParryScoutReport,
+  parseParryProfileUrl,
+  ParryScoutCache,
+  resolveParryScoutPlayer,
+  scoutParryPlayer,
+} from './scout.js';
+
+const MY_USER_ID = '019ce9ba-debd-7e11-84a2-77258f52644e';
+const OPPONENT_USER_ID = 'opponent-user-id';
+
+function makeUser(id: string, gamerTag: string): User {
+  const user = new User();
+  user.setId(id);
+  user.setGamerTag(gamerTag);
+  return user;
+}
+
+function makeEntrant(users: User[]): Entrant {
+  const entrant = new Entrant();
+  entrant.setId(`entrant-${users[0]?.getId()}`);
+  entrant.setUsersList(users);
+  return entrant;
+}
+
+function makeSeed(id: string, seedNum: number, entrant: Entrant): Seed {
+  const seed = new Seed();
+  seed.setId(id);
+  seed.setSeed(seedNum);
+  const eventEntrant = new EventEntrant();
+  eventEntrant.setEntrant(entrant);
+  eventEntrant.setSeed(seedNum);
+  seed.setEventEntrant(eventEntrant);
+  return seed;
+}
+
+function makeSlot(slotNum: number, seedId: string, score: number): Slot {
+  const slot = new Slot();
+  slot.setSlot(slotNum);
+  slot.setSeedId(seedId);
+  slot.setScore(score);
+  return slot;
+}
+
+function timestamp(seconds: number): Timestamp {
+  const ts = new Timestamp();
+  ts.setSeconds(seconds);
+  return ts;
+}
+
+function makeCharacter(slug: string): Character {
+  const character = new Character();
+  character.setSlug(slug);
+  return character;
+}
+
+function makeStage(slug: string): Stage {
+  const stage = new Stage();
+  stage.setSlug(slug);
+  return stage;
+}
+
+function makeGameSlot(
+  slotNum: number,
+  userId: string,
+  characterSlug: string,
+  placement: number,
+): MatchGameSlot {
+  const gameSlot = new MatchGameSlot();
+  gameSlot.setSlot(slotNum);
+  gameSlot.setPlacement(placement);
+  const participant = new MatchGameParticipant();
+  participant.setUserId(userId);
+  participant.setCharactersList([makeCharacter(characterSlug)]);
+  gameSlot.setParticipantsList([participant]);
+  return gameSlot;
+}
+
+interface BuildOptions {
+  matchState?: MatchState;
+  mySlotScore?: number;
+  opponentSlotScore?: number;
+  gameSlug?: string | null;
+  matchGames?: MatchGame[];
+  eventName?: string;
+  tournamentName?: string;
+  eventSlug?: string;
+  tournamentSlug?: string;
+  opponentGamerTag?: string;
+  winnersPlacement?: number;
+  losersPlacement?: number;
+  teamOpponent?: boolean;
+  endedAtSeconds?: number;
+}
+
+/** Builds a realistic, fully-populated MatchContext (as `.toObject()`) — mirrors sync.test.ts's factory, extended with slug/placement fields V9-B scouting reads. */
+function makeMatchContext(options: BuildOptions = {}): ParryggMatchContext {
+  const {
+    matchState = MatchState.MATCH_STATE_COMPLETED,
+    mySlotScore = 2,
+    opponentSlotScore = 1,
+    gameSlug = PARRYGG_SSBU_SLUG,
+    matchGames = [],
+    eventName = 'Ultimate Singles',
+    tournamentName = 'Test Weekly 42',
+    eventSlug,
+    tournamentSlug,
+    opponentGamerTag = 'PowPow',
+    winnersPlacement,
+    losersPlacement,
+    teamOpponent = false,
+    endedAtSeconds = 1_700_000_000,
+  } = options;
+
+  const myUser = makeUser(MY_USER_ID, 'Me');
+  const opponentUser = makeUser(OPPONENT_USER_ID, opponentGamerTag);
+  const opponentUsers = teamOpponent
+    ? [opponentUser, makeUser('teammate-id', 'Teammate')]
+    : [opponentUser];
+
+  const mySeedMsg = makeSeed('seed-mine', 8, makeEntrant([myUser]));
+  const opponentSeedMsg = makeSeed('seed-opponent', 12, makeEntrant(opponentUsers));
+
+  const match = new Match();
+  match.setId('match-111');
+  match.setRound(2);
+  match.setState(matchState);
+  match.setSlotsList([
+    makeSlot(0, 'seed-mine', mySlotScore),
+    makeSlot(1, 'seed-opponent', opponentSlotScore),
+  ]);
+  match.setMatchGamesList(matchGames);
+  match.setEndedAt(timestamp(endedAtSeconds));
+  if (winnersPlacement != null) {
+    match.setWinnersPlacement(winnersPlacement);
+  }
+  if (losersPlacement != null) {
+    match.setLosersPlacement(losersPlacement);
+  }
+
+  const context = new MatchContext();
+  context.setMatch(match);
+  context.setSeedsList([mySeedMsg, opponentSeedMsg]);
+
+  if (gameSlug !== null) {
+    const game = new Game();
+    game.setSlug(gameSlug);
+    context.setGame(game);
+  }
+
+  const hierarchy = new Hierarchy();
+  const tournamentPath = new Path();
+  tournamentPath.setType(PathType.PATH_TYPE_TOURNAMENT);
+  tournamentPath.setName(tournamentName);
+  if (tournamentSlug) {
+    tournamentPath.setSlug(tournamentSlug);
+  }
+  const eventPath = new Path();
+  eventPath.setType(PathType.PATH_TYPE_EVENT);
+  eventPath.setName(eventName);
+  if (eventSlug) {
+    eventPath.setSlug(eventSlug);
+  }
+  hierarchy.setPathsList([tournamentPath, eventPath]);
+  context.setHierarchy(hierarchy);
+
+  return context.toObject();
+}
+
+describe('parseParryProfileUrl', () => {
+  it('parses a bare profile URL', () => {
+    expect(parseParryProfileUrl(`https://parry.gg/profile/${MY_USER_ID}`)).toBe(MY_USER_ID);
+  });
+
+  it('tolerates missing protocol and a trailing slash', () => {
+    expect(parseParryProfileUrl(`parry.gg/profile/${MY_USER_ID}/`)).toBe(MY_USER_ID);
+  });
+
+  it('returns null for a non-parry.gg URL', () => {
+    expect(parseParryProfileUrl('https://start.gg/user/07dc2239')).toBeNull();
+  });
+
+  it('returns null for a parry.gg URL that is not a profile', () => {
+    expect(parseParryProfileUrl('https://parry.gg/my-tournament-01931d1c')).toBeNull();
+  });
+
+  it('returns null for a bare gamer tag (not a URL at all)', () => {
+    expect(parseParryProfileUrl('PowPow')).toBeNull();
+  });
+
+  it('returns null when the path segment is not a valid UUID v7', () => {
+    expect(parseParryProfileUrl('https://parry.gg/profile/not-a-uuid')).toBeNull();
+  });
+});
+
+describe('resolveParryScoutPlayer', () => {
+  function stubClients(overrides: {
+    getUser?: (id: string) => ParryggUserSummary | null;
+    search?: ParryggUserSummary[];
+  }): ParryggClients {
+    return {
+      users: {
+        getUser: vi.fn(async (request: { getId: () => string }) => {
+          const found = overrides.getUser?.(request.getId());
+          return {
+            getUser: () =>
+              found
+                ? { toObject: () => ({ id: found.id, gamerTag: found.gamerTag, bioMd: '' }) }
+                : undefined,
+          };
+        }),
+        getUsers: vi.fn(async () => ({
+          getUsersList: () =>
+            (overrides.search ?? []).map((u) => ({ toObject: () => ({ ...u, bioMd: '' }) })),
+        })),
+      } as unknown as ParryggClients['users'],
+      matches: {} as unknown as ParryggClients['matches'],
+    };
+  }
+
+  it('resolves a profile URL directly via getUser', async () => {
+    const clients = stubClients({
+      getUser: (id) => (id === MY_USER_ID ? { id: MY_USER_ID, gamerTag: 'Pandem1c' } : null),
+    });
+    const result = await resolveParryScoutPlayer(
+      'key',
+      `https://parry.gg/profile/${MY_USER_ID}`,
+      clients,
+    );
+    expect(result).toEqual({ parryUserId: MY_USER_ID, gamerTag: 'Pandem1c' });
+  });
+
+  it('resolves a bare UUID directly via getUser', async () => {
+    const clients = stubClients({
+      getUser: (id) => (id === MY_USER_ID ? { id: MY_USER_ID, gamerTag: 'Pandem1c' } : null),
+    });
+    const result = await resolveParryScoutPlayer('key', MY_USER_ID, clients);
+    expect(result).toEqual({ parryUserId: MY_USER_ID, gamerTag: 'Pandem1c' });
+  });
+
+  it('resolves a bare tag via search, taking the best EXACT match', async () => {
+    const clients = stubClients({
+      search: [
+        { id: 'id-1', gamerTag: 'PowPow2' },
+        { id: 'id-2', gamerTag: 'PowPow' },
+      ],
+    });
+    const result = await resolveParryScoutPlayer('key', 'PowPow', clients);
+    expect(result).toEqual({ parryUserId: 'id-2', gamerTag: 'PowPow' });
+  });
+
+  it('is case-insensitive for the exact-tag match', async () => {
+    const clients = stubClients({ search: [{ id: 'id-2', gamerTag: 'PowPow' }] });
+    const result = await resolveParryScoutPlayer('key', 'powpow', clients);
+    expect(result?.parryUserId).toBe('id-2');
+  });
+
+  it('returns null when no exact tag match is found among fuzzy candidates', async () => {
+    const clients = stubClients({ search: [{ id: 'id-1', gamerTag: 'PowPow2' }] });
+    const result = await resolveParryScoutPlayer('key', 'PowPow', clients);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a direct id/URL does not resolve to a user', async () => {
+    const clients = stubClients({ getUser: () => null });
+    const result = await resolveParryScoutPlayer('key', MY_USER_ID, clients);
+    expect(result).toBeNull();
+  });
+});
+
+describe('accumulateParryMatchContext', () => {
+  function emptyAcc() {
+    return {
+      sampledSets: 0,
+      sampledGames: 0,
+      characters: new Map<number, { games: number; wins: number }>(),
+      stages: new Map<number, { games: number; wins: number }>(),
+      events: new Map<
+        string,
+        {
+          eventName: string;
+          tournamentName?: string;
+          placement?: number;
+          slug?: string;
+          lastSetAt: number;
+        }
+      >(),
+      opponents: new Map<string, number>(),
+    };
+  }
+
+  it('aggregates characters, stages, events, and opponents from the scouted player perspective', () => {
+    const acc = emptyAcc();
+    const game = new MatchGame();
+    game.setStagesList([makeStage('battlefield')]);
+    game.setSlotsList([
+      makeGameSlot(0, MY_USER_ID, 'mario', 1),
+      makeGameSlot(1, OPPONENT_USER_ID, 'sonic', 2),
+    ]);
+    const context = makeMatchContext({ matchGames: [game] });
+
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+
+    expect(acc.sampledSets).toBe(1);
+    expect(acc.sampledGames).toBe(1);
+    expect(acc.characters.get(1)).toEqual({ games: 1, wins: 1 }); // Mario
+    expect(acc.opponents.get('PowPow')).toBe(1);
+    const event = [...acc.events.values()][0];
+    expect(event).toMatchObject({
+      eventName: 'Ultimate Singles',
+      tournamentName: 'Test Weekly 42',
+    });
+  });
+
+  it('skips matches that are not completed', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({ matchState: MatchState.MATCH_STATE_IN_PROGRESS });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    expect(acc.sampledSets).toBe(0);
+  });
+
+  it('skips 0-0 walkovers', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({ mySlotScore: 0, opponentSlotScore: 0 });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    expect(acc.sampledSets).toBe(0);
+  });
+
+  it('skips matches with no game identified, and non-SSBU games', () => {
+    const acc = emptyAcc();
+    accumulateParryMatchContext(acc, makeMatchContext({ gameSlug: null }), MY_USER_ID);
+    accumulateParryMatchContext(
+      acc,
+      makeMatchContext({ gameSlug: 'super-smash-bros-melee' }),
+      MY_USER_ID,
+    );
+    expect(acc.sampledSets).toBe(0);
+  });
+
+  it('skips team entrants', () => {
+    const acc = emptyAcc();
+    accumulateParryMatchContext(acc, makeMatchContext({ teamOpponent: true }), MY_USER_ID);
+    expect(acc.sampledSets).toBe(0);
+  });
+
+  it('still counts a sampled set with no per-game detail, but contributes no character/stage rows (sparse young data)', () => {
+    const acc = emptyAcc();
+    accumulateParryMatchContext(acc, makeMatchContext({ matchGames: [] }), MY_USER_ID);
+    expect(acc.sampledSets).toBe(1);
+    expect(acc.sampledGames).toBe(0);
+    expect(acc.characters.size).toBe(0);
+    expect(acc.stages.size).toBe(0);
+    // Event/opponent are still recorded even with no game detail.
+    expect(acc.opponents.get('PowPow')).toBe(1);
+  });
+
+  it('groups unmapped characters under fighterId 0', () => {
+    const acc = emptyAcc();
+    const game = new MatchGame();
+    game.setStagesList([makeStage('battlefield')]);
+    game.setSlotsList([
+      makeGameSlot(0, MY_USER_ID, 'totally-unknown-character', 1),
+      makeGameSlot(1, OPPONENT_USER_ID, 'sonic', 2),
+    ]);
+    accumulateParryMatchContext(acc, makeMatchContext({ matchGames: [game] }), MY_USER_ID);
+    expect(acc.characters.get(0)).toEqual({ games: 1, wins: 1 });
+  });
+
+  it('groups unresolvable stages under stageId 0', () => {
+    const acc = emptyAcc();
+    const game = new MatchGame();
+    game.setStagesList([makeStage('some-brand-new-stage')]);
+    game.setSlotsList([
+      makeGameSlot(0, MY_USER_ID, 'mario', 1),
+      makeGameSlot(1, OPPONENT_USER_ID, 'sonic', 2),
+    ]);
+    accumulateParryMatchContext(acc, makeMatchContext({ matchGames: [game] }), MY_USER_ID);
+    expect(acc.stages.get(0)).toEqual({ games: 1, wins: 1 });
+  });
+
+  it('captures a tournament+event slug pair when both path types carry one', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({
+      tournamentSlug: 'my-tournament-01931d1c',
+      eventSlug: 'test',
+    });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    const event = [...acc.events.values()][0];
+    expect(event?.slug).toBe('my-tournament-01931d1c/test');
+  });
+
+  it('omits the slug when only one half of the pair is present', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({ tournamentSlug: 'my-tournament-01931d1c' });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    const event = [...acc.events.values()][0];
+    expect(event?.slug).toBeUndefined();
+  });
+
+  it('attributes winnersPlacement when I won the match', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({
+      mySlotScore: 3,
+      opponentSlotScore: 1,
+      winnersPlacement: 1,
+      losersPlacement: 0,
+    });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    const event = [...acc.events.values()][0];
+    expect(event?.placement).toBe(1);
+  });
+
+  it('attributes losersPlacement when I lost the match', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({
+      mySlotScore: 1,
+      opponentSlotScore: 3,
+      winnersPlacement: 0,
+      losersPlacement: 4,
+    });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    const event = [...acc.events.values()][0];
+    expect(event?.placement).toBe(4);
+  });
+
+  it('omits placement when it is 0 (not a meaningful placement match)', () => {
+    const acc = emptyAcc();
+    const context = makeMatchContext({ winnersPlacement: 0, losersPlacement: 0 });
+    accumulateParryMatchContext(acc, context, MY_USER_ID);
+    const event = [...acc.events.values()][0];
+    expect(event?.placement).toBeUndefined();
+  });
+});
+
+describe('buildParryScoutReport / scoutParryPlayer', () => {
+  const player = { parryUserId: MY_USER_ID, gamerTag: 'Pandem1c' };
+
+  function clientsReturning(contexts: ParryggMatchContext[]): ParryggClients {
+    return {
+      users: {} as unknown as ParryggClients['users'],
+      matches: {
+        getMatches: vi.fn(async () => ({
+          getMatchesList: () => contexts.map((c) => ({ toObject: () => c })),
+        })),
+      } as unknown as ParryggClients['matches'],
+    };
+  }
+
+  it('builds a full ScoutReportData with a parrygg-sourced identity', async () => {
+    const game = new MatchGame();
+    game.setStagesList([makeStage('battlefield')]);
+    game.setSlotsList([
+      makeGameSlot(0, MY_USER_ID, 'mario', 1),
+      makeGameSlot(1, OPPONENT_USER_ID, 'sonic', 2),
+    ]);
+    const clients = clientsReturning([makeMatchContext({ matchGames: [game] })]);
+
+    const report = await buildParryScoutReport('api-key', player, clients);
+
+    expect(report.player).toEqual({
+      source: 'parrygg',
+      parryUserId: MY_USER_ID,
+      gamerTag: 'Pandem1c',
+    });
+    expect(report.sampledSets).toBe(1);
+    expect(report.characters[0]).toMatchObject({ fighterId: 1, games: 1, wins: 1 });
+  });
+
+  it('tolerates empty matchGames everywhere (no character/stage rows, still events + opponents)', async () => {
+    const clients = clientsReturning([makeMatchContext({ matchGames: [] })]);
+    const report = await buildParryScoutReport('api-key', player, clients);
+    expect(report.characters).toEqual([]);
+    expect(report.stages).toEqual([]);
+    expect(report.recentEvents.length).toBeGreaterThan(0);
+    expect(report.commonOpponents.length).toBeGreaterThan(0);
+  });
+
+  it('scoutParryPlayer resolves + builds + caches by parryUserId', async () => {
+    let getMatchesCalls = 0;
+    const clients: ParryggClients = {
+      users: {
+        getUser: vi.fn(async () => ({
+          getUser: () => ({
+            toObject: () => ({ id: MY_USER_ID, gamerTag: 'Pandem1c', bioMd: '' }),
+          }),
+        })),
+        getUsers: vi.fn(),
+      } as unknown as ParryggClients['users'],
+      matches: {
+        getMatches: vi.fn(async () => {
+          getMatchesCalls += 1;
+          return { getMatchesList: () => [] };
+        }),
+      } as unknown as ParryggClients['matches'],
+    };
+    const cache = new ParryScoutCache();
+
+    const first = await scoutParryPlayer('key', MY_USER_ID, cache, clients);
+    const second = await scoutParryPlayer('key', MY_USER_ID, cache, clients);
+
+    expect(first).not.toBeNull();
+    expect(second).toEqual(first);
+    expect(getMatchesCalls).toBe(1); // second call was a cache hit
+  });
+
+  it('scoutParryPlayer returns null when the player does not resolve', async () => {
+    const clients: ParryggClients = {
+      users: {
+        getUser: vi.fn(async () => ({ getUser: () => undefined })),
+        getUsers: vi.fn(async () => ({ getUsersList: () => [] })),
+      } as unknown as ParryggClients['users'],
+      matches: { getMatches: vi.fn() } as unknown as ParryggClients['matches'],
+    };
+    const result = await scoutParryPlayer('key', 'nobody', new ParryScoutCache(), clients);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/parrygg/scout.ts
+++ b/apps/api/src/parrygg/scout.ts
@@ -1,0 +1,436 @@
+import { MatchState } from '@parry-gg/client';
+import type { ScoutReportData } from '@smash-tracker/shared';
+import {
+  getUser,
+  getUserMatches,
+  searchUsers,
+  type ParryggClients,
+  type ParryggMatchContext,
+} from './client.js';
+import {
+  findSeeds,
+  PARRYGG_SSBU_SLUG,
+  PATH_TYPE_EVENT,
+  PATH_TYPE_TOURNAMENT,
+  pathNameByType,
+  pathSlugByType,
+  type Seed,
+} from './sync.js';
+import { parryggCharacterSlugToFighterId } from './characters.js';
+import { resolveParryggStage } from './stages.js';
+
+/**
+ * V9-B Feature 4: scout ANY parry.gg player, mirroring the shape/conventions
+ * of ../startgg/scout.ts closely enough that both feed the exact same
+ * `ScoutReportData` shape — everything downstream (the Scout page, the AI
+ * report payload assembly) is source-agnostic once it has a `ScoutReportData`.
+ *
+ * Key structural difference from start.gg: there is no separate "sets"
+ * concept to paginate — `getUserMatches` returns the user's full match
+ * history in one gRPC call (parry.gg is young; nobody has thousands of
+ * matches yet), so there's no page cap to enforce here the way start.gg's
+ * `MAX_SCOUT_PAGES` exists for its per-page GraphQL query.
+ */
+
+const MAX_RECENT_EVENTS = 10;
+const MAX_COMMON_OPPONENTS = 10;
+const UNMAPPED_FIGHTER_ID = 0;
+const UNKNOWN_STAGE_ID = 0;
+
+// ---------------------------------------------------------------------------
+// Input parsing
+// ---------------------------------------------------------------------------
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(/^[a-z]+:\/\//i.test(value) ? value : `https://${value}`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A UUID v7 (parry.gg's user id format — verified live against the API, see
+ * ../parrygg/client.ts and the V8-A/V8-B PR notes). Version nibble '7',
+ * variant nibble one of 8/9/a/b per RFC 9562.
+ */
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Parses a parry.gg profile URL into a bare user id, or null when `rawQuery`
+ * doesn't look like one. Verified profile URL shape (WebSearch + WebFetch
+ * against live parry.gg profile pages, 2026-07-06):
+ * `https://parry.gg/profile/{uuid-v7}` — no gamer tag ever appears in the
+ * URL, only the UUID, e.g.
+ * "https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e".
+ *
+ * Accepts the URL with or without protocol/trailing slash/query/hash, same
+ * tolerance as start.gg's `parseScoutInput`. Returns null (not a throw) so
+ * callers can fall through to bare-tag search — a parry.gg URL is a strong,
+ * unambiguous signal, but anything else must not be assumed to be one.
+ */
+export function parseParryProfileUrl(rawQuery: string): string | null {
+  const trimmed = rawQuery.trim();
+  const url = parseUrl(trimmed);
+  if (!url || !/(^|\.)parry\.gg$/i.test(url.hostname)) {
+    return null;
+  }
+  const match = /^\/profile\/([0-9a-f-]+)\/?$/i.exec(url.pathname);
+  const candidate = match?.[1];
+  if (candidate && UUID_V7_PATTERN.test(candidate)) {
+    return candidate;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolvedParryScoutPlayer {
+  parryUserId: string;
+  gamerTag: string;
+}
+
+/**
+ * Resolves a parry.gg scouting query to a player identity:
+ * - A parry.gg profile URL resolves directly via `getUser`.
+ * - A bare user id (already a UUID v7) resolves directly via `getUser`.
+ * - Anything else is treated as a gamer tag: `searchUsers` fuzzy-matches,
+ *   and the best EXACT (case-insensitive) tag match wins; no exact match
+ *   means "not found" (null) rather than guessing at a fuzzy result.
+ */
+export async function resolveParryScoutPlayer(
+  apiKey: string,
+  rawQuery: string,
+  clients?: ParryggClients,
+): Promise<ResolvedParryScoutPlayer | null> {
+  const trimmed = rawQuery.trim();
+  const profileUserId = parseParryProfileUrl(trimmed);
+  const directUserId = profileUserId ?? (UUID_V7_PATTERN.test(trimmed) ? trimmed : null);
+
+  if (directUserId) {
+    const user = await getUser(apiKey, directUserId, clients);
+    return user ? { parryUserId: user.id, gamerTag: user.gamerTag } : null;
+  }
+
+  const candidates = await searchUsers(apiKey, trimmed, 10, clients);
+  const exact = candidates.find((c) => c.gamerTag.toLowerCase() === trimmed.toLowerCase());
+  return exact ? { parryUserId: exact.id, gamerTag: exact.gamerTag } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+interface Accumulators {
+  sampledSets: number;
+  sampledGames: number;
+  characters: Map<number, { games: number; wins: number }>;
+  stages: Map<number, { games: number; wins: number }>;
+  events: Map<
+    string,
+    {
+      eventName: string;
+      tournamentName?: string;
+      placement?: number;
+      slug?: string;
+      lastSetAt: number;
+    }
+  >;
+  opponents: Map<string, number>;
+}
+
+function emptyAccumulators(): Accumulators {
+  return {
+    sampledSets: 0,
+    sampledGames: 0,
+    characters: new Map(),
+    stages: new Map(),
+    events: new Map(),
+    opponents: new Map(),
+  };
+}
+
+function bump(map: Map<number, { games: number; wins: number }>, key: number, won: boolean): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.games += 1;
+    if (won) {
+      existing.wins += 1;
+    }
+  } else {
+    map.set(key, { games: 1, wins: won ? 1 : 0 });
+  }
+}
+
+/**
+ * Folds one parry.gg MatchContext into the accumulators, from the scouted
+ * player's own perspective. Mirrors `sync.ts`'s `gamesFromMatchContext`
+ * filtering/shape-handling (completed-only, SSBU-only, singles-only,
+ * sparse-data tolerance) but aggregates in memory instead of writing match
+ * records — same relationship `startgg/scout.ts`'s `accumulateScoutSet` has
+ * to `startgg/sync.ts`'s `gamesFromSet`. Exported for tests.
+ */
+export function accumulateParryMatchContext(
+  acc: Accumulators,
+  context: ParryggMatchContext,
+  parryUserId: string,
+): void {
+  const match = context.match;
+  if (!match) {
+    return;
+  }
+
+  const slots = match.slotsList;
+  const bothScoresZero = slots.length === 2 && slots.every((s) => s.score === 0);
+  if (match.state !== MatchState.MATCH_STATE_COMPLETED || bothScoresZero) {
+    return;
+  }
+
+  // SSBU filter: same "never assume" convention as sync.ts — no `game` at
+  // all, or a `game` that isn't SSBU, both mean "skip".
+  if (!context.game || context.game.slug !== PARRYGG_SSBU_SLUG) {
+    return;
+  }
+
+  const seedResult = findSeeds(context.seedsList, parryUserId);
+  if (seedResult === 'team' || !seedResult) {
+    return;
+  }
+  const { mine, opponent } = seedResult;
+
+  acc.sampledSets += 1;
+
+  const opponentUser = opponent.eventEntrant?.entrant?.usersList[0];
+  const opponentTag = opponentUser?.gamerTag?.trim() || opponent.eventEntrant?.name?.trim();
+  if (opponentTag) {
+    acc.opponents.set(opponentTag, (acc.opponents.get(opponentTag) ?? 0) + 1);
+  }
+
+  const paths = context.hierarchy?.pathsList ?? [];
+  const eventName = pathNameByType(paths, PATH_TYPE_EVENT);
+  const tournamentName = pathNameByType(paths, PATH_TYPE_TOURNAMENT);
+  const tournamentSlug = pathSlugByType(paths, PATH_TYPE_TOURNAMENT);
+  const eventSlugPart = pathSlugByType(paths, PATH_TYPE_EVENT);
+  // parry.gg's public event URL is `{tournamentSlug}/{eventSlug}` (verified
+  // live, 2026-07-06: a tournament page like "/my-tournament-01931d1c" links
+  // its events at "/my-tournament-01931d1c/test", confirmed via the site's
+  // own bracket/standings sub-pages) — both halves are required, so a slug
+  // is only recorded when both path types are present.
+  const slug = tournamentSlug && eventSlugPart ? `${tournamentSlug}/${eventSlugPart}` : undefined;
+
+  // "Placement where meaningful" — Match.winnersPlacement/losersPlacement
+  // are only nonzero on the match that actually decided a final bracket
+  // placement (e.g. the true Grand Finals), not on every match a player
+  // plays. Attribute whichever side's placement applies to ME.
+  const placement = myWonMatch(match, mine)
+    ? match.winnersPlacement || undefined
+    : match.losersPlacement || undefined;
+
+  const eventKey = eventName ? `${tournamentName ?? ''}::${eventName}` : undefined;
+  if (eventKey) {
+    const endedAtSeconds = match.endedAt?.seconds ?? match.stateUpdatedAt?.seconds;
+    const lastSetAtMs =
+      typeof endedAtSeconds === 'number'
+        ? endedAtSeconds * 1000
+        : (context.eventStartDate?.seconds ?? 0) * 1000;
+    const existing = acc.events.get(eventKey);
+    if (!existing || lastSetAtMs > existing.lastSetAt) {
+      acc.events.set(eventKey, {
+        eventName: eventName!,
+        ...(tournamentName ? { tournamentName } : {}),
+        ...(placement != null ? { placement } : {}),
+        ...(slug ? { slug } : {}),
+        lastSetAt: lastSetAtMs,
+      });
+    } else {
+      if (placement != null) {
+        existing.placement = placement;
+      }
+      if (slug) {
+        existing.slug = slug;
+      }
+    }
+  }
+
+  const games = match.matchGamesList;
+  // Only "mine" is needed here — unlike sync.ts, the scout accumulator only
+  // ever tracks the scouted player's OWN character/stage picks (their own
+  // perspective), never the opponent's, so there's no opponent slot lookup.
+  const mySlotEntry = slots.find((s) => s.seedId === mine.id);
+
+  if (games.length === 0) {
+    // No per-game detail — same "sparse young data" tolerance as sync.ts:
+    // still counted as a sampled set, but contributes no character/stage
+    // rows (there is nothing to attribute a character pick to).
+    return;
+  }
+
+  games.forEach((game) => {
+    const myGameSlot =
+      mySlotEntry != null ? game.slotsList.find((s) => s.slot === mySlotEntry.slot) : undefined;
+    if (!myGameSlot) {
+      return;
+    }
+    acc.sampledGames += 1;
+
+    const myParticipant =
+      myGameSlot.participantsList.find((p) => p.userId === parryUserId) ??
+      myGameSlot.participantsList[0];
+    const myCharacterSlug = myParticipant?.charactersList[0]?.slug;
+    const fighterId = parryggCharacterSlugToFighterId(myCharacterSlug) ?? UNMAPPED_FIGHTER_ID;
+    const won = (myGameSlot.placement ?? 0) === 1;
+    bump(acc.characters, fighterId, won);
+
+    const stageSlug = game.stagesList[0]?.slug;
+    const resolvedStage = resolveParryggStage(stageSlug);
+    bump(acc.stages, resolvedStage?.id ?? UNKNOWN_STAGE_ID, won);
+  });
+}
+
+/** Whether the seed identified as "mine" won the overall match (by final slot score). */
+function myWonMatch(match: NonNullable<ParryggMatchContext['match']>, mine: Seed): boolean {
+  const mySlot = match.slotsList.find((s) => s.seedId === mine.id);
+  const otherSlot = match.slotsList.find((s) => s.seedId !== mine.id);
+  return (mySlot?.score ?? 0) > (otherSlot?.score ?? 0);
+}
+
+function toReport(acc: Accumulators, player: ResolvedParryScoutPlayer): ScoutReportData {
+  const characters = [...acc.characters.entries()]
+    .map(([fighterId, { games, wins }]) => ({ fighterId, games, wins }))
+    .sort((a, b) => b.games - a.games);
+
+  const stages = [...acc.stages.entries()]
+    .map(([stageId, { games, wins }]) => ({ stageId, games, wins }))
+    .sort((a, b) => b.games - a.games);
+
+  const recentEvents = [...acc.events.values()]
+    .sort((a, b) => b.lastSetAt - a.lastSetAt)
+    .slice(0, MAX_RECENT_EVENTS)
+    .map((event) => ({
+      eventName: event.eventName,
+      ...(event.tournamentName ? { tournamentName: event.tournamentName } : {}),
+      ...(event.placement != null ? { placement: event.placement } : {}),
+      // parry.gg events are deliberately left WITHOUT a rendered deep link
+      // for now even though a slug is captured here — see the code comment
+      // in ScoutRecentEventsCard.tsx for why (no verified parry.gg EVENT
+      // page URL, only the profile URL). The slug/source are still recorded
+      // so a future verification only needs a web-side change.
+      ...(event.slug ? { slug: event.slug, source: 'parrygg' as const } : {}),
+      lastSetAt: event.lastSetAt,
+    }));
+
+  const commonOpponents = [...acc.opponents.entries()]
+    .map(([gamerTag, sets]) => ({ gamerTag, sets }))
+    .sort((a, b) => b.sets - a.sets)
+    .slice(0, MAX_COMMON_OPPONENTS);
+
+  return {
+    player: {
+      source: 'parrygg',
+      parryUserId: player.parryUserId,
+      gamerTag: player.gamerTag,
+    },
+    sampledSets: acc.sampledSets,
+    sampledGames: acc.sampledGames,
+    characters,
+    stages,
+    recentEvents,
+    commonOpponents,
+  };
+}
+
+/**
+ * Fetches and aggregates a parry.gg player's full completed-match history
+ * into a `ScoutReportData`. Exported for tests; `scoutParryPlayer` below
+ * wraps this with the cache.
+ */
+export async function buildParryScoutReport(
+  apiKey: string,
+  player: ResolvedParryScoutPlayer,
+  clients?: ParryggClients,
+): Promise<ScoutReportData> {
+  const acc = emptyAccumulators();
+  const contexts = await getUserMatches(apiKey, player.parryUserId, clients);
+  for (const context of contexts) {
+    accumulateParryMatchContext(acc, context, player.parryUserId);
+  }
+  return toReport(acc, player);
+}
+
+// ---------------------------------------------------------------------------
+// Caching — own instance, source-prefixed keys not needed since this cache
+// is entirely separate from the start.gg one (see startgg/scout.ts for the
+// rationale on why an in-memory, per-instance cache is a pragmatic fit here).
+// ---------------------------------------------------------------------------
+
+const CACHE_MAX_ENTRIES = 50;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface CacheEntry {
+  report: ScoutReportData;
+  expiresAt: number;
+}
+
+export class ParryScoutCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly maxEntries = CACHE_MAX_ENTRIES,
+    private readonly ttlMs = CACHE_TTL_MS,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get(parryUserId: string): ScoutReportData | null {
+    const entry = this.entries.get(parryUserId);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(parryUserId);
+      return null;
+    }
+    this.entries.delete(parryUserId);
+    this.entries.set(parryUserId, entry);
+    return entry.report;
+  }
+
+  set(parryUserId: string, report: ScoutReportData): void {
+    this.entries.delete(parryUserId);
+    this.entries.set(parryUserId, { report, expiresAt: this.now() + this.ttlMs });
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+/** Resolves + aggregates a parry.gg scout report for `rawQuery`, using `cache` to skip re-fetching. */
+export async function scoutParryPlayer(
+  apiKey: string,
+  rawQuery: string,
+  cache: ParryScoutCache,
+  clients?: ParryggClients,
+): Promise<ScoutReportData | null> {
+  const player = await resolveParryScoutPlayer(apiKey, rawQuery, clients);
+  if (!player) {
+    return null;
+  }
+
+  const cached = cache.get(player.parryUserId);
+  if (cached) {
+    return cached;
+  }
+
+  const report = await buildParryScoutReport(apiKey, player, clients);
+  cache.set(player.parryUserId, report);
+  return report;
+}

--- a/apps/api/src/parrygg/sync.ts
+++ b/apps/api/src/parrygg/sync.ts
@@ -38,24 +38,33 @@ interface ImportableGame {
   opponentTag: string;
 }
 
-type Seed = ParryggMatchContext['seedsList'][number];
-type PathEntry = NonNullable<ParryggMatchContext['hierarchy']>['pathsList'][number];
+export type Seed = ParryggMatchContext['seedsList'][number];
+export type PathEntry = NonNullable<ParryggMatchContext['hierarchy']>['pathsList'][number];
 
-/** `hierarchy.pathsList` path types (see @parry-gg/client's `PathType` enum): 0=tournament, 1=event, 2=phase, 3=bracket. */
-const PATH_TYPE_TOURNAMENT = 0;
-const PATH_TYPE_EVENT = 1;
+/** `hierarchy.pathsList` path types (see @parry-gg/client's `PathType` enum): 0=tournament, 1=event, 2=phase, 3=bracket. Exported for reuse by ../parrygg/scout.ts (V9-B). */
+export const PATH_TYPE_TOURNAMENT = 0;
+export const PATH_TYPE_EVENT = 1;
 
-function pathNameByType(paths: PathEntry[], type: number): string | undefined {
+/** Exported for reuse by ../parrygg/scout.ts (V9-B) — same slug/name path lookup, one implementation. */
+export function pathNameByType(paths: PathEntry[], type: number): string | undefined {
   return paths.find((p) => p.type === type)?.name?.trim() || undefined;
+}
+
+/** Same lookup as `pathNameByType`, but for the path's `slug` instead of its `name` (V9-B — event deep links). */
+export function pathSlugByType(paths: PathEntry[], type: number): string | undefined {
+  return paths.find((p) => p.type === type)?.slug?.trim() || undefined;
 }
 
 /**
  * Finds the seed whose entrant is the linked parry.gg user, and the
  * opposing seed. Returns null when either side is a team entrant
  * (`usersList.length > 1` — singles only for v1, see `teamEntrants`
- * counter) or when the match doesn't have exactly two seeds.
+ * counter) or when the match doesn't have exactly two seeds. Exported for
+ * reuse by ../parrygg/scout.ts (V9-B) — same "who am I in this match" logic
+ * that sync uses for a linked account applies unchanged to any parry.gg
+ * user id being scouted.
  */
-function findSeeds(
+export function findSeeds(
   seeds: Seed[],
   parryUserId: string,
 ): { mine: Seed; opponent: Seed } | 'team' | null {

--- a/apps/api/src/reports/generate.test.ts
+++ b/apps/api/src/reports/generate.test.ts
@@ -359,6 +359,7 @@ const PAYLOAD = {
     myCharacterRecords: [],
     vsTopCharacters: [],
     recentForm: { wins: 0, losses: 0, sampleSize: 0 },
+    matchupAdvisor: [],
   },
   notes: null,
 };

--- a/apps/api/src/reports/generate.ts
+++ b/apps/api/src/reports/generate.ts
@@ -2,11 +2,15 @@ import type { Database } from 'firebase-admin/database';
 import Anthropic from '@anthropic-ai/sdk';
 import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
 import {
+  buildMatchupAdvisor,
   generatedScoutReportSchema,
   matchRecordSchema,
   opponentNoteMapSchema,
+  selectMyCandidateFighterIds,
   SpriteList,
   type GeneratedScoutReport,
+  type MatchupEvidence,
+  type MyCharacterRecordVsOpponent,
   type OpponentNote,
   type ScoutReportData,
 } from '@smash-tracker/shared';
@@ -72,6 +76,17 @@ export interface ReportPayload {
     vsTopCharacters: MatchupAggregate[];
     /** W/L over the user's most recent 50 matches (any opponent). */
     recentForm: { wins: number; losses: number; sampleSize: number };
+    /**
+     * V9-B Feature 3: the SAME deterministic matchup-advisor ranking the web
+     * ScoutMatchupAdvisorCard shows, one entry per opponent top-5 character
+     * — kept lean (opponent's top-5 only, not the full roster) per the
+     * feature's payload-size guidance. `characterStrategy` must ground its
+     * picks in this, not contradict it without stating why (see SYSTEM_PROMPT).
+     */
+    matchupAdvisor: Array<{
+      opponentCharacter: string;
+      ranked: Array<{ character: string; score: number; evidence: MatchupEvidence }>;
+    }>;
   };
   notes: OpponentNote | null;
 }
@@ -127,6 +142,13 @@ export async function assembleReportPayload(
 
   const scoutedCanonicalName = normalizeOpponentTag(scout.player.gamerTag);
 
+  // H2H matching: the `opponentUserSlug` shortcut only ever applies to
+  // start.gg-scouted players (`scout.player.userSlug` is a start.gg-only
+  // field — see scoutPlayerIdentitySchema). For a parry.gg-scouted player
+  // (V9-B Feature 4), `scout.player.userSlug` is simply absent, so this
+  // condition naturally short-circuits false and every match falls through
+  // to the canonicalized-gamerTag path below unchanged — no source-specific
+  // branch needed here.
   const matchesVsScoutedPlayer = rawMatches.filter((match) => {
     if (
       match.opponentUserSlug &&
@@ -216,26 +238,18 @@ export async function assembleReportPayload(
   // (the user's own top-5 characters by games played in their own match
   // history), each broken down overall AND vs. the opponent's top-5
   // characters. This is what grounds characterStrategy — the model must only
-  // recommend characters the user demonstrably plays.
-  const gamesPlayedByFighterId = new Map<number, number>();
-  for (const match of rawMatches) {
-    gamesPlayedByFighterId.set(
-      match.fighter_id,
-      (gamesPlayedByFighterId.get(match.fighter_id) ?? 0) + 1,
-    );
-  }
-  const myTopFighterIds = [...gamesPlayedByFighterId.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, MY_TOP_CHARACTERS_COUNT)
-    .map(([fighterId]) => fighterId);
+  // recommend characters the user demonstrably plays. `selectMyCandidateFighterIds`
+  // is the SAME shared helper `ScoutMatchupAdvisorCard` uses client-side, so
+  // both the AI report's grounding and the web card's advisor rank the exact
+  // same candidate set.
+  const myFighterIds = selectMyCandidateFighterIds(
+    rawMatches.map((match) => match.fighter_id),
+    primaryFighterIds,
+    secondaryFighterIds,
+    MY_TOP_CHARACTERS_COUNT,
+  );
 
-  const myFighterIds = new Set<number>([
-    ...primaryFighterIds,
-    ...secondaryFighterIds,
-    ...myTopFighterIds,
-  ]);
-
-  const myCharacterRecords: CharacterRecord[] = [...myFighterIds].map((fighterId) => {
+  const myCharacterRecords: CharacterRecord[] = myFighterIds.map((fighterId) => {
     const matchesAsThisCharacter = rawMatches.filter((match) => match.fighter_id === fighterId);
     const wins = matchesAsThisCharacter.filter((match) => match.win).length;
     const losses = matchesAsThisCharacter.length - wins;
@@ -260,6 +274,38 @@ export async function assembleReportPayload(
     };
   });
 
+  // matchupAdvisor (V9-B Feature 3): the SAME deterministic ranking the web
+  // ScoutMatchupAdvisorCard shows, computed server-side from the shared
+  // `matchupAdvisor.ts` module — zero added Claude cost, and guarantees the
+  // model's characterStrategy can never contradict what the UI already told
+  // the user without a stated reason (see the updated SYSTEM_PROMPT below).
+  // Raw per-my-character W/L vs. each opponent top character, built from the
+  // SAME `rawMatches` used for `myCharacterRecords` above (not re-fetched).
+  const recordsByOpponentFighterId = new Map<number, MyCharacterRecordVsOpponent[]>(
+    topCharacterIds.map((opponentFighterId) => [
+      opponentFighterId,
+      myFighterIds.map((fighterId) => {
+        const matchesAsThisVsOpponent = rawMatches.filter(
+          (match) => match.fighter_id === fighterId && match.opponent_id === opponentFighterId,
+        );
+        const wins = matchesAsThisVsOpponent.filter((match) => match.win).length;
+        return { fighterId, wins, losses: matchesAsThisVsOpponent.length - wins };
+      }),
+    ]),
+  );
+  const matchupAdvisor = buildMatchupAdvisor(
+    topCharacterIds,
+    myFighterIds,
+    recordsByOpponentFighterId,
+  ).map((ranking) => ({
+    opponentCharacter: fighterName(ranking.opponentFighterId),
+    ranked: ranking.ranked.map((pick) => ({
+      character: fighterName(pick.fighterId),
+      score: pick.score,
+      evidence: pick.evidence,
+    })),
+  }));
+
   return {
     scout,
     headToHead,
@@ -272,6 +318,7 @@ export async function assembleReportPayload(
         losses: recentMatches.length - recentWins,
         sampleSize: recentMatches.length,
       },
+      matchupAdvisor,
     },
     notes,
   };
@@ -314,14 +361,15 @@ Hard rules — follow these exactly:
 - If a conclusion is drawn from fewer than 5 games of evidence (a character matchup, a stage record, a head-to-head record, etc.), you MUST flag that sample-size caveat explicitly in confidenceNotes.
 - Stage names and character names in your output must come VERBATIM from the data provided — do not paraphrase, translate, or invent alternate spellings.
 - Be concise and actionable. No filler, no generic advice that isn't grounded in this specific opponent's data.
-- The payload contains: "scout" (the opponent's public start.gg history — their characters, stages, recent events, common opponents), "headToHead" (the user's own past matches against this exact player, if any), "userContext" (the user's own character selections and character-matchup records, the user's raw W/L record against players of the opponent's most-used characters broken down by stage, and the user's recent overall form), and "notes" (a saved tendency note about this opponent, if the user has one).
+- The payload contains: "scout" (the opponent's public tournament-site history — their characters, stages, recent events, common opponents), "headToHead" (the user's own past matches against this exact player, if any), "userContext" (the user's own character selections and character-matchup records, the user's raw W/L record against players of the opponent's most-used characters broken down by stage, the user's recent overall form, and a deterministic matchup advisor ranking — see below), and "notes" (a saved tendency note about this opponent, if the user has one).
 - When headToHead is empty, set the headToHead field in your response to null — do not fabricate a head-to-head summary.
 - Output must conform to the provided JSON schema exactly.
 
 Character strategy is CO-EQUAL in importance with stage strategy — treat characterStrategy with the same rigor and specificity you give stageStrategy, not as an afterthought:
 - "userContext.myFighters" lists the user's own primary/secondary character selections. "userContext.myCharacterRecords" gives, for each character the user demonstrably plays (their selections plus their most-used characters by games played), that character's overall W/L and W/L against each of the opponent's top characters.
+- "userContext.matchupAdvisor" is a DETERMINISTIC, pre-computed ranking (not generated by you) of the user's own characters against each of the opponent's top-5 characters, blending the user's real record with tier-list/archetype priors — each entry's "evidence" explains why (a record, a tier score, an archetype edge). Treat this ranking as the GROUND TRUTH starting point for characterStrategy: your picks should normally match its top-ranked character for the opponent's most-used character. You MAY explain nuance or adjust for something the ranking can't see (e.g. stage-specific patterns, a saved note), but if your recommendation diverges from the advisor's top pick you MUST say so explicitly and state why in characterStrategy.reasoning — never silently contradict it.
 - You MUST recommend picks ONLY from characters that appear in "userContext.myFighters" or "userContext.myCharacterRecords" — NEVER recommend a character the user does not play, even if it would theoretically counter the opponent well.
-- characterStrategy.picks must include a game-1 recommendation, and characterStrategy.reasoning must state what to switch to if the opponent changes character (e.g. "Game 1: X; if they swap to Y, counter with Z"), grounded in the user's actual W/L from myCharacterRecords against the opponent's specific top characters — not generic tier-list reasoning.
+- characterStrategy.picks must include a game-1 recommendation, and characterStrategy.reasoning must state what to switch to if the opponent changes character (e.g. "Game 1: X; if they swap to Y, counter with Z"), grounded in the user's actual W/L from myCharacterRecords against the opponent's specific top characters and the matchupAdvisor ranking — not generic tier-list reasoning invented from scratch.
 - If the user's own character data is too sparse to ground a confident recommendation, say so explicitly in characterStrategy.reasoning and confidenceNotes rather than guessing.`;
 
 /** Thrown for a Claude response that didn't produce a usable report. */

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Anthropic from '@anthropic-ai/sdk';
 import type { StartggConfig, ReportsConfig } from '../config/env.js';
 import type { AnthropicLikeClient } from '../reports/generate.js';
+import type { ParryggClients } from '../parrygg/client.js';
 import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
 
 const STARTGG_CONFIG: StartggConfig = {
@@ -855,5 +856,104 @@ describe('GET /api/reports/:id (configured, allowlisted)', () => {
       player: { gamerTag: 'Pandem1c' },
       report: VALID_REPORT,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V9-B Feature 4: parry.gg-sourced report generation.
+// ---------------------------------------------------------------------------
+
+const PARRY_USER_ID = '019ce9ba-debd-7e11-84a2-77258f52644e';
+
+function parryClients(overrides: {
+  getUser?: () => { id: string; gamerTag: string } | null;
+}): ParryggClients {
+  return {
+    users: {
+      getUser: vi.fn(async () => {
+        const found = overrides.getUser?.() ?? null;
+        return {
+          getUser: () => (found ? { toObject: () => ({ ...found, bioMd: '' }) } : undefined),
+        };
+      }),
+      getUsers: vi.fn(async () => ({ getUsersList: () => [] })),
+    } as unknown as ParryggClients['users'],
+    matches: {
+      getMatches: vi.fn(async () => ({ getMatchesList: () => [] })),
+    } as unknown as ParryggClients['matches'],
+  };
+}
+
+describe('POST /api/reports (parry.gg, V9-B, allowlisted)', () => {
+  it('answers 503 for a parry.gg query when only start.gg is configured', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('generates and stores a report for a parry.gg-scouted player', async () => {
+    const { app, database } = buildTestApp({
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      player: { source: 'parrygg', parryUserId: PARRY_USER_ID, gamerTag: 'Pandem1c' },
+      report: VALID_REPORT,
+    });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const scoutReports = dump.scoutReports as Record<string, Record<string, unknown>>;
+    const stored = Object.values(scoutReports[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({
+      player: { source: 'parrygg', parryUserId: PARRY_USER_ID },
+    });
+  });
+
+  it('returns 404 when no parry.gg player resolves', async () => {
+    const { app } = buildTestApp({
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -41,7 +41,15 @@ function scoutFetchMock(): typeof fetch {
   }) as typeof fetch;
 }
 
-const VALID_REPORT = {
+/**
+ * What VALID_REPORT looks like once persisted (V9-B fix): the write path
+ * strips null-valued fields before the RTDB write (RTDB would delete them
+ * anyway — deleting on OUR side keeps the stored shape and the read-back
+ * shape identical), so `headToHead: null` is simply absent. Defined as the
+ * BASE shape; `VALID_REPORT` (the model's generation output, where the field
+ * is required) composes it with the explicit null.
+ */
+const STORED_VALID_REPORT = {
   overview: 'A fast-falling Fox/Falco player.',
   gameplan: ['Punish landing lag.'],
   characterStrategy: {
@@ -53,10 +61,11 @@ const VALID_REPORT = {
     picks: ['Battlefield'],
     reasoning: 'Flat stages favor us.',
   },
-  headToHead: null,
   watchFor: ['Shine spikes off stage.'],
   confidenceNotes: 'No sampled sets — treat this as a cold read.',
 };
+
+const VALID_REPORT = { ...STORED_VALID_REPORT, headToHead: null };
 
 /** Pre-V7-B.1 stored report shape: lacks `characterStrategy` entirely. */
 const PRE_B1_REPORT = {
@@ -311,7 +320,7 @@ describe('POST /api/reports (configured, allowlisted)', () => {
     expect(body).toMatchObject({
       model: 'claude-opus-4-8',
       player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
-      report: VALID_REPORT,
+      report: STORED_VALID_REPORT,
     });
     expect(typeof body.id).toBe('string');
     expect(typeof body.createdAt).toBe('number');
@@ -325,15 +334,20 @@ describe('POST /api/reports (configured, allowlisted)', () => {
     expect(capturedParams).not.toHaveProperty('temperature');
     expect(capturedParams).not.toHaveProperty('top_p');
 
-    // Assert the RTDB write.
+    // Assert the RTDB write, including the V9-B null-strip: `headToHead:
+    // null` must NOT be persisted (RTDB deletes null keys on write anyway —
+    // storing the already-stripped shape keeps write and read-back
+    // identical, see routes/reports.ts).
     const dump = database.dump() as Record<string, unknown>;
     const scoutReports = dump.scoutReports as Record<string, Record<string, unknown>>;
-    const stored = Object.values(scoutReports[TEST_UID]!)[0]!;
+    const stored = Object.values(scoutReports[TEST_UID]!)[0]! as Record<string, unknown>;
     expect(stored).toMatchObject({
       model: 'claude-opus-4-8',
       player: { id: 1802316, gamerTag: 'Pandem1c' },
-      report: VALID_REPORT,
+      report: STORED_VALID_REPORT,
     });
+    expect(stored.report).not.toHaveProperty('headToHead');
+    expect(body.report).not.toHaveProperty('headToHead');
   });
 
   it('maps a refusal to 502 with a human-readable message', async () => {
@@ -927,7 +941,7 @@ describe('POST /api/reports (parry.gg, V9-B, allowlisted)', () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({
       player: { source: 'parrygg', parryUserId: PARRY_USER_ID, gamerTag: 'Pandem1c' },
-      report: VALID_REPORT,
+      report: STORED_VALID_REPORT,
     });
 
     const dump = database.dump() as Record<string, unknown>;
@@ -955,5 +969,176 @@ describe('POST /api/reports (parry.gg, V9-B, allowlisted)', () => {
       payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
     });
     expect(response.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V9-B production fixes: RTDB null-stripping resilience + billing-enabled
+// read access.
+// ---------------------------------------------------------------------------
+
+describe('GET /api/reports* — RTDB-stripped and corrupt stored records (V9-B fix)', () => {
+  /**
+   * The exact shape production RTDB hands back for a record persisted with
+   * `headToHead: null` before the write-path fix: RTDB deletes null-valued
+   * keys on write, so the field is ABSENT (not null).
+   */
+  const RTDB_STRIPPED_RECORD = {
+    createdAt: 1000,
+    model: 'claude-opus-4-8',
+    player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+    report: STORED_VALID_REPORT, // no headToHead key at all
+  };
+
+  function appWithSeed(seed: Record<string, unknown>) {
+    const built = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    built.database.seed(`scoutReports/${TEST_UID}`, seed);
+    return built;
+  }
+
+  it('GET /reports round-trips a stored record whose headToHead was RTDB-stripped (absent)', async () => {
+    const { app } = appWithSeed({ stripped: RTDB_STRIPPED_RECORD });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ id: 'stripped', report: STORED_VALID_REPORT });
+    expect(body[0].report).not.toHaveProperty('headToHead');
+  });
+
+  it('GET /reports/:id round-trips the RTDB-stripped shape', async () => {
+    const { app } = appWithSeed({ stripped: RTDB_STRIPPED_RECORD });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/stripped',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ id: 'stripped', report: STORED_VALID_REPORT });
+  });
+
+  it('GET /reports skips a corrupt record (missing report entirely) and still returns the valid ones', async () => {
+    const { app } = appWithSeed({
+      good: RTDB_STRIPPED_RECORD,
+      corrupt: {
+        createdAt: 2000,
+        model: 'claude-opus-4-8',
+        player: { id: 999, gamerTag: 'Broken' },
+        // no `report` at all — one bad row must never 500 the whole library
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ id: 'good' });
+  });
+});
+
+describe('GET /api/reports* — billing-enabled read access (V9-B fix)', () => {
+  const NON_ALLOWLIST_CONFIG: ReportsConfig = {
+    anthropicApiKey: 'sk-test-key',
+    allowedUids: new Set(['someone-else']),
+  };
+  const STRIPE_CONFIG = {
+    secretKey: 'sk-test-123',
+    webhookSecret: 'whsec-test-456',
+  };
+
+  const SEEDED_RECORD = {
+    createdAt: 1000,
+    model: 'claude-opus-4-8',
+    player: { id: 1802316, gamerTag: 'Pandem1c' },
+    report: STORED_VALID_REPORT,
+  };
+
+  it('a billing-enabled non-allowlisted uid can list its reports (it can PAY to generate them via POST)', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`scoutReports/${TEST_UID}`, { r1: SEEDED_RECORD });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toHaveLength(1);
+  });
+
+  it('a billing-enabled non-allowlisted uid can reopen a single report', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      stripe: STRIPE_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+    database.seed(`scoutReports/${TEST_UID}`, { r1: SEEDED_RECORD });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/reports/r1',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ id: 'r1', player: { gamerTag: 'Pandem1c' } });
+  });
+
+  it('still 403s a non-allowlisted uid on both read routes when Stripe is NOT configured (pre-V7-C behavior, unchanged)', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: NON_ALLOWLIST_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+    });
+
+    const list = await app.inject({ method: 'GET', url: '/api/reports', headers: authHeader() });
+    expect(list.statusCode).toBe(403);
+
+    const single = await app.inject({
+      method: 'GET',
+      url: '/api/reports/r1',
+      headers: authHeader(),
+    });
+    expect(single.statusCode).toBe(403);
   });
 });

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -7,9 +7,11 @@ import {
   reportsConfigSchema,
   scoutReportRecordSchema,
 } from '@smash-tracker/shared';
-import type { ReportsConfig, StartggConfig, StripeConfig } from '../config/env.js';
+import type { ParryggConfig, ReportsConfig, StartggConfig, StripeConfig } from '../config/env.js';
 import { StartggApiError } from '../startgg/client.js';
 import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
+import { parseParryProfileUrl, ParryScoutCache, scoutParryPlayer } from '../parrygg/scout.js';
+import type { ParryggClients } from '../parrygg/client.js';
 import {
   assembleReportPayload,
   Anthropic,
@@ -28,6 +30,10 @@ export interface ReportsRoutesOptions {
   client?: AnthropicLikeClient;
   /** Overridable fetch for the start.gg GraphQL calls (tests). */
   fetchImpl?: typeof fetch;
+  /** parry.gg integration config (V9-B Feature 4); null/omitted means a query resolved to parry.gg answers 503 (start.gg queries are unaffected). */
+  parryggConfig?: ParryggConfig | null;
+  /** Overridable parry.gg gRPC-Web service clients (tests). */
+  parryggClients?: ParryggClients;
 }
 
 const reportIdParamsSchema = z.object({
@@ -62,9 +68,14 @@ const reportIdParamsSchema = z.object({
  * credits" dialog.
  */
 const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, options) => {
-  const { config, startggConfig, stripeConfig } = options;
+  const { config, startggConfig, stripeConfig, parryggConfig } = options;
 
-  if (!config || !startggConfig) {
+  // AI reports need Claude configured, AND at least one of the two scouting
+  // engines (start.gg or parry.gg) to actually source data from — same
+  // per-source 503 gating as POST /api/scout below (a query resolved to a
+  // source with no config answers 503 for THAT request, not a blanket
+  // route-level 503, unless NEITHER source is configured at all).
+  if (!config || (!startggConfig && !parryggConfig)) {
     app.all('/reports*', async (_request, reply) => {
       return reply.code(503).send({
         error: 'Service Unavailable',
@@ -77,6 +88,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
 
   const fetchImpl = options.fetchImpl ?? fetch;
   const scoutCache = new ScoutCache();
+  const parryScoutCache = new ParryScoutCache();
   const client: AnthropicLikeClient =
     options.client ?? new Anthropic({ apiKey: config.anthropicApiKey });
 
@@ -120,6 +132,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
           404: errorResponseSchema,
           429: errorResponseSchema,
           502: errorResponseSchema,
+          503: errorResponseSchema,
         },
       },
     },
@@ -134,18 +147,42 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         });
       }
 
+      const rawQuery = request.body.query;
+      // Same source-resolution rule as POST /api/scout: a pasted parry.gg
+      // profile URL always overrides `source` (or its default).
+      const effectiveSource = parseParryProfileUrl(rawQuery)
+        ? 'parrygg'
+        : (request.body.source ?? 'startgg');
+
+      if (effectiveSource === 'parrygg' && !parryggConfig) {
+        return reply.code(503).send({
+          error: 'Service Unavailable',
+          message: 'parry.gg integration is not configured on this server',
+          statusCode: 503,
+        });
+      }
+      if (effectiveSource === 'startgg' && !startggConfig) {
+        return reply.code(503).send({
+          error: 'Service Unavailable',
+          message: 'start.gg integration is not configured on this server',
+          statusCode: 503,
+        });
+      }
+
       let input;
-      try {
-        input = parseScoutInput(request.body.query);
-      } catch (err) {
-        if (err instanceof ScoutInputError) {
-          return reply.code(400).send({
-            error: 'Bad Request',
-            message: err.message,
-            statusCode: 400,
-          });
+      if (effectiveSource === 'startgg') {
+        try {
+          input = parseScoutInput(rawQuery);
+        } catch (err) {
+          if (err instanceof ScoutInputError) {
+            return reply.code(400).send({
+              error: 'Bad Request',
+              message: err.message,
+              statusCode: 400,
+            });
+          }
+          throw err;
         }
-        throw err;
       }
 
       // V7-C: non-allowlisted uids spend one credit per generation attempt.
@@ -174,29 +211,46 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       }
 
       let scout;
-      try {
-        scout = await scoutPlayer(startggConfig.apiToken, input, fetchImpl, scoutCache);
-      } catch (err) {
-        if (err instanceof StartggApiError && err.status === 429) {
+      if (effectiveSource === 'parrygg') {
+        scout = await scoutParryPlayer(
+          parryggConfig!.apiKey,
+          rawQuery,
+          parryScoutCache,
+          options.parryggClients,
+        );
+        if (!scout) {
           await refundIfSpent();
-          return reply.code(429).send({
-            error: 'Too Many Requests',
-            message: 'start.gg is rate-limiting requests right now — try again shortly',
-            statusCode: 429,
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: 'No parry.gg player found for that query',
+            statusCode: 404,
           });
         }
-        await refundIfSpent();
-        request.log.error({ err }, 'start.gg scout lookup failed during report generation');
-        throw err;
-      }
+      } else {
+        try {
+          scout = await scoutPlayer(startggConfig!.apiToken, input!, fetchImpl, scoutCache);
+        } catch (err) {
+          if (err instanceof StartggApiError && err.status === 429) {
+            await refundIfSpent();
+            return reply.code(429).send({
+              error: 'Too Many Requests',
+              message: 'start.gg is rate-limiting requests right now — try again shortly',
+              statusCode: 429,
+            });
+          }
+          await refundIfSpent();
+          request.log.error({ err }, 'start.gg scout lookup failed during report generation');
+          throw err;
+        }
 
-      if (!scout) {
-        await refundIfSpent();
-        return reply.code(404).send({
-          error: 'Not Found',
-          message: 'No start.gg player found for that query',
-          statusCode: 404,
-        });
+        if (!scout) {
+          await refundIfSpent();
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: 'No start.gg player found for that query',
+            statusCode: 404,
+          });
+        }
       }
 
       const payload = await assembleReportPayload(request.uid, scout, app.firebase.database);

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -92,6 +92,19 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
   const client: AnthropicLikeClient =
     options.client ?? new Anthropic({ apiKey: config.anthropicApiKey });
 
+  /**
+   * Access rule for the READ routes (GET /reports, GET /reports/:id) — must
+   * match POST's: allowlisted uids OR anyone when Stripe billing is
+   * configured (V7-C). Since V7-C, a billing-enabled non-allowlisted uid can
+   * PAY to generate a report via POST; gating the read routes to the
+   * allowlist alone (the pre-V9-B behavior) meant they could buy credits,
+   * generate a report, and then be 403'd from ever listing or reopening it.
+   * When Stripe is NOT configured, the pre-V7-C allowlist-only 403 behavior
+   * is unchanged.
+   */
+  const canReadReports = (uid: string): boolean =>
+    config.allowedUids.has(uid) || stripeConfig !== null;
+
   app.addHook('preHandler', app.authenticate);
 
   // GET /api/reports/config — never 403s; tells the web app whether to show
@@ -294,12 +307,24 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         throw err;
       }
 
+      // RTDB deletes null-valued keys on write, so persisting the model's
+      // `headToHead: null` (a legitimate "no head-to-head history" output)
+      // would come back with the key ABSENT and previously corrupted the
+      // stored record (see storedScoutReportSchema's doc). Strip null fields
+      // before writing — house conditional-spread convention — so records
+      // are stored in exactly the shape they'll be read back in.
+      const { headToHead, ...reportRest } = report;
+      const storedReport = {
+        ...reportRest,
+        ...(headToHead !== null ? { headToHead } : {}),
+      };
+
       const ref = app.firebase.database.ref(`scoutReports/${request.uid}`).push();
       const record = {
         createdAt: Date.now(),
         model: 'claude-opus-4-8',
         player: scout.player,
-        report,
+        report: storedReport,
       };
       try {
         await ref.set(record);
@@ -332,7 +357,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       },
     },
     async (request, reply) => {
-      if (!config.allowedUids.has(request.uid)) {
+      if (!canReadReports(request.uid)) {
         return reply.code(403).send({
           error: 'Forbidden',
           message: 'AI reports are not enabled for this account',
@@ -345,9 +370,24 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         return [];
       }
 
+      // safeParse + skip, not parse: one corrupt stored record (e.g. a
+      // pre-fix row RTDB null-stripped — see storedScoutReportSchema — or
+      // any future shape drift) must never 500 the caller's ENTIRE library.
+      // Skipped records are logged with their id so they're findable, not
+      // silently swallowed.
       const raw = snapshot.val() as Record<string, unknown>;
       return Object.entries(raw)
-        .map(([id, value]) => scoutReportRecordSchema.parse({ id, ...(value as object) }))
+        .flatMap(([id, value]) => {
+          const parsed = scoutReportRecordSchema.safeParse({ id, ...(value as object) });
+          if (!parsed.success) {
+            request.log.warn(
+              { reportId: id, issues: parsed.error.issues },
+              'skipping stored scout report that failed schema validation',
+            );
+            return [];
+          }
+          return [parsed.data];
+        })
         .sort((a, b) => b.createdAt - a.createdAt);
     },
   );
@@ -366,7 +406,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       },
     },
     async (request, reply) => {
-      if (!config.allowedUids.has(request.uid)) {
+      if (!canReadReports(request.uid)) {
         return reply.code(403).send({
           error: 'Forbidden',
           message: 'AI reports are not enabled for this account',

--- a/apps/api/src/routes/scout.test.ts
+++ b/apps/api/src/routes/scout.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { StartggConfig } from '../config/env.js';
 import { authHeader, buildTestApp } from '../test-support/testApp.js';
+import type { ParryggClients } from '../parrygg/client.js';
 
 const CONFIG: StartggConfig = {
   clientId: 'client-123',
@@ -199,5 +200,135 @@ describe('POST /api/scout (configured)', () => {
     expect(second.statusCode).toBe(200);
     // Same underlying player id -> cache hit -> no additional sets fetch.
     expect(setsFetches).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V9-B Feature 4: parry.gg scouting — source resolution + independent 503s.
+// ---------------------------------------------------------------------------
+
+const PARRY_USER_ID = '019ce9ba-debd-7e11-84a2-77258f52644e';
+
+function parryClients(overrides: {
+  getUser?: () => { id: string; gamerTag: string } | null;
+}): ParryggClients {
+  return {
+    users: {
+      getUser: vi.fn(async () => {
+        const found = overrides.getUser?.() ?? null;
+        return {
+          getUser: () => (found ? { toObject: () => ({ ...found, bioMd: '' }) } : undefined),
+        };
+      }),
+      getUsers: vi.fn(async () => ({ getUsersList: () => [] })),
+    } as unknown as ParryggClients['users'],
+    matches: {
+      getMatches: vi.fn(async () => ({ getMatchesList: () => [] })),
+    } as unknown as ParryggClients['matches'],
+  };
+}
+
+describe('POST /api/scout (parry.gg, V9-B)', () => {
+  it('answers 503 when neither integration is configured', async () => {
+    const { app } = buildTestApp();
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 for a parry.gg query when only start.gg is configured', async () => {
+    const { app } = buildTestApp({ startgg: CONFIG, startggFetch: scoutFetchMock() });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('answers 503 for a start.gg query when only parry.gg is configured', async () => {
+    const { app } = buildTestApp({
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({}),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('a pasted parry.gg profile URL resolves via parry.gg regardless of the source field', async () => {
+    const { app } = buildTestApp({
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}`, source: 'startgg' },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      player: { source: 'parrygg', parryUserId: PARRY_USER_ID, gamerTag: 'Pandem1c' },
+    });
+  });
+
+  it('respects an explicit source: parrygg for a bare tag', async () => {
+    const { app } = buildTestApp({
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: PARRY_USER_ID, source: 'parrygg' },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ player: { source: 'parrygg' } });
+  });
+
+  it('returns 404 when no parry.gg player resolves', async () => {
+    const { app } = buildTestApp({
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: `https://parry.gg/profile/${PARRY_USER_ID}` },
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('defaults to start.gg when source is omitted and the query is not a parry.gg URL', async () => {
+    const { app } = buildTestApp({
+      startgg: CONFIG,
+      startggFetch: scoutFetchMock(),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({}),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: { query: 'user/07dc2239' },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ player: { id: 1802316 } });
   });
 });

--- a/apps/api/src/routes/scout.ts
+++ b/apps/api/src/routes/scout.ts
@@ -4,37 +4,52 @@ import {
   scoutQuerySchema,
   scoutReportDataSchema,
 } from '@smash-tracker/shared';
-import type { StartggConfig } from '../config/env.js';
+import type { ParryggConfig, StartggConfig } from '../config/env.js';
 import { StartggApiError } from '../startgg/client.js';
 import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
+import { parseParryProfileUrl, ParryScoutCache, scoutParryPlayer } from '../parrygg/scout.js';
+import type { ParryggClients } from '../parrygg/client.js';
 
 export interface ScoutRoutesOptions {
   config: StartggConfig | null;
   /** Overridable fetch for the start.gg GraphQL calls (tests). */
   fetchImpl?: typeof fetch;
+  /** parry.gg integration config (V9-B Feature 4); null/omitted means parry.gg queries answer 503 (start.gg queries are unaffected). */
+  parryggConfig?: ParryggConfig | null;
+  /** Overridable parry.gg gRPC-Web service clients (tests). */
+  parryggClients?: ParryggClients;
 }
 
 /**
- * POST /api/scout — "opponent research before bracket": scout ANY start.gg
- * player (not just linked accounts) by profile URL, bare slug, or numeric
- * player id. Aggregates their PUBLIC recent SSBU set history server-side
- * (using our own API token — never a user token) into a `ScoutReportData`.
- * Signed-in users only (Bearer auth), same as the rest of /api — scouting
- * isn't itself sensitive, but it does spend shared start.gg rate-limit
+ * POST /api/scout — "opponent research before bracket": scout ANY player on
+ * start.gg OR (V9-B Feature 4) parry.gg by profile URL, bare slug/tag, or
+ * (start.gg only) numeric player id. Aggregates their PUBLIC match history
+ * server-side (using our own API token/key — never a user token) into a
+ * `ScoutReportData`. Signed-in users only (Bearer auth), same as the rest of
+ * /api — scouting isn't itself sensitive, but it does spend shared rate-limit
  * budget, so it's gated behind sign-in like every other integration route.
  *
- * A single in-memory `ScoutCache` (see startgg/scout.ts) is shared across
- * requests to this plugin instance, so repeated scouts of the same player
- * during a bracket don't re-burn the rate limit.
+ * Source resolution: a pasted parry.gg profile URL ALWAYS wins (unambiguous
+ * signal), overriding whatever `source` the client sent. Otherwise the
+ * effective source is `request.body.source ?? 'startgg'` — back-compat with
+ * every pre-V9-B client that never sent `source` at all. Each site's config
+ * gates independently: a query resolved to parry.gg when `parryggConfig` is
+ * absent answers 503 (parry.gg not configured) even if start.gg IS
+ * configured, and vice versa — the two integrations are fully independent.
+ *
+ * Separate in-memory caches per source (`ScoutCache` for start.gg,
+ * `ParryScoutCache` for parry.gg — see their respective scout.ts modules for
+ * the caching rationale), both shared across requests to this plugin
+ * instance.
  */
 const scoutRoutes: FastifyPluginAsyncZod<ScoutRoutesOptions> = async (app, options) => {
-  const { config } = options;
+  const { config, parryggConfig } = options;
 
-  if (!config) {
+  if (!config && !parryggConfig) {
     app.all('/scout', async (_request, reply) => {
       return reply.code(503).send({
         error: 'Service Unavailable',
-        message: 'start.gg integration is not configured on this server',
+        message: 'No scouting integration is configured on this server',
         statusCode: 503,
       });
     });
@@ -43,6 +58,7 @@ const scoutRoutes: FastifyPluginAsyncZod<ScoutRoutesOptions> = async (app, optio
 
   const fetchImpl = options.fetchImpl ?? fetch;
   const cache = new ScoutCache();
+  const parryCache = new ParryScoutCache();
 
   app.post(
     '/scout',
@@ -55,13 +71,53 @@ const scoutRoutes: FastifyPluginAsyncZod<ScoutRoutesOptions> = async (app, optio
           400: errorResponseSchema,
           404: errorResponseSchema,
           429: errorResponseSchema,
+          503: errorResponseSchema,
         },
       },
     },
     async (request, reply) => {
+      const rawQuery = request.body.query;
+      // A pasted parry.gg profile URL is unambiguous and always overrides
+      // the client's `source` (or its default) — see the module doc.
+      const effectiveSource = parseParryProfileUrl(rawQuery)
+        ? 'parrygg'
+        : (request.body.source ?? 'startgg');
+
+      if (effectiveSource === 'parrygg') {
+        if (!parryggConfig) {
+          return reply.code(503).send({
+            error: 'Service Unavailable',
+            message: 'parry.gg integration is not configured on this server',
+            statusCode: 503,
+          });
+        }
+        const report = await scoutParryPlayer(
+          parryggConfig.apiKey,
+          rawQuery,
+          parryCache,
+          options.parryggClients,
+        );
+        if (!report) {
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: 'No parry.gg player found for that query',
+            statusCode: 404,
+          });
+        }
+        return report;
+      }
+
+      if (!config) {
+        return reply.code(503).send({
+          error: 'Service Unavailable',
+          message: 'start.gg integration is not configured on this server',
+          statusCode: 503,
+        });
+      }
+
       let input;
       try {
-        input = parseScoutInput(request.body.query);
+        input = parseScoutInput(rawQuery);
       } catch (err) {
         if (err instanceof ScoutInputError) {
           return reply.code(400).send({

--- a/apps/api/src/startgg/client.ts
+++ b/apps/api/src/startgg/client.ts
@@ -187,6 +187,8 @@ const setsPageSchema = z.object({
                 .object({
                   id: z.number().nullish(),
                   name: z.string().nullish(),
+                  /** Event slug, e.g. "tournament/the-big-house-9/event/ultimate-singles" — used to deep-link scouted recent events (V9-B). */
+                  slug: z.string().nullish(),
                   isOnline: z.boolean().nullish(),
                   numEntrants: z.number().int().nullish(),
                   videogame: z.object({ id: z.number() }).nullish(),
@@ -287,7 +289,7 @@ const SETS_QUERY = `query PlayerSets($playerId: ID!, $page: Int!, $perPage: Int!
         displayScore
         totalGames
         vodUrl
-        event { id name isOnline numEntrants videogame { id } tournament { name } }
+        event { id name slug isOnline numEntrants videogame { id } tournament { name } }
         slots {
           entrant {
             id

--- a/apps/api/src/startgg/scout.test.ts
+++ b/apps/api/src/startgg/scout.test.ts
@@ -25,6 +25,7 @@ function makeSet(overrides: Partial<StartggSet> = {}): StartggSet {
     event: {
       id: 987,
       name: 'Ultimate Singles',
+      slug: 'tournament/test-weekly-42/event/ultimate-singles',
       isOnline: true,
       numEntrants: 512,
       videogame: { id: 1386 },
@@ -233,6 +234,7 @@ describe('accumulateScoutSet', () => {
           placement?: number;
           numEntrants?: number;
           lastSetAt: number;
+          slug?: string;
         }
       >(),
       opponents: new Map<string, number>(),
@@ -256,7 +258,16 @@ describe('accumulateScoutSet', () => {
       tournamentName: 'Test Weekly 42',
       placement: 33,
       numEntrants: 512,
+      slug: 'tournament/test-weekly-42/event/ultimate-singles',
     });
+  });
+
+  it('tolerates a set whose event has no slug (back-compat: older start.gg responses / any nullish slug)', () => {
+    const acc = emptyAcc();
+    const set = makeSet({ event: { ...makeSet().event, slug: undefined } });
+    accumulateScoutSet(acc, set, PLAYER_ID);
+    const event = acc.events.get(987);
+    expect(event?.slug).toBeUndefined();
   });
 
   it('strips a sponsor prefix from the common-opponent tag', () => {
@@ -390,7 +401,12 @@ describe('buildScoutReport', () => {
     expect(report.characters[0]).toMatchObject({ fighterId: 67, games: 4, wins: 2 });
     expect(report.commonOpponents[0]).toEqual({ gamerTag: 'PowPow', sets: 2 });
     expect(report.recentEvents).toHaveLength(1);
-    expect(report.recentEvents[0]).toMatchObject({ eventName: 'Ultimate Singles', placement: 33 });
+    expect(report.recentEvents[0]).toMatchObject({
+      eventName: 'Ultimate Singles',
+      placement: 33,
+      slug: 'tournament/test-weekly-42/event/ultimate-singles',
+      source: 'startgg',
+    });
   });
 
   it('caps pagination at 15 pages even when start.gg reports more', async () => {

--- a/apps/api/src/startgg/scout.ts
+++ b/apps/api/src/startgg/scout.ts
@@ -121,6 +121,8 @@ interface Accumulators {
       placement?: number;
       numEntrants?: number;
       lastSetAt: number;
+      /** start.gg event slug, e.g. "tournament/the-big-house-9/event/ultimate-singles" — used to deep-link (V9-B Feature 2). */
+      slug?: string;
     }
   >;
   opponents: Map<string, number>;
@@ -200,6 +202,7 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
     const tournamentName = set.event?.tournament?.name?.trim();
     const placement = playerEntrant.standing?.placement ?? undefined;
     const numEntrants = set.event?.numEntrants ?? undefined;
+    const slug = set.event?.slug?.trim() || undefined;
     const lastSetAtMs = completedAt * 1000;
     const existing = acc.events.get(eventId);
     if (!existing || lastSetAtMs > existing.lastSetAt) {
@@ -208,6 +211,7 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
         ...(tournamentName ? { tournamentName } : {}),
         ...(placement != null ? { placement } : {}),
         ...(numEntrants != null ? { numEntrants } : {}),
+        ...(slug ? { slug } : {}),
         lastSetAt: lastSetAtMs,
       });
     } else {
@@ -221,6 +225,9 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
       }
       if (tournamentName) {
         existing.tournamentName = tournamentName;
+      }
+      if (slug) {
+        existing.slug = slug;
       }
     }
   }
@@ -271,6 +278,7 @@ function toReport(acc: Accumulators, player: ResolvedScoutPlayer): ScoutReportDa
       ...(event.tournamentName ? { tournamentName: event.tournamentName } : {}),
       ...(event.placement != null ? { placement: event.placement } : {}),
       ...(event.numEntrants != null ? { numEntrants: event.numEntrants } : {}),
+      ...(event.slug ? { slug: event.slug, source: 'startgg' as const } : {}),
       lastSetAt: event.lastSetAt,
     }));
 

--- a/apps/web/src/hooks/useScoutPlayer.test.tsx
+++ b/apps/web/src/hooks/useScoutPlayer.test.tsx
@@ -48,7 +48,7 @@ function ScoutProbe() {
   const scout = useScoutPlayer();
   return (
     <div>
-      <button onClick={() => scout.mutate('user/07dc2239')}>go</button>
+      <button onClick={() => scout.mutate({ query: 'user/07dc2239' })}>go</button>
       {scout.isPending && <div>pending</div>}
       {scout.isSuccess && <div>gamerTag: {scout.data.player.gamerTag}</div>}
       {scout.isError && <div>errored</div>}

--- a/apps/web/src/hooks/useScoutPlayer.ts
+++ b/apps/web/src/hooks/useScoutPlayer.ts
@@ -1,16 +1,24 @@
 import { useMutation } from '@tanstack/react-query';
+import type { ScoutSource } from '@smash-tracker/shared';
 import { api } from '@/lib/api';
+
+export interface ScoutPlayerInput {
+  query: string;
+  /** V9-B Feature 4: which site to resolve a bare tag/slug/id against; a pasted parry.gg profile URL auto-detects server-side regardless of this. */
+  source?: ScoutSource;
+}
 
 /**
  * POST /api/scout — runs on submit (not auto-fetched like the rest of the
  * app's queries), since it's a user-initiated lookup of a third-party
- * player's public start.gg history rather than data tied to the signed-in
- * account. A `useMutation` gives the Scout page `isPending`/`error`/`data`
- * without needing a query key (there's no cache to invalidate elsewhere —
- * the server already caches per player id, see startgg/scout.ts).
+ * player's public tournament-site history rather than data tied to the
+ * signed-in account. A `useMutation` gives the Scout page
+ * `isPending`/`error`/`data` without needing a query key (there's no cache
+ * to invalidate elsewhere — the server already caches per player id/source,
+ * see startgg/scout.ts and parrygg/scout.ts).
  */
 export function useScoutPlayer() {
   return useMutation({
-    mutationFn: (query: string) => api.scout.lookup({ query }),
+    mutationFn: (input: ScoutPlayerInput) => api.scout.lookup(input),
   });
 }

--- a/apps/web/src/hooks/useScoutReports.test.tsx
+++ b/apps/web/src/hooks/useScoutReports.test.tsx
@@ -75,7 +75,7 @@ function GenerateProbe() {
   const generate = useGenerateReport();
   return (
     <div>
-      <button onClick={() => generate.mutate('user/07dc2239')}>generate</button>
+      <button onClick={() => generate.mutate({ query: 'user/07dc2239' })}>generate</button>
       {generate.isPending && <div>pending</div>}
       {generate.isSuccess && <div>gamerTag: {generate.data.player.gamerTag}</div>}
     </div>
@@ -125,7 +125,7 @@ describe('useScoutReports', () => {
     fireEvent.click(screen.getByText('generate'));
 
     await waitFor(() => expect(screen.getByText('gamerTag: Pandem1c')).toBeInTheDocument());
-    expect(reportsGenerate).toHaveBeenCalledWith('user/07dc2239');
+    expect(reportsGenerate).toHaveBeenCalledWith({ query: 'user/07dc2239' });
   });
 
   it('useScoutReportsList resolves the list response', async () => {

--- a/apps/web/src/hooks/useScoutReports.ts
+++ b/apps/web/src/hooks/useScoutReports.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { GenerateReportRequest } from '@smash-tracker/shared';
 import { api } from '@/lib/api';
 import { useAuth } from './useAuth';
 
@@ -25,7 +26,7 @@ export function useReportsConfig() {
 export function useGenerateReport() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (query: string) => api.reports.generate(query),
+    mutationFn: (input: GenerateReportRequest) => api.reports.generate(input),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: scoutReportsListQueryKey });
     },

--- a/apps/web/src/layouts/nav.ts
+++ b/apps/web/src/layouts/nav.ts
@@ -10,6 +10,7 @@ import {
   LineChart,
   TrendingUp,
   Trophy,
+  Sparkles,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -28,6 +29,7 @@ export const navItems: NavItem[] = [
   { title: 'Matchups', href: '/matchups', icon: Swords },
   { title: 'Scouting', href: '/opponents', icon: Target },
   { title: 'Scout a Player', href: '/scout', icon: Search },
+  { title: 'AI Reports', href: '/reports', icon: Sparkles },
   { title: 'Match Data', href: '/match-data', icon: LineChart },
   { title: 'Trends', href: '/trends', icon: TrendingUp },
   { title: 'Groups', href: '/groups', icon: Trophy },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -39,6 +39,7 @@ import {
   type CreateMatchInput,
   type CreditPackId,
   type FighterSelectionInput,
+  type GenerateReportRequest,
   type Match,
   type ParryggLinkRequest,
   type ParryggLoginCompleteRequest,
@@ -339,7 +340,7 @@ export const api = {
     list: () => apiRequestParsed('/api/tournaments', tournamentEntryListSchema),
   },
   scout: {
-    /** POST /api/scout — scout ANY start.gg player by URL, slug, or numeric id. */
+    /** POST /api/scout — scout ANY start.gg OR parry.gg player (V9-B) by URL, slug/tag, or numeric id. */
     lookup: (input: ScoutQuery) =>
       apiRequestParsed('/api/scout', scoutReportDataSchema, { method: 'POST', body: input }),
   },
@@ -349,12 +350,14 @@ export const api = {
     /**
      * POST /api/reports — generate (and store) an AI scouting report.
      * Goes directly to the API origin: generation regularly outlives the
-     * Hosting proxy's 60s rewrite timeout.
+     * Hosting proxy's 60s rewrite timeout. `source` (V9-B Feature 4) picks
+     * start.gg vs. parry.gg for a bare query — same semantics as POST
+     * /api/scout.
      */
-    generate: (query: string) =>
+    generate: (input: GenerateReportRequest) =>
       apiRequestParsed('/api/reports', scoutReportRecordSchema, {
         method: 'POST',
-        body: generateReportRequestSchema.parse({ query }),
+        body: generateReportRequestSchema.parse(input),
         baseUrl: getDirectApiBaseUrl(),
       }),
     /** GET /api/reports — the signed-in user's past AI reports, newest first. */

--- a/apps/web/src/pages/Reports/ReportsPage.test.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import { ReportsPage } from './ReportsPage';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const reportsConfig = vi.fn();
+const reportsList = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    reports: {
+      config: (...args: unknown[]) => reportsConfig(...args),
+      list: (...args: unknown[]) => reportsList(...args),
+    },
+  },
+  ApiError: class MockApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  },
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <ReportsPage />
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const REPORT_SHAPE = {
+  overview: 'overview',
+  gameplan: [],
+  stageStrategy: { bans: [], picks: [], reasoning: '' },
+  headToHead: null,
+  watchFor: [],
+  confidenceNotes: '',
+};
+
+describe('ReportsPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  it('shows a friendly note when AI reports are not enabled', async () => {
+    reportsConfig.mockResolvedValue({ enabled: false });
+    reportsList.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/AI reports aren't enabled for this account yet/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the empty state when enabled but no reports exist', async () => {
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText(/No AI scouting reports yet/)).toBeInTheDocument();
+  });
+
+  it('groups reports by player (source-aware), newest group and newest report first', async () => {
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([
+      {
+        id: 'r1',
+        createdAt: 1_700_000_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: REPORT_SHAPE,
+      },
+      {
+        id: 'r2',
+        createdAt: 1_700_200_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: REPORT_SHAPE,
+      },
+      {
+        id: 'r3',
+        createdAt: 1_700_100_000_000,
+        model: 'claude-opus-4-8',
+        player: { gamerTag: 'PowPow', source: 'parrygg', parryUserId: 'parry-uid-1' },
+        report: REPORT_SHAPE,
+      },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Pandem1c')).toBeInTheDocument();
+    expect(screen.getByText('PowPow')).toBeInTheDocument();
+    expect(screen.getByText('parry.gg')).toBeInTheDocument();
+
+    // Two rows: Pandem1c (2 reports grouped) and PowPow (1 report).
+    const rows = screen.getAllByText(/^Pandem1c$|^PowPow$/);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('expands a group with multiple reports and opens an older one inline', async () => {
+    const user = userEvent.setup();
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([
+      {
+        id: 'newer',
+        createdAt: 1_700_200_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: { ...REPORT_SHAPE, overview: 'Newer overview' },
+      },
+      {
+        id: 'older',
+        createdAt: 1_700_000_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: { ...REPORT_SHAPE, overview: 'Older overview' },
+      },
+    ]);
+
+    renderPage();
+    await screen.findByText('Pandem1c');
+
+    await user.click(screen.getByRole('button', { name: 'Show older reports' }));
+    await user.click(screen.getByRole('button', { name: /Older report/ }));
+
+    expect((await screen.findAllByText('Older overview')).length).toBeGreaterThan(0);
+  });
+
+  it('opens the newest report inline on row click', async () => {
+    const user = userEvent.setup();
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([
+      {
+        id: 'r1',
+        createdAt: 1_700_000_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: { ...REPORT_SHAPE, overview: 'The overview text' },
+      },
+    ]);
+
+    renderPage();
+    await user.click(await screen.findByText('Pandem1c'));
+
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+    expect(screen.getAllByText('The overview text').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/Reports/ReportsPage.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
+import { scoutIdentityKey, type ScoutReportRecord } from '@smash-tracker/shared';
+import { useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ScoutAiReportCard } from '@/pages/Scout/components/ScoutAiReportCard';
+
+interface ReportGroup {
+  key: string;
+  gamerTag: string;
+  source: 'startgg' | 'parrygg';
+  /** Newest-first, mirroring GET /api/reports' own ordering. */
+  reports: ScoutReportRecord[];
+}
+
+function sourceLabel(source: 'startgg' | 'parrygg'): string {
+  return source === 'parrygg' ? 'parry.gg' : 'start.gg';
+}
+
+/** Groups reports by scouted-player identity (source-aware, V9-B), newest report first within each group, groups ordered by their own most-recent report. */
+function groupReports(reports: ScoutReportRecord[]): ReportGroup[] {
+  const byKey = new Map<string, ReportGroup>();
+  for (const record of reports) {
+    const key = scoutIdentityKey(record.player);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.reports.push(record);
+    } else {
+      byKey.set(key, {
+        key,
+        gamerTag: record.player.gamerTag,
+        source: record.player.source ?? 'startgg',
+        reports: [record],
+      });
+    }
+  }
+  // Each group's reports are already newest-first (GET /api/reports'
+  // ordering is preserved by insertion order here); groups themselves sort
+  // by their own newest report, most recent group first.
+  return [...byKey.values()].sort(
+    (a, b) => (b.reports[0]?.createdAt ?? 0) - (a.reports[0]?.createdAt ?? 0),
+  );
+}
+
+function ReportGroupRow({
+  group,
+  selectedId,
+  onSelect,
+}: {
+  group: ReportGroup;
+  selectedId: string | null;
+  onSelect: (record: ScoutReportRecord) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const newest = group.reports[0];
+  if (!newest) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-1 border-b pb-3 last:border-b-0 last:pb-0">
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-auto flex-1 justify-start gap-2 px-2 py-2 font-normal"
+          onClick={() => onSelect(newest)}
+        >
+          <span className="font-medium">{group.gamerTag}</span>
+          <span className="text-xs text-muted-foreground">{sourceLabel(group.source)}</span>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {new Date(newest.createdAt).toLocaleDateString()}
+          </span>
+        </Button>
+        {group.reports.length > 1 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0"
+            onClick={() => setExpanded((v) => !v)}
+            aria-label={expanded ? 'Hide older reports' : 'Show older reports'}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+          </Button>
+        )}
+      </div>
+      {expanded && group.reports.length > 1 && (
+        <ul className="ml-4 flex flex-col gap-1 border-l pl-3">
+          {group.reports.slice(1).map((record) => (
+            <li key={record.id}>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-auto w-full justify-between px-2 py-1.5 font-normal"
+                onClick={() => onSelect(record)}
+              >
+                <span className="text-sm text-muted-foreground">Older report</span>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(record.createdAt).toLocaleDateString()}
+                </span>
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {selectedId && group.reports.some((r) => r.id === selectedId) && (
+        <div className="mt-2">
+          <ScoutAiReportCard record={group.reports.find((r) => r.id === selectedId)!} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * `/reports` — "AI Reports": every stored AI scouting report the signed-in
+ * user has generated (V7-B's `GET /api/reports`), grouped by scouted player
+ * (source-aware, V9-B — a start.gg player and a parry.gg player never
+ * collide even if their numeric-looking ids happen to coincide, see
+ * `scoutIdentityKey`), newest report first within a group, groups ordered by
+ * their own most recent report.
+ *
+ * Clicking a row expands the full report inline using `ScoutAiReportCard`
+ * (the same component the Scout page uses — download/print come for free).
+ * When AI reports aren't enabled for this account at all, shows a friendly
+ * note instead of an empty list (distinct from "enabled but nothing
+ * generated yet", which shows the ordinary empty state).
+ */
+export function ReportsPage() {
+  const reportsConfig = useReportsConfig();
+  const reportsList = useScoutReportsList();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const groups = useMemo(() => groupReports(reportsList.data ?? []), [reportsList.data]);
+
+  const enabled = reportsConfig.data?.enabled ?? false;
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6">
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-6 text-primary" />
+        <h1 className="text-2xl font-semibold tracking-tight">AI Reports</h1>
+      </div>
+
+      {reportsConfig.isSuccess && !enabled && (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          AI reports aren't enabled for this account yet.
+        </div>
+      )}
+
+      {enabled && (
+        <>
+          {reportsList.isLoading && (
+            <p className="text-sm text-muted-foreground">Loading your reports…</p>
+          )}
+
+          {reportsList.isSuccess && groups.length === 0 && (
+            <div className="rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
+              No AI scouting reports yet. Generate one from the{' '}
+              <a href="/scout" className="underline">
+                Scout a Player
+              </a>{' '}
+              page.
+            </div>
+          )}
+
+          {groups.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Your Reports</CardTitle>
+                <CardDescription>Grouped by player, most recently scouted first.</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-3">
+                {groups.map((group) => (
+                  <ReportGroupRow
+                    key={group.key}
+                    group={group}
+                    selectedId={selectedId}
+                    onSelect={(record) => setSelectedId(record.id)}
+                  />
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -135,7 +135,10 @@ describe('ScoutPage', () => {
     await user.click(screen.getByRole('button', { name: 'Scout' }));
 
     await waitFor(() =>
-      expect(scoutLookup).toHaveBeenCalledWith({ query: 'https://start.gg/user/07dc2239' }),
+      expect(scoutLookup).toHaveBeenCalledWith({
+        query: 'https://start.gg/user/07dc2239',
+        source: 'startgg',
+      }),
     );
     expect(await screen.findByText('Pandem1c')).toBeInTheDocument();
     expect(screen.getByText(/Public start\.gg data · sampled last 3 sets/)).toBeInTheDocument();
@@ -336,7 +339,9 @@ describe('ScoutPage — AI reports feature enabled', () => {
 
     await user.click(screen.getByRole('button', { name: /Generate AI report/ }));
 
-    await waitFor(() => expect(reportsGenerate).toHaveBeenCalledWith('user/07dc2239'));
+    await waitFor(() =>
+      expect(reportsGenerate).toHaveBeenCalledWith({ query: 'user/07dc2239', source: 'startgg' }),
+    );
     expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
     expect(screen.getAllByText(GENERATED_RECORD.report.overview).length).toBeGreaterThan(0);
   });

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -2,12 +2,18 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
-import type { ScoutReportData, ScoutReportRecord } from '@smash-tracker/shared';
+import {
+  scoutIdentityKey,
+  type ScoutReportData,
+  type ScoutReportRecord,
+  type ScoutSource,
+} from '@smash-tracker/shared';
 import { ApiError } from '@/lib/api';
 import { useScoutPlayer } from '@/hooks/useScoutPlayer';
 import { useMatches } from '@/hooks/useMatches';
 import { useGenerateReport, useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
 import { useCredits } from '@/hooks/useBilling';
+import { useParryggStatus } from '@/hooks/useParrygg';
 import { getOpponentProfile } from '@/lib/stats';
 import { Button } from '@/components/ui/button';
 import { ScoutSearchForm } from './components/ScoutSearchForm';
@@ -16,8 +22,10 @@ import { ScoutCharactersCard } from './components/ScoutCharactersCard';
 import { ScoutStagesCard } from './components/ScoutStagesCard';
 import { ScoutRecentEventsCard } from './components/ScoutRecentEventsCard';
 import { ScoutCommonOpponentsCard } from './components/ScoutCommonOpponentsCard';
+import { ScoutMatchupAdvisorCard } from './components/ScoutMatchupAdvisorCard';
 import { YourHistoryStrip } from './components/YourHistoryStrip';
 import { ScoutAiReportCard } from './components/ScoutAiReportCard';
+import { ScoutReportHistorySelector } from './components/ScoutReportHistorySelector';
 import { ScoutPastReportsCard } from './components/ScoutPastReportsCard';
 import { BuyCreditsDialog } from '@/components/billing/BuyCreditsDialog';
 
@@ -89,10 +97,22 @@ export function ScoutPage() {
   const generateReport = useGenerateReport();
   const pastReports = useScoutReportsList();
   const credits = useCredits();
+  const parryggStatus = useParryggStatus();
+  // parry.gg toggle is hidden entirely when the integration isn't configured
+  // on this deployment (V9-B Feature 4) — an unconfigured server answers 503
+  // for every /api/integrations/parrygg/* route, which surfaces here as a
+  // query error rather than a normal { linked: false } response. Fails
+  // CLOSED (hides the toggle) for anything other than a confirmed successful
+  // status fetch, rather than assuming enabled on an ambiguous error.
+  const parryggEnabled = parryggStatus.isSuccess;
 
-  const [lastQuery, setLastQuery] = useState<string | null>(null);
+  const [lastQuery, setLastQuery] = useState<{ query: string; source: ScoutSource } | null>(null);
   const [selectedRecord, setSelectedRecord] = useState<ScoutReportRecord | null>(null);
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
+  // V9-B Feature 1: which of the CURRENT player's stored reports the history
+  // selector has picked (index into the reverse-chronological list from
+  // GET /api/reports); null means "use the newest" (the default).
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
 
   const report: ScoutReportData | undefined = scout.data;
   const aiReportsEnabled = reportsConfig.data?.enabled ?? false;
@@ -147,21 +167,31 @@ export function ScoutPage() {
     return getOpponentProfile(matches, needle);
   }, [matches, report]);
 
-  // The most recent stored report for the CURRENTLY scouted player, if any —
-  // matched by start.gg player id (stable across re-scouts, unlike gamerTag
-  // which can change). Newest-first is already guaranteed by GET /api/reports.
-  const storedRecordForCurrentPlayer = useMemo(() => {
+  // Every stored report for the CURRENTLY scouted player, newest first —
+  // matched via `scoutIdentityKey` (source-aware: a start.gg player id and a
+  // parry.gg parryUserId never collide, and pre-V9-B records with no
+  // `source` at all still match correctly since the key defaults to
+  // 'startgg'). Newest-first is already guaranteed by GET /api/reports.
+  const reportsForCurrentPlayer = useMemo(() => {
     if (!report) {
-      return null;
+      return [];
     }
-    return pastReports.data?.find((record) => record.player.id === report.player.id) ?? null;
+    const needle = scoutIdentityKey(report.player);
+    return (pastReports.data ?? []).filter((record) => scoutIdentityKey(record.player) === needle);
   }, [pastReports.data, report]);
 
-  const handleSubmit = (query: string) => {
+  // V9-B Feature 1: the history selector picks an index into
+  // `reportsForCurrentPlayer`; out-of-range (e.g. the list shrank) falls back
+  // to the newest (index 0).
+  const storedRecordForCurrentPlayer =
+    reportsForCurrentPlayer[historyIndex ?? 0] ?? reportsForCurrentPlayer[0] ?? null;
+
+  const handleSubmit = (query: string, source: ScoutSource) => {
     setSelectedRecord(null);
+    setHistoryIndex(null);
     generateReport.reset();
-    setLastQuery(query);
-    scout.mutate(query);
+    setLastQuery({ query, source });
+    scout.mutate({ query, source });
   };
 
   const handleGenerateReport = () => {
@@ -169,6 +199,7 @@ export function ScoutPage() {
       return;
     }
     setSelectedRecord(null);
+    setHistoryIndex(null);
     generateReport.mutate(lastQuery, {
       onError: (error) => {
         if (error instanceof ApiError && error.status === 402) {
@@ -191,15 +222,21 @@ export function ScoutPage() {
 
   // Other players' past reports — this player's own reports are already
   // shown automatically above, so they're excluded here to avoid duplication.
+  // Same source-aware key as `reportsForCurrentPlayer` above.
+  const currentPlayerKey = report ? scoutIdentityKey(report.player) : null;
   const otherPastReports = (pastReports.data ?? []).filter(
-    (record) => record.player.id !== report?.player.id,
+    (record) => scoutIdentityKey(record.player) !== currentPlayerKey,
   );
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6">
       <h1 className="text-2xl font-semibold tracking-tight">Scout a Player</h1>
 
-      <ScoutSearchForm onSubmit={handleSubmit} isPending={scout.isPending} />
+      <ScoutSearchForm
+        onSubmit={handleSubmit}
+        isPending={scout.isPending}
+        parryggEnabled={parryggEnabled}
+      />
 
       {scout.isError && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
@@ -290,7 +327,20 @@ export function ScoutPage() {
             </div>
           )}
 
+          {/* V9-B Feature 1: only rendered when this player has MORE THAN ONE
+              stored report — a single report needs no navigation, it's just
+              shown directly via storedRecordForCurrentPlayer below. */}
+          {!generateReport.data && !selectedRecord && reportsForCurrentPlayer.length > 1 && (
+            <ScoutReportHistorySelector
+              reports={reportsForCurrentPlayer}
+              index={historyIndex ?? 0}
+              onChange={setHistoryIndex}
+            />
+          )}
+
           {displayedRecord && <ScoutAiReportCard record={displayedRecord} />}
+
+          <ScoutMatchupAdvisorCard scoutedCharacters={report.characters} matches={matches} />
 
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <ScoutCharactersCard characters={report.characters} />
@@ -312,8 +362,9 @@ export function ScoutPage() {
 
       {!report && !scout.isError && !scout.isPending && (
         <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
-          Paste a start.gg profile URL, slug, or player id above to pull up their public tournament
-          history.
+          {parryggEnabled
+            ? 'Paste a start.gg or parry.gg profile URL, slug/tag, or player id above to pull up their public tournament history.'
+            : 'Paste a start.gg profile URL, slug, or player id above to pull up their public tournament history.'}
         </div>
       )}
 

--- a/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Match, ScoutCharacterUsage } from '@smash-tracker/shared';
+import { ScoutMatchupAdvisorCard } from './ScoutMatchupAdvisorCard';
+
+const useFightersMock = vi.fn();
+vi.mock('@/hooks/useFighters', () => ({
+  useFighters: () => useFightersMock(),
+}));
+
+// Fighter ids: 82 Steve, 52 Little Mac, 9 Pikachu (see fighterData.ts).
+function makeMatch(overrides: Partial<Match>): Match {
+  return {
+    id: `m-${Math.random()}`,
+    fighter_id: 82,
+    opponent_id: 9,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'none',
+    time: Date.now(),
+    win: true,
+    ...overrides,
+  };
+}
+
+const SCOUTED_CHARACTERS: ScoutCharacterUsage[] = [{ fighterId: 9, games: 10, wins: 6 }];
+
+describe('ScoutMatchupAdvisorCard', () => {
+  it('shows the empty state when the scout has no character data', () => {
+    useFightersMock.mockReturnValue({ data: { primary: [82], secondary: [] } });
+    render(<ScoutMatchupAdvisorCard scoutedCharacters={[]} matches={[]} />);
+
+    expect(screen.getByText(/No character data for this scout yet/)).toBeInTheDocument();
+  });
+
+  it('prompts to pick a fighter when the user has no characters/matches at all', () => {
+    useFightersMock.mockReturnValue({ data: { primary: [], secondary: [] } });
+    render(<ScoutMatchupAdvisorCard scoutedCharacters={SCOUTED_CHARACTERS} matches={[]} />);
+
+    expect(screen.getByText(/Pick a primary or secondary character/)).toBeInTheDocument();
+  });
+
+  it('recommends the best pick per opponent character, using the user primary fighter as a candidate', () => {
+    useFightersMock.mockReturnValue({ data: { primary: [82], secondary: [] } });
+    render(<ScoutMatchupAdvisorCard scoutedCharacters={SCOUTED_CHARACTERS} matches={[]} />);
+
+    expect(screen.getByText('vs. Pikachu')).toBeInTheDocument();
+    expect(screen.getByText('Steve')).toBeInTheDocument();
+  });
+
+  it('lets the users own record vs. a specific opponent character override the tier prior', () => {
+    useFightersMock.mockReturnValue({ data: { primary: [82, 52], secondary: [] } });
+    const matches = [
+      ...Array.from({ length: 18 }, () => makeMatch({ fighter_id: 52, opponent_id: 9, win: true })),
+      ...Array.from({ length: 2 }, () => makeMatch({ fighter_id: 52, opponent_id: 9, win: false })),
+    ];
+    render(<ScoutMatchupAdvisorCard scoutedCharacters={SCOUTED_CHARACTERS} matches={matches} />);
+
+    // Little Mac's dominant, well-sampled record against Pikachu should win
+    // out over Steve's much higher tier score (best pick, not just present).
+    const bestPickRegion = screen.getByText('vs. Pikachu').closest('li');
+    expect(bestPickRegion).not.toBeNull();
+    expect(bestPickRegion!.textContent).toContain('Little Mac');
+    expect(bestPickRegion!.textContent).toContain('18-2 in your sets');
+  });
+
+  it('hides opponent characters with fighterId 0 (unmapped)', () => {
+    useFightersMock.mockReturnValue({ data: { primary: [82], secondary: [] } });
+    render(
+      <ScoutMatchupAdvisorCard
+        scoutedCharacters={[{ fighterId: 0, games: 5, wins: 2 }]}
+        matches={[]}
+      />,
+    );
+    expect(screen.getByText(/No character data for this scout yet/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.tsx
@@ -1,0 +1,191 @@
+import { useMemo } from 'react';
+import { Swords } from 'lucide-react';
+import type {
+  Match,
+  MyCharacterRecordVsOpponent,
+  ScoutCharacterUsage,
+} from '@smash-tracker/shared';
+import { rankMatchup, selectMyCandidateFighterIds, type MatchupPick } from '@smash-tracker/shared';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getFighterById } from '@/data/sprites';
+import { useFighters } from '@/hooks/useFighters';
+
+const MAX_OPPONENT_ROWS = 5;
+const MY_TOP_CHARACTERS_COUNT = 5;
+
+interface AdvisorRow {
+  opponentFighterId: number;
+  opponentGames: number;
+  best: MatchupPick;
+  worst: MatchupPick | null;
+}
+
+function fighterLabel(fighterId: number): string {
+  return getFighterById(fighterId)?.name ?? 'Unknown';
+}
+
+function PickChip({ pick, tone }: { pick: MatchupPick; tone: 'best' | 'worst' }) {
+  const sprite = getFighterById(pick.fighterId);
+  const evidenceParts: string[] = [];
+  if (pick.evidence.record) {
+    evidenceParts.push(`${pick.evidence.record} in your sets`);
+  }
+  evidenceParts.push(`tier ${pick.evidence.tierScore.toFixed(1)}/10`);
+  if (pick.evidence.archetypeEdge > 0) {
+    evidenceParts.push('archetype edge');
+  } else if (pick.evidence.archetypeEdge < 0) {
+    evidenceParts.push('archetype disadvantage');
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {sprite ? (
+        <img src={sprite.url} alt="" className="size-6 object-contain" />
+      ) : (
+        <span className="flex size-6 items-center justify-center rounded bg-muted text-[10px] font-semibold text-muted-foreground">
+          ?
+        </span>
+      )}
+      <div className="flex flex-col leading-tight">
+        <span className={`text-sm font-medium ${tone === 'worst' ? 'text-muted-foreground' : ''}`}>
+          {sprite?.name ?? 'Unknown'}
+        </span>
+        <span className="text-xs text-muted-foreground">{evidenceParts.join(' · ')}</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * V9-B Feature 3: deterministic (zero AI cost) character-pick advisor —
+ * "who should I play against each of their characters", ranked by the
+ * shared `matchupAdvisor.ts` blend of the user's own W/L record with
+ * tier-list/archetype priors. Placed between the AI-report area and
+ * Character Usage on the scout result.
+ *
+ * Hidden rows: opponent characters with `fighterId === 0` (unmapped) are
+ * excluded — there's nothing to advise against for "unknown character".
+ * Empty state: when the scout has no character data at all (common for
+ * parry.gg's younger/sparser match data), says so plainly rather than
+ * rendering an empty table.
+ */
+export function ScoutMatchupAdvisorCard({
+  scoutedCharacters,
+  matches,
+}: {
+  scoutedCharacters: ScoutCharacterUsage[];
+  matches: Match[];
+}) {
+  const { data: fighters } = useFighters();
+
+  const myFighterIds = useMemo(
+    () =>
+      selectMyCandidateFighterIds(
+        matches.map((m) => m.fighter_id),
+        fighters?.primary ?? [],
+        fighters?.secondary ?? [],
+        MY_TOP_CHARACTERS_COUNT,
+      ),
+    [fighters, matches],
+  );
+
+  const opponentFighterIds = useMemo(
+    () =>
+      scoutedCharacters
+        .filter((c) => c.fighterId !== 0)
+        .slice(0, MAX_OPPONENT_ROWS)
+        .map((c) => c.fighterId),
+    [scoutedCharacters],
+  );
+
+  const rows: AdvisorRow[] = useMemo(() => {
+    if (myFighterIds.length === 0) {
+      return [];
+    }
+    return opponentFighterIds.flatMap((opponentFighterId) => {
+      const records: MyCharacterRecordVsOpponent[] = myFighterIds.map((fighterId) => {
+        const vsMatches = matches.filter(
+          (m) => m.fighter_id === fighterId && m.opponent_id === opponentFighterId,
+        );
+        const wins = vsMatches.filter((m) => m.win).length;
+        return { fighterId, wins, losses: vsMatches.length - wins };
+      });
+      const ranking = rankMatchup(opponentFighterId, myFighterIds, records);
+      if (!ranking.best) {
+        return [];
+      }
+      const opponentGames =
+        scoutedCharacters.find((c) => c.fighterId === opponentFighterId)?.games ?? 0;
+      return [
+        {
+          opponentFighterId,
+          opponentGames,
+          best: ranking.best,
+          worst: ranking.worst,
+        },
+      ];
+    });
+  }, [matches, myFighterIds, opponentFighterIds, scoutedCharacters]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Swords className="size-4" />
+          Matchup Advisor
+        </CardTitle>
+        <CardDescription>
+          Your best (and worst) pick against each of their characters — blends your own record with
+          tier list and archetype data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {opponentFighterIds.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No character data for this scout yet — common on parry.gg while match data is still
+            sparse. Check back after they've played more sets.
+          </p>
+        ) : myFighterIds.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Pick a primary or secondary character (or log a few matches) to get personalized
+            recommendations.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-4">
+            {rows.map((row) => (
+              <li
+                key={row.opponentFighterId}
+                className="flex flex-col gap-2 border-b pb-4 last:border-b-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex items-center gap-2">
+                  {(() => {
+                    const opponentSprite = getFighterById(row.opponentFighterId);
+                    return opponentSprite ? (
+                      <img src={opponentSprite.url} alt="" className="size-7 object-contain" />
+                    ) : (
+                      <span className="flex size-7 items-center justify-center rounded bg-muted text-[10px] font-semibold text-muted-foreground">
+                        ?
+                      </span>
+                    );
+                  })()}
+                  <div className="flex flex-col leading-tight">
+                    <span className="text-sm font-medium">
+                      vs. {fighterLabel(row.opponentFighterId)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {row.opponentGames} game{row.opponentGames === 1 ? '' : 's'} sampled
+                    </span>
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-4">
+                  <PickChip pick={row.best} tone="best" />
+                  {row.worst && <PickChip pick={row.worst} tone="worst" />}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ScoutRecentEvent } from '@smash-tracker/shared';
+import { ScoutRecentEventsCard } from './ScoutRecentEventsCard';
+
+describe('ScoutRecentEventsCard', () => {
+  it('renders a start.gg event with a slug as an external link to start.gg', () => {
+    const events: ScoutRecentEvent[] = [
+      {
+        eventName: 'Ultimate Singles',
+        lastSetAt: 1_700_000_000_000,
+        slug: 'tournament/the-big-house-9/event/ultimate-singles',
+        source: 'startgg',
+      },
+    ];
+    render(<ScoutRecentEventsCard events={events} />);
+
+    const link = screen.getByRole('link', { name: /Ultimate Singles/ });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.start.gg/tournament/the-big-house-9/event/ultimate-singles',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders a pre-V9-B event with no slug as plain text (back-compat)', () => {
+    const events: ScoutRecentEvent[] = [
+      { eventName: 'Ultimate Singles', lastSetAt: 1_700_000_000_000 },
+    ];
+    render(<ScoutRecentEventsCard events={events} />);
+
+    expect(screen.getByText('Ultimate Singles')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a parry.gg event as plain text even when a slug is present (no verified event URL shape)', () => {
+    const events: ScoutRecentEvent[] = [
+      {
+        eventName: 'Ultimate Singles',
+        lastSetAt: 1_700_000_000_000,
+        slug: 'my-tournament-01931d1c/test',
+        source: 'parrygg',
+      },
+    ];
+    render(<ScoutRecentEventsCard events={events} />);
+
+    expect(screen.getByText('Ultimate Singles')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no events', () => {
+    render(<ScoutRecentEventsCard events={[]} />);
+    expect(screen.getByText('No recent events sampled.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.tsx
@@ -1,4 +1,4 @@
-import { Trophy } from 'lucide-react';
+import { ExternalLink, Trophy } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -9,6 +9,31 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import type { ScoutRecentEvent } from '@smash-tracker/shared';
+
+/**
+ * Builds the public event URL for an event with a `slug`, or `null` when the
+ * event can't be deep-linked. start.gg event slugs already carry the full
+ * path (e.g. "tournament/the-big-house-9/event/ultimate-singles"), so the
+ * link is simply `https://www.start.gg/{slug}` (V9-B Feature 2, verified
+ * against start.gg's own URL convention).
+ *
+ * parry.gg events are deliberately NOT linked here even when a slug is
+ * present in principle: unlike start.gg, this app has not empirically
+ * verified a working parry.gg EVENT page URL (only the PROFILE URL shape,
+ * `https://parry.gg/profile/{uuid}`, was confirmed live — see
+ * apps/api/src/parrygg/scout.ts). Rather than guess at a URL shape that
+ * might 404, parry.gg-sourced events render as plain text until that shape
+ * is verified.
+ */
+function eventUrl(event: ScoutRecentEvent): string | null {
+  if (!event.slug) {
+    return null;
+  }
+  if (event.source === 'parrygg') {
+    return null;
+  }
+  return `https://www.start.gg/${event.slug}`;
+}
 
 function ordinal(n: number): string {
   const mod100 = n % 100;
@@ -49,34 +74,49 @@ export function ScoutRecentEventsCard({ events }: { events: ScoutRecentEvent[] }
               </TableRow>
             </TableHeader>
             <TableBody>
-              {events.map((event) => (
-                <TableRow key={`${event.eventName}-${event.lastSetAt}`}>
-                  <TableCell>
-                    <div className="flex flex-col">
-                      <span className="font-medium">{event.eventName}</span>
-                      {event.tournamentName && (
-                        <span className="text-xs text-muted-foreground">
-                          {event.tournamentName}
+              {events.map((event) => {
+                const url = eventUrl(event);
+                return (
+                  <TableRow key={`${event.eventName}-${event.lastSetAt}`}>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        {url ? (
+                          <a
+                            href={url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 font-medium text-primary hover:underline"
+                          >
+                            {event.eventName}
+                            <ExternalLink className="size-3" />
+                          </a>
+                        ) : (
+                          <span className="font-medium">{event.eventName}</span>
+                        )}
+                        {event.tournamentName && (
+                          <span className="text-xs text-muted-foreground">
+                            {event.tournamentName}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {event.placement ? (
+                        <span className="inline-flex items-center gap-1">
+                          {event.placement === 1 && <Trophy className="size-3.5 text-amber-500" />}
+                          {ordinal(event.placement)}
                         </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
                       )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {event.placement ? (
-                      <span className="inline-flex items-center gap-1">
-                        {event.placement === 1 && <Trophy className="size-3.5 text-amber-500" />}
-                        {ordinal(event.placement)}
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right">{event.numEntrants ?? '—'}</TableCell>
-                  <TableCell className="text-right text-muted-foreground">
-                    {new Date(event.lastSetAt).toLocaleDateString()}
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                    <TableCell className="text-right">{event.numEntrants ?? '—'}</TableCell>
+                    <TableCell className="text-right text-muted-foreground">
+                      {new Date(event.lastSetAt).toLocaleDateString()}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/apps/web/src/pages/Scout/components/ScoutReportHeader.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHeader.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ScoutReportData } from '@smash-tracker/shared';
+import { ScoutReportHeader } from './ScoutReportHeader';
+
+function baseReport(overrides: Partial<ScoutReportData['player']> = {}): ScoutReportData {
+  return {
+    player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239', ...overrides },
+    sampledSets: 3,
+    sampledGames: 6,
+    characters: [],
+    stages: [],
+    recentEvents: [],
+    commonOpponents: [],
+  };
+}
+
+describe('ScoutReportHeader', () => {
+  it('links to start.gg for a pre-V9-B report with no source field (back-compat)', () => {
+    render(<ScoutReportHeader report={baseReport()} />);
+    const link = screen.getByRole('link', { name: /View Pandem1c on start\.gg/ });
+    expect(link).toHaveAttribute('href', 'https://start.gg/user/07dc2239');
+    expect(screen.getByText(/Public start\.gg data/)).toBeInTheDocument();
+  });
+
+  it('links to parry.gg for a parrygg-sourced report', () => {
+    const report: ScoutReportData = {
+      player: {
+        gamerTag: 'Pandem1c',
+        source: 'parrygg',
+        parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+      },
+      sampledSets: 1,
+      sampledGames: 2,
+      characters: [],
+      stages: [],
+      recentEvents: [],
+      commonOpponents: [],
+    };
+    render(<ScoutReportHeader report={report} />);
+    const link = screen.getByRole('link', { name: /View Pandem1c on parry\.gg/ });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
+    );
+    expect(screen.getByText(/Public parry\.gg data/)).toBeInTheDocument();
+  });
+
+  it('renders no profile link when no identifying slug/id is available', () => {
+    render(<ScoutReportHeader report={baseReport({ userSlug: undefined })} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
@@ -3,13 +3,28 @@ import { Card, CardContent } from '@/components/ui/card';
 import type { ScoutReportData } from '@smash-tracker/shared';
 
 /**
- * Report header: the scouted player's gamer tag, a start.gg profile link
- * (when a slug is available), and the sample-size caption every scouting
- * report carries — "this is public data, and it's a sample, not their whole
- * history."
+ * Report header: the scouted player's gamer tag, a profile link (when
+ * available), and the sample-size caption every scouting report carries —
+ * "this is public data, and it's a sample, not their whole history."
+ *
+ * V9-B Feature 4: source-aware — `report.player.source` is absent for every
+ * pre-V9-B report (start.gg was the only source), so `?? 'startgg'` keeps
+ * old reports labeled/linked exactly as before. parry.gg identities have no
+ * `userSlug` (that field is start.gg-only), so their profile link is built
+ * from `parryUserId` instead — the verified `https://parry.gg/profile/{id}`
+ * shape (see apps/api/src/parrygg/scout.ts).
  */
 export function ScoutReportHeader({ report }: { report: ScoutReportData }) {
-  const profileUrl = report.player.userSlug ? `https://start.gg/${report.player.userSlug}` : null;
+  const source = report.player.source ?? 'startgg';
+  const profileUrl =
+    source === 'parrygg'
+      ? report.player.parryUserId
+        ? `https://parry.gg/profile/${report.player.parryUserId}`
+        : null
+      : report.player.userSlug
+        ? `https://start.gg/${report.player.userSlug}`
+        : null;
+  const sourceLabel = source === 'parrygg' ? 'parry.gg' : 'start.gg';
 
   return (
     <Card>
@@ -21,16 +36,16 @@ export function ScoutReportHeader({ report }: { report: ScoutReportData }) {
               href={profileUrl}
               target="_blank"
               rel="noreferrer"
-              aria-label={`View ${report.player.gamerTag} on start.gg`}
+              aria-label={`View ${report.player.gamerTag} on ${sourceLabel}`}
               className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
             >
               <ExternalLink className="size-3.5" />
-              start.gg profile
+              {sourceLabel} profile
             </a>
           )}
         </div>
         <p className="text-sm text-muted-foreground">
-          Public start.gg data · sampled last {report.sampledSets} set
+          Public {sourceLabel} data · sampled last {report.sampledSets} set
           {report.sampledSets === 1 ? '' : 's'} ({report.sampledGames} game
           {report.sampledGames === 1 ? '' : 's'})
         </p>

--- a/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ScoutReportRecord } from '@smash-tracker/shared';
+import { ScoutReportHistorySelector } from './ScoutReportHistorySelector';
+
+function makeRecord(id: string, createdAt: number): ScoutReportRecord {
+  return {
+    id,
+    createdAt,
+    model: 'claude-opus-4-8',
+    player: { id: 1802316, gamerTag: 'Pandem1c' },
+    report: {
+      overview: 'overview',
+      gameplan: [],
+      stageStrategy: { bans: [], picks: [], reasoning: '' },
+      headToHead: null,
+      watchFor: [],
+      confidenceNotes: '',
+    },
+  };
+}
+
+// Newest-first, matching GET /api/reports ordering.
+const REPORTS: ScoutReportRecord[] = [
+  makeRecord('r3', 1_700_300_000_000),
+  makeRecord('r2', 1_700_200_000_000),
+  makeRecord('r1', 1_700_100_000_000),
+];
+
+describe('ScoutReportHistorySelector', () => {
+  it('shows "Report N of total" counting from the oldest, for the newest report by default', () => {
+    render(<ScoutReportHistorySelector reports={REPORTS} index={0} onChange={() => {}} />);
+    expect(screen.getByText(/Report 3 of 3/)).toBeInTheDocument();
+  });
+
+  it('moves to an older report and back with prev/next', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ScoutReportHistorySelector reports={REPORTS} index={0} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Older report' }));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('disables "newer" at the newest report and "older" at the oldest', () => {
+    const { rerender } = render(
+      <ScoutReportHistorySelector reports={REPORTS} index={0} onChange={() => {}} />,
+    );
+    expect(screen.getByRole('button', { name: 'Newer report' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Older report' })).not.toBeDisabled();
+
+    rerender(<ScoutReportHistorySelector reports={REPORTS} index={2} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Older report' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Newer report' })).not.toBeDisabled();
+  });
+
+  it('renders nothing for an out-of-range index', () => {
+    const { container } = render(
+      <ScoutReportHistorySelector reports={REPORTS} index={99} onChange={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.tsx
@@ -1,0 +1,63 @@
+import { ChevronLeft, ChevronRight, History } from 'lucide-react';
+import type { ScoutReportRecord } from '@smash-tracker/shared';
+import { Button } from '@/components/ui/button';
+
+/**
+ * V9-B Feature 1: a compact prev/next selector shown above the AI report
+ * card when the scouted player has MULTIPLE stored reports — without it,
+ * only the newest report for a player is ever reachable (see
+ * `ScoutPage.storedRecordForCurrentPlayer`). `reports` is newest-first (same
+ * ordering `GET /api/reports` guarantees); `index` 0 is the newest.
+ */
+export function ScoutReportHistorySelector({
+  reports,
+  index,
+  onChange,
+}: {
+  reports: ScoutReportRecord[];
+  index: number;
+  onChange: (index: number) => void;
+}) {
+  const total = reports.length;
+  const current = reports[index];
+  if (!current) {
+    return null;
+  }
+
+  // Displayed as "Report N of total" where N counts from the OLDEST (so
+  // "Report 1" is the first one ever generated) while `index` internally
+  // counts from the newest — the ordinal for the current record is simply
+  // `total - index`.
+  const ordinal = total - index;
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <History className="size-4" />
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="size-7"
+        disabled={index >= total - 1}
+        onClick={() => onChange(index + 1)}
+        aria-label="Older report"
+      >
+        <ChevronLeft className="size-4" />
+      </Button>
+      <span>
+        Report {ordinal} of {total} · {new Date(current.createdAt).toLocaleDateString()}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="size-7"
+        disabled={index <= 0}
+        onClick={() => onChange(index - 1)}
+        aria-label="Newer report"
+      >
+        <ChevronRight className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Scout/components/ScoutSearchForm.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutSearchForm.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScoutSearchForm } from './ScoutSearchForm';
+
+describe('ScoutSearchForm', () => {
+  it('submits with source: startgg by default, and hides the toggle when parrygg is disabled', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} parryggEnabled={false} />);
+
+    expect(screen.queryByRole('radiogroup', { name: /Scouting source/ })).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('user/07dc2239', 'startgg');
+  });
+
+  it('shows the source toggle when parrygg is enabled, and submits the selected source', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} parryggEnabled />);
+
+    await user.type(screen.getByLabelText(/start\.gg or parry\.gg profile URL/), 'PowPow');
+    await user.click(screen.getByRole('radio', { name: 'parry.gg' }));
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('PowPow', 'parrygg');
+  });
+
+  it('auto-detects a pasted parry.gg profile URL and overrides the toggle', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} parryggEnabled />);
+
+    // Toggle starts on start.gg...
+    expect(screen.getByRole('radio', { name: 'start.gg' })).toHaveAttribute('aria-checked', 'true');
+
+    await user.type(
+      screen.getByLabelText(/start\.gg or parry\.gg profile URL/),
+      'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
+    );
+
+    // ...but flips to parry.gg once the URL is unambiguous, and disables manual toggling.
+    expect(screen.getByRole('radio', { name: 'parry.gg' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'start.gg' })).toBeDisabled();
+    expect(screen.getByRole('radio', { name: 'parry.gg' })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
+      'parrygg',
+    );
+  });
+
+  it('does not submit an empty query', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} />);
+
+    expect(screen.getByRole('button', { name: 'Scout' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
@@ -1,23 +1,45 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
+import type { ScoutSource } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+
+/**
+ * Client-side hint only — a lightweight mirror of the server's own
+ * `parseParryProfileUrl` detection (apps/api/src/parrygg/scout.ts), used
+ * purely to auto-select/disable the source toggle when the pasted text is
+ * unambiguously a parry.gg profile URL. The SERVER re-detects and overrides
+ * regardless of what `source` is sent, so this never needs to be exhaustive
+ * — a false negative here just means the toggle doesn't visually flip before
+ * submit, not an incorrect scout.
+ */
+function looksLikeParryProfileUrl(value: string): boolean {
+  return /parry\.gg\/profile\//i.test(value.trim());
+}
 
 export function ScoutSearchForm({
   onSubmit,
   isPending,
+  parryggEnabled = false,
 }: {
-  onSubmit: (query: string) => void;
+  onSubmit: (query: string, source: ScoutSource) => void;
   isPending: boolean;
+  /** Hides the source toggle entirely when parry.gg isn't configured on this deployment (V9-B Feature 4). */
+  parryggEnabled?: boolean;
 }) {
   const [query, setQuery] = useState('');
+  const [source, setSource] = useState<ScoutSource>('startgg');
+
+  const detectedParryUrl = useMemo(() => looksLikeParryProfileUrl(query), [query]);
+  const effectiveSource: ScoutSource = detectedParryUrl ? 'parrygg' : source;
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const trimmed = query.trim();
     if (trimmed) {
-      onSubmit(trimmed);
+      onSubmit(trimmed, effectiveSource);
     }
   };
 
@@ -26,26 +48,68 @@ export function ScoutSearchForm({
       <CardHeader>
         <CardTitle>Scout a Player</CardTitle>
         <CardDescription>
-          Paste a start.gg profile URL, a "user/&lt;slug&gt;" reference, or a numeric player id to
-          pull up their public tournament history before you play them.
+          {parryggEnabled
+            ? 'Paste a start.gg or parry.gg profile URL, a bare gamer tag, a "user/<slug>" reference, or a numeric player id to pull up their public tournament history before you play them.'
+            : 'Paste a start.gg profile URL, a "user/<slug>" reference, or a numeric player id to pull up their public tournament history before you play them.'}
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
-          <div className="relative flex-1">
-            <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="https://start.gg/user/07dc2239"
-              className="pl-8"
-              disabled={isPending}
-              aria-label="start.gg profile URL, slug, or player id"
-            />
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={
+                  parryggEnabled
+                    ? 'https://start.gg/user/07dc2239 or a parry.gg profile URL'
+                    : 'https://start.gg/user/07dc2239'
+                }
+                className="pl-8"
+                disabled={isPending}
+                aria-label={
+                  parryggEnabled
+                    ? 'start.gg or parry.gg profile URL, slug/tag, or player id'
+                    : 'start.gg profile URL, slug, or player id'
+                }
+              />
+            </div>
+            <Button type="submit" disabled={isPending || query.trim().length === 0}>
+              {isPending ? 'Scouting…' : 'Scout'}
+            </Button>
           </div>
-          <Button type="submit" disabled={isPending || query.trim().length === 0}>
-            {isPending ? 'Scouting…' : 'Scout'}
-          </Button>
+
+          {parryggEnabled && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Source:</span>
+              <ToggleGroup
+                type="single"
+                variant="outline"
+                size="sm"
+                value={effectiveSource}
+                disabled={detectedParryUrl}
+                onValueChange={(value) => {
+                  if (value === 'startgg' || value === 'parrygg') {
+                    setSource(value);
+                  }
+                }}
+                aria-label="Scouting source"
+              >
+                <ToggleGroupItem value="startgg" aria-label="start.gg">
+                  start.gg
+                </ToggleGroupItem>
+                <ToggleGroupItem value="parrygg" aria-label="parry.gg">
+                  parry.gg
+                </ToggleGroupItem>
+              </ToggleGroup>
+              {detectedParryUrl && (
+                <span className="text-xs text-muted-foreground">
+                  Detected a parry.gg profile URL.
+                </span>
+              )}
+            </div>
+          )}
         </form>
         {isPending && (
           <p className="mt-2 text-sm text-muted-foreground">

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -6,6 +6,7 @@ import { ChooseSecondaryPage } from '@/pages/CharacterSelect/ChooseSecondaryPage
 import { MatchupsPage } from '@/pages/Matchups/MatchupsPage';
 import { OpponentsPage } from '@/pages/Opponents/OpponentsPage';
 import { ScoutPage } from '@/pages/Scout/ScoutPage';
+import { ReportsPage } from '@/pages/Reports/ReportsPage';
 import { MatchDataPage } from '@/pages/MatchData/MatchDataPage';
 import { TrendsPage } from '@/pages/Trends/TrendsPage';
 import { GroupsPage } from '@/pages/Groups/GroupsPage';
@@ -81,6 +82,14 @@ export function AppRouter() {
           element={
             <ProtectedRoute>
               <ScoutPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/reports"
+          element={
+            <ProtectedRoute>
+              <ReportsPage />
             </ProtectedRoute>
           }
         />

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,3 +34,5 @@ export * from './reports.js';
 export * from './glicko.js';
 export * from './groups.js';
 export * from './billing.js';
+export * from './meta.js';
+export * from './matchupAdvisor.js';

--- a/packages/shared/src/matchupAdvisor.test.ts
+++ b/packages/shared/src/matchupAdvisor.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMatchupAdvisor,
+  rankMatchup,
+  selectMyCandidateFighterIds,
+  type MyCharacterRecordVsOpponent,
+} from './matchupAdvisor.js';
+import { getFighterMeta } from './meta.js';
+
+// Fighter ids used below (see fighterData.ts):
+// 82 Steve (S+, zoner/trapper), 36 Snake (S+, zoner/trapper), 8 Fox (S, rushdown),
+// 26 Ganondorf (D+, heavy), 52 Little Mac (D+, rushdown/grappler), 75 Piranha Plant (D, trapper/zoner)
+
+describe('rankMatchup', () => {
+  it('falls back to tier/archetype prior when there is no data', () => {
+    // Steve (S+) vs. Ganondorf (D+) as candidates against some opponent —
+    // with zero recorded games for either, the far-higher tier score should
+    // win out.
+    const ranking = rankMatchup(9 /* opponent: Pikachu */, [82, 26], []);
+    expect(ranking.best?.fighterId).toBe(82);
+    expect(ranking.worst?.fighterId).toBe(26);
+    // No record evidence should be attached when the sample is empty.
+    expect(ranking.best?.evidence.record).toBeUndefined();
+  });
+
+  it('lets a rich, favorable record overturn a worse tier placement', () => {
+    // Little Mac (D+) has a dominant, well-sampled record against this
+    // opponent; Steve (S+) has never been played against them. The user's
+    // real results should win out over Steve's much higher tier score once
+    // the sample is large.
+    const records: MyCharacterRecordVsOpponent[] = [{ fighterId: 52, wins: 18, losses: 2 }];
+    const ranking = rankMatchup(9, [82, 52], records);
+    expect(ranking.best?.fighterId).toBe(52);
+    expect(ranking.best?.evidence.record).toBe('18-2');
+  });
+
+  it('barely moves off the prior for a thin (1-2 game) sample', () => {
+    // A single loss with Little Mac shouldn't be enough to conclude Little
+    // Mac is bad against this opponent relative to Steve's much stronger
+    // prior — thin samples should shrink toward the prior, not dominate it.
+    const records: MyCharacterRecordVsOpponent[] = [{ fighterId: 52, wins: 0, losses: 1 }];
+    const ranking = rankMatchup(9, [82, 52], records);
+    expect(ranking.best?.fighterId).toBe(82);
+  });
+
+  it('shows monotonically increasing confidence in the record as sample size grows', () => {
+    // With a consistent 100% win rate, more games sampled should pull the
+    // blended score monotonically closer to 1 (fully trusting the record).
+    const withFew = rankMatchup(9, [52], [{ fighterId: 52, wins: 2, losses: 0 }]).best!;
+    const withMany = rankMatchup(9, [52], [{ fighterId: 52, wins: 20, losses: 0 }]).best!;
+    expect(withMany.score).toBeGreaterThan(withFew.score);
+  });
+
+  it('degrades gracefully for an unmapped/unknown fighter id', () => {
+    const unknownId = 999999;
+    expect(() => getFighterMeta(unknownId)).not.toThrow();
+    const ranking = rankMatchup(9, [unknownId, 82], []);
+    expect(ranking.ranked).toHaveLength(2);
+    // Steve's much higher tier score should still beat the mid-pack default
+    // assigned to the unknown id.
+    expect(ranking.best?.fighterId).toBe(82);
+  });
+
+  it('returns null best/worst for an empty candidate list', () => {
+    const ranking = rankMatchup(9, [], []);
+    expect(ranking.best).toBeNull();
+    expect(ranking.worst).toBeNull();
+    expect(ranking.ranked).toEqual([]);
+  });
+
+  it('returns null worst (not a duplicate of best) for a single candidate', () => {
+    const ranking = rankMatchup(9, [82], []);
+    expect(ranking.best?.fighterId).toBe(82);
+    expect(ranking.worst).toBeNull();
+  });
+
+  it('orders every candidate by descending score', () => {
+    const ranking = rankMatchup(9, [82, 8, 26, 52], []);
+    const scores = ranking.ranked.map((r) => r.score);
+    for (let i = 1; i < scores.length; i += 1) {
+      expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]!);
+    }
+  });
+});
+
+describe('buildMatchupAdvisor', () => {
+  it('ranks each opponent fighter id independently', () => {
+    const recordsByOpponent = new Map<number, MyCharacterRecordVsOpponent[]>([
+      [9, [{ fighterId: 52, wins: 15, losses: 1 }]],
+      [36, [{ fighterId: 82, wins: 1, losses: 15 }]],
+    ]);
+    const rankings = buildMatchupAdvisor([9, 36], [82, 52], recordsByOpponent);
+    expect(rankings).toHaveLength(2);
+    expect(rankings[0]?.opponentFighterId).toBe(9);
+    expect(rankings[0]?.best?.fighterId).toBe(52);
+    expect(rankings[1]?.opponentFighterId).toBe(36);
+    // Steve's own bad record vs. this opponent should pull it down even
+    // though it's a strong tier pick in general.
+    expect(rankings[1]?.ranked.find((r) => r.fighterId === 82)?.evidence.record).toBe('1-15');
+  });
+
+  it('returns an empty array for an empty opponent list', () => {
+    expect(buildMatchupAdvisor([], [82], new Map())).toEqual([]);
+  });
+});
+
+describe('selectMyCandidateFighterIds', () => {
+  it('unions primary/secondary selections with the top-played characters', () => {
+    const played = [8, 8, 8, 26, 26, 52]; // Fox x3, Ganondorf x2, Little Mac x1
+    const result = selectMyCandidateFighterIds(played, [82], [36]);
+    expect(new Set(result)).toEqual(new Set([82, 36, 8, 26, 52]));
+  });
+
+  it('de-duplicates when a primary/secondary fighter is also top-played', () => {
+    const played = [82, 82, 82];
+    const result = selectMyCandidateFighterIds(played, [82], []);
+    expect(result).toEqual([82]);
+  });
+
+  it('caps the top-played contribution at topCount, independent of primary/secondary', () => {
+    const played = [1, 1, 1, 2, 2, 3, 4, 5, 6];
+    const result = selectMyCandidateFighterIds(played, [], [], 2);
+    // Only the top 2 by games played (1 and 2) should be included.
+    expect(new Set(result)).toEqual(new Set([1, 2]));
+  });
+
+  it('returns an empty list when there is no data at all', () => {
+    expect(selectMyCandidateFighterIds([], [], [])).toEqual([]);
+  });
+});

--- a/packages/shared/src/matchupAdvisor.ts
+++ b/packages/shared/src/matchupAdvisor.ts
@@ -1,0 +1,195 @@
+import { archetypeEdge, getFighterMeta } from './meta.js';
+
+/**
+ * V9-B Feature 3: deterministic character-pick recommendations — ZERO added
+ * AI cost. Pure functions only, so both the web `ScoutMatchupAdvisorCard`
+ * and the API's `reports/generate.ts` payload assembly can call the exact
+ * same logic and never disagree.
+ *
+ * The core idea: for a given opponent character, rank each of the user's
+ * candidate fighters by a blended score that leans on the user's OWN
+ * head-to-head record as it gets more reliable (more games played), and
+ * falls back to tier-list + archetype-counter priors when that record is
+ * thin or nonexistent. See `pickScore` for the exact blend.
+ */
+
+/** Raw W/L the user has for one of their own fighters against one opponent fighter. */
+export interface MyCharacterRecordVsOpponent {
+  fighterId: number;
+  wins: number;
+  losses: number;
+}
+
+/** Evidence backing one ranked pick, for display/grounding. */
+export interface MatchupEvidence {
+  /** "W-L" the user has with this fighter against the opponent character, when any games exist. */
+  record?: string;
+  tierScore: number;
+  /** Archetype counter edge in [-1, 1]; positive favors the user's fighter. */
+  archetypeEdge: number;
+}
+
+export interface MatchupPick {
+  fighterId: number;
+  /** Blended score in roughly [0, 1] — higher is a better pick. Not a win-probability estimate, just a ranking score. */
+  score: number;
+  evidence: MatchupEvidence;
+}
+
+export interface MatchupRanking {
+  opponentFighterId: number;
+  /** All candidate fighters, best first. */
+  ranked: MatchupPick[];
+  best: MatchupPick | null;
+  worst: MatchupPick | null;
+}
+
+/**
+ * Sample size at which the user's own record and the tier/archetype prior
+ * contribute equally to the blended score. Below this, the prior dominates;
+ * well above it, the user's actual record dominates. 8 games (roughly two
+ * best-of-5 sets) is enough to start meaning something in Smash, without
+ * demanding a huge sample before real data counts at all.
+ */
+const CONFIDENCE_HALF_SAMPLE = 8;
+
+/**
+ * How much the prior (tier score + archetype edge) is allowed to move the
+ * blended score away from a neutral 0.5, at most. Priors are heuristics, not
+ * certainties — even a "perfect" S+ vs. D+ matchup on paper shouldn't be
+ * modeled as a mathematical guarantee, so the prior is compressed into
+ * `[0.5 - PRIOR_SWING, 0.5 + PRIOR_SWING]` rather than the full `[0, 1]`.
+ * This keeps a sufficiently large real sample ALWAYS able to outweigh the
+ * prior, however extreme, once `sampleWeight` gets close enough to 1.
+ */
+const PRIOR_SWING = 0.25;
+
+/** Converts a tier score (0-10) to a [0, 1] scale for blending. */
+function normalizedTierScore(tierScore: number): number {
+  return Math.min(Math.max(tierScore, 0), 10) / 10;
+}
+
+/** Converts an archetype edge ([-1, 1]) to a [0, 1] scale for blending. */
+function normalizedArchetypeEdge(edge: number): number {
+  return (edge + 1) / 2;
+}
+
+/**
+ * Blended pick score in [0, 1] for one candidate fighter against one
+ * opponent fighter:
+ *
+ * - `prior` = 70% tier-score comparison (the candidate's own tier score,
+ *   normalized) + 30% archetype counter edge (normalized) — tier placement
+ *   is the stronger, more character-specific signal; archetype counters fill
+ *   in texture when two characters are tier-adjacent.
+ * - `sampleWeight` = games / (games + CONFIDENCE_HALF_SAMPLE) — 0 with no
+ *   data, 0.5 at the half-sample point, asymptotically approaching 1 as the
+ *   sample grows. This is the confidence-weighting: thin samples barely move
+ *   the needle away from the prior; rich samples dominate it.
+ * - final score = `sampleWeight * winRate + (1 - sampleWeight) * prior`.
+ *
+ * Degrades gracefully for an unmapped/unknown fighter id: `getFighterMeta`
+ * always returns a mid-pack default rather than throwing, so an unrecognized
+ * id still produces a valid (just uninformative) score.
+ */
+function pickScore(
+  candidateFighterId: number,
+  opponentFighterId: number,
+  record: MyCharacterRecordVsOpponent | undefined,
+): MatchupPick {
+  const mine = getFighterMeta(candidateFighterId);
+  const theirs = getFighterMeta(opponentFighterId);
+
+  const edge = archetypeEdge(mine.archetypes, theirs.archetypes);
+  const rawPrior = 0.7 * normalizedTierScore(mine.tierScore) + 0.3 * normalizedArchetypeEdge(edge);
+  // Compress into [0.5 - PRIOR_SWING, 0.5 + PRIOR_SWING] — see PRIOR_SWING doc.
+  const prior = 0.5 + (rawPrior - 0.5) * (2 * PRIOR_SWING);
+
+  const games = (record?.wins ?? 0) + (record?.losses ?? 0);
+  const winRate = games > 0 ? (record?.wins ?? 0) / games : prior;
+  const sampleWeight = games / (games + CONFIDENCE_HALF_SAMPLE);
+
+  const score = sampleWeight * winRate + (1 - sampleWeight) * prior;
+
+  return {
+    fighterId: candidateFighterId,
+    score,
+    evidence: {
+      ...(games > 0 ? { record: `${record?.wins ?? 0}-${record?.losses ?? 0}` } : {}),
+      tierScore: mine.tierScore,
+      archetypeEdge: edge,
+    },
+  };
+}
+
+/**
+ * Ranks the user's candidate fighters against ONE opponent fighter, best
+ * pick first. `myFighterIds` should be de-duplicated by the caller (e.g. the
+ * union of primary/secondary + most-played); an empty list yields an empty
+ * ranking (no candidates to recommend).
+ */
+export function rankMatchup(
+  opponentFighterId: number,
+  myFighterIds: number[],
+  myRecordsVsOpponent: MyCharacterRecordVsOpponent[],
+): MatchupRanking {
+  const recordByFighterId = new Map(myRecordsVsOpponent.map((r) => [r.fighterId, r]));
+
+  const ranked = myFighterIds
+    .map((fighterId) => pickScore(fighterId, opponentFighterId, recordByFighterId.get(fighterId)))
+    .sort((a, b) => b.score - a.score);
+
+  return {
+    opponentFighterId,
+    ranked,
+    best: ranked[0] ?? null,
+    worst: ranked.length > 1 ? (ranked[ranked.length - 1] ?? null) : null,
+  };
+}
+
+/**
+ * Ranks every opponent fighter id in `opponentFighterIds` (typically the
+ * scouted player's top characters). `myRecordsVsOpponent` maps opponent
+ * fighter id -> the user's per-character records against that specific
+ * opponent character (raw counts, one entry per one of the user's own
+ * fighters).
+ */
+export function buildMatchupAdvisor(
+  opponentFighterIds: number[],
+  myFighterIds: number[],
+  myRecordsVsOpponent: Map<number, MyCharacterRecordVsOpponent[]>,
+): MatchupRanking[] {
+  return opponentFighterIds.map((opponentFighterId) =>
+    rankMatchup(opponentFighterId, myFighterIds, myRecordsVsOpponent.get(opponentFighterId) ?? []),
+  );
+}
+
+const DEFAULT_TOP_CHARACTERS_COUNT = 5;
+
+/**
+ * Selects the candidate fighter ids the advisor should rank against a given
+ * opponent: the union of the user's primary/secondary selections and their
+ * own top-N most-played characters (by games played, from `myFighterIdsPlayed`
+ * — one entry per game, e.g. `matches.map(m => m.fighter_id)`). Shared so the
+ * web `ScoutMatchupAdvisorCard` and the API's `reports/generate.ts` payload
+ * assembly compute the EXACT same candidate list from equivalent inputs,
+ * rather than maintaining two implementations of the same "what do I play"
+ * heuristic that could quietly drift apart.
+ */
+export function selectMyCandidateFighterIds(
+  myFighterIdsPlayed: number[],
+  primaryFighterIds: number[],
+  secondaryFighterIds: number[],
+  topCount = DEFAULT_TOP_CHARACTERS_COUNT,
+): number[] {
+  const gamesPlayedByFighterId = new Map<number, number>();
+  for (const fighterId of myFighterIdsPlayed) {
+    gamesPlayedByFighterId.set(fighterId, (gamesPlayedByFighterId.get(fighterId) ?? 0) + 1);
+  }
+  const myTopFighterIds = [...gamesPlayedByFighterId.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topCount)
+    .map(([fighterId]) => fighterId);
+
+  return [...new Set<number>([...primaryFighterIds, ...secondaryFighterIds, ...myTopFighterIds])];
+}

--- a/packages/shared/src/meta.ts
+++ b/packages/shared/src/meta.ts
@@ -1,0 +1,363 @@
+/**
+ * V9-B Feature 3: a static, deterministic Super Smash Bros. Ultimate meta
+ * dataset — ZERO added AI/API cost. Used by `matchupAdvisor.ts` to blend the
+ * user's own head-to-head record against tier placement + archetype counters
+ * when recommending which of the user's characters to reach for against a
+ * given opponent character.
+ *
+ * TIER SOURCE: adapted from the tier list published at
+ * https://beatcopgame.com/smash-ultimate-tier-list/ (captured 2026-07-06),
+ * itself derived from the UltRank 2026 community rankings
+ * (https://www.ssbwiki.com/UltRank_2026, 4th list, released 2026-05-06).
+ * Tier placements are inherently approximate/subjective community consensus,
+ * not a precise measurement — encoded honestly as a coarse 0-10 scale (S+ ~
+ * 10 down to D ~ 1) rather than false per-character precision. `SpriteList`
+ * groups a few in-game "echo"/multi-character entries the tier list treats
+ * as one line already (e.g. Peach/Daisy, Simon/Richter, Ryu/Ken, Pyra/Mythra)
+ * — those share a tier score here, matching how this roster models them as
+ * one fighter id. `Pokemon Trainer` (id 38) is scored as the trainer's
+ * overall placement (its three Pokemon aren't separate roster entries in
+ * `SpriteList`).
+ *
+ * This is a ONE-FILE edit point: updating for a future tier list means
+ * editing `TIER_SCORE_BY_FIGHTER_ID` below (and the source-of-truth comment
+ * above) — no other module needs to change.
+ */
+
+/** A small, deliberately coarse set of playstyle archetypes. A fighter may have more than one. */
+export type Archetype =
+  'zoner' | 'rushdown' | 'swordfighter' | 'grappler' | 'heavy' | 'trapper' | 'allRounder';
+
+export interface FighterMeta {
+  fighterId: number;
+  /** 0 (bottom of the list) - 10 (top of the list), see module doc for source. */
+  tierScore: number;
+  archetypes: Archetype[];
+}
+
+/**
+ * Tier score by `SpriteList` fighter id. Derived from the July 2026
+ * beatcopgame.com list (see module doc): S+ = 10, S = 8.7, A+ = 7.5, A = 6.5,
+ * A- = 5.7, B+ = 5, B = 4.2, B- = 3.5, C+ = 2.8, C = 2, D+ = 1.2, D = 0.5 —
+ * evenly spaced buckets standing in for the list's own tier bands, not a
+ * claim of finer precision than the source supports.
+ */
+const S_PLUS = 10;
+const S = 8.7;
+const A_PLUS = 7.5;
+const A = 6.5;
+const A_MINUS = 5.7;
+const B_PLUS = 5;
+const B = 4.2;
+const B_MINUS = 3.5;
+const C_PLUS = 2.8;
+const C = 2;
+const D_PLUS = 1.2;
+const D = 0.5;
+
+const TIER_SCORE_BY_FIGHTER_ID: Readonly<Record<number, number>> = {
+  1: A_MINUS, // Mario
+  2: C, // Donkey Kong
+  3: C_PLUS, // Link
+  4: C, // Samus
+  5: C_PLUS, // Dark Samus
+  6: S, // Yoshi
+  7: C, // Kirby
+  8: S, // Fox
+  9: S, // Pikachu
+  10: A_MINUS, // Luigi
+  11: A_MINUS, // Ness
+  12: A_MINUS, // Captain Falcon
+  13: C, // Jigglypuff
+  14: S, // Peach
+  15: S, // Daisy (shares Peach's tier line)
+  16: B_PLUS, // Bowser
+  17: B, // Ice Climbers (unlisted on source; placed at B, mid-pack grapple/pair archetype)
+  18: A, // Sheik
+  19: B, // Zelda
+  20: A_MINUS, // Dr. Mario (shares Mario's tier line)
+  21: B_PLUS, // Pichu
+  22: A_MINUS, // Falco
+  23: A, // Marth
+  24: A_PLUS, // Lucina
+  25: C_PLUS, // Young Link
+  26: D_PLUS, // Ganondorf
+  27: B, // Mewtwo
+  28: A, // Roy
+  29: B_PLUS, // Chrom (shares Roy's swordfighter family, one band below Roy per source split)
+  30: S_PLUS, // Mr. Game & Watch
+  31: C, // Meta Knight
+  32: B, // Pit (Palutena family placement, unlisted directly)
+  33: B, // Dark Pit
+  34: A, // Zero Suit Samus
+  35: A_PLUS, // Wario
+  36: S_PLUS, // Snake
+  37: B_PLUS, // Ike
+  38: B, // Pokemon Trainer
+  39: S, // Diddy Kong
+  40: B, // Lucas
+  41: S, // Sonic
+  42: B, // King Dedede
+  43: A_PLUS, // Olimar
+  44: A_MINUS, // Lucario
+  45: S, // R.O.B.
+  46: A_MINUS, // Toon Link
+  47: A_PLUS, // Wolf
+  48: B, // Villager
+  49: A, // Mega Man
+  50: A_MINUS, // Wii Fit Trainer
+  51: C_PLUS, // Rosalina & Luma
+  52: D_PLUS, // Little Mac
+  53: A, // Greninja
+  54: B_PLUS, // Mii Brawler
+  55: B, // Mii Swordfighter
+  56: B, // Mii Gunner
+  57: A_PLUS, // Palutena
+  58: A, // Pac-Man
+  59: B, // Robin
+  60: A, // Shulk
+  61: B_MINUS, // Bowser Jr.
+  62: B_MINUS, // Duck Hunt
+  63: A, // Ryu
+  64: A, // Ken (shares Ryu's tier line)
+  65: A_PLUS, // Cloud
+  66: B_MINUS, // Corrin
+  67: C, // Bayonetta
+  68: A, // Inkling
+  69: B_PLUS, // Ridley
+  70: C_PLUS, // Simon
+  71: C_PLUS, // Richter (shares Simon's tier line)
+  72: C, // King K. Rool
+  73: B, // Isabelle
+  74: D_PLUS, // Incineroar
+  75: D, // Piranha Plant
+  76: S, // Joker
+  77: B_PLUS, // Hero
+  78: B, // Banjo & Kazooie
+  79: B, // Terry
+  80: B, // Byleth (unlisted directly, placed with the mid-pack swordfighter cluster)
+  81: S_PLUS, // Min Min
+  82: S_PLUS, // Steve
+  83: B_PLUS, // Sephiroth
+  84: S, // Pyra/Mythra
+  85: S, // Kazuya
+};
+
+/**
+ * Archetypes by fighter id. Kept intentionally coarse — most fighters get
+ * one or two tags reflecting their dominant, widely-agreed-upon playstyle,
+ * not an exhaustive character study.
+ */
+const ARCHETYPES_BY_FIGHTER_ID: Readonly<Record<number, Archetype[]>> = {
+  1: ['allRounder'], // Mario
+  2: ['heavy', 'grappler'], // Donkey Kong
+  3: ['zoner', 'trapper'], // Link
+  4: ['zoner'], // Samus
+  5: ['zoner'], // Dark Samus
+  6: ['rushdown', 'allRounder'], // Yoshi
+  7: ['rushdown'], // Kirby
+  8: ['rushdown'], // Fox
+  9: ['rushdown'], // Pikachu
+  10: ['rushdown', 'grappler'], // Luigi
+  11: ['trapper'], // Ness
+  12: ['rushdown'], // Captain Falcon
+  13: ['rushdown'], // Jigglypuff
+  14: ['zoner', 'allRounder'], // Peach
+  15: ['zoner', 'allRounder'], // Daisy
+  16: ['heavy', 'grappler'], // Bowser
+  17: ['grappler', 'trapper'], // Ice Climbers
+  18: ['rushdown', 'zoner'], // Sheik
+  19: ['zoner', 'trapper'], // Zelda
+  20: ['allRounder'], // Dr. Mario
+  21: ['rushdown'], // Pichu
+  22: ['rushdown'], // Falco
+  23: ['swordfighter'], // Marth
+  24: ['swordfighter'], // Lucina
+  25: ['zoner', 'rushdown'], // Young Link
+  26: ['heavy'], // Ganondorf
+  27: ['zoner'], // Mewtwo
+  28: ['swordfighter'], // Roy
+  29: ['swordfighter'], // Chrom
+  30: ['trapper', 'zoner'], // Mr. Game & Watch
+  31: ['rushdown', 'swordfighter'], // Meta Knight
+  32: ['swordfighter', 'zoner'], // Pit
+  33: ['swordfighter', 'zoner'], // Dark Pit
+  34: ['rushdown', 'zoner'], // Zero Suit Samus
+  35: ['allRounder', 'rushdown'], // Wario
+  36: ['zoner', 'trapper'], // Snake
+  37: ['swordfighter', 'heavy'], // Ike
+  38: ['zoner', 'allRounder'], // Pokemon Trainer
+  39: ['rushdown'], // Diddy Kong
+  40: ['trapper'], // Lucas
+  41: ['rushdown'], // Sonic
+  42: ['heavy', 'grappler'], // King Dedede
+  43: ['zoner', 'trapper'], // Olimar
+  44: ['allRounder'], // Lucario
+  45: ['zoner', 'allRounder'], // R.O.B.
+  46: ['zoner', 'rushdown'], // Toon Link
+  47: ['zoner', 'allRounder'], // Wolf
+  48: ['trapper', 'zoner'], // Villager
+  49: ['zoner', 'trapper'], // Mega Man
+  50: ['allRounder', 'trapper'], // Wii Fit Trainer
+  51: ['zoner', 'trapper'], // Rosalina & Luma
+  52: ['rushdown', 'grappler'], // Little Mac
+  53: ['rushdown'], // Greninja
+  54: ['allRounder'], // Mii Brawler
+  55: ['swordfighter'], // Mii Swordfighter
+  56: ['zoner'], // Mii Gunner
+  57: ['zoner', 'allRounder'], // Palutena
+  58: ['zoner', 'trapper'], // Pac-Man
+  59: ['zoner', 'trapper'], // Robin
+  60: ['swordfighter', 'allRounder'], // Shulk
+  61: ['trapper', 'heavy'], // Bowser Jr.
+  62: ['zoner', 'trapper'], // Duck Hunt
+  63: ['rushdown', 'allRounder'], // Ryu
+  64: ['rushdown', 'allRounder'], // Ken
+  65: ['swordfighter', 'allRounder'], // Cloud
+  66: ['grappler', 'swordfighter'], // Corrin
+  67: ['rushdown'], // Bayonetta
+  68: ['zoner', 'trapper'], // Inkling
+  69: ['heavy', 'grappler'], // Ridley
+  70: ['zoner', 'trapper'], // Simon
+  71: ['zoner', 'trapper'], // Richter
+  72: ['heavy', 'grappler'], // King K. Rool
+  73: ['trapper'], // Isabelle
+  74: ['heavy', 'grappler'], // Incineroar
+  75: ['trapper', 'zoner'], // Piranha Plant
+  76: ['zoner', 'trapper'], // Joker
+  77: ['zoner', 'trapper'], // Hero
+  78: ['zoner', 'trapper'], // Banjo & Kazooie
+  79: ['zoner', 'rushdown'], // Terry
+  80: ['swordfighter', 'allRounder'], // Byleth
+  81: ['zoner'], // Min Min
+  82: ['zoner', 'trapper'], // Steve
+  83: ['swordfighter'], // Sephiroth
+  84: ['swordfighter', 'zoner'], // Pyra/Mythra
+  85: ['rushdown', 'grappler'], // Kazuya
+};
+
+const DEFAULT_TIER_SCORE = B; // Mid-pack fallback for any fighter id not explicitly listed above.
+const DEFAULT_ARCHETYPES: Archetype[] = ['allRounder'];
+
+/** Looks up meta (tier score + archetypes) for a fighter id, degrading gracefully for unknown ids. */
+export function getFighterMeta(fighterId: number): FighterMeta {
+  return {
+    fighterId,
+    tierScore: TIER_SCORE_BY_FIGHTER_ID[fighterId] ?? DEFAULT_TIER_SCORE,
+    archetypes: ARCHETYPES_BY_FIGHTER_ID[fighterId] ?? DEFAULT_ARCHETYPES,
+  };
+}
+
+/**
+ * Archetype-vs-archetype counter matrix: `COUNTER_MATRIX[a][b]` is how well
+ * archetype `a` fares against archetype `b` — `1` favors `a`, `-1` favors
+ * `b`, `0` is roughly even. Deliberately coarse rationale, encoded once:
+ *
+ * - zoner beats rushdown (space control punishes approach) and grappler
+ *   (grapplers must close distance through zoning tools), loses to trapper
+ *   (traps neutralize projectile-based space control) and swordfighter
+ *   (disjointed range matches/beats zoning tools).
+ * - rushdown beats trapper (constant pressure denies setup time) and heavy
+ *   (speed exploits poor mobility), loses to zoner and grappler (grabs
+ *   punish committed approaches).
+ * - swordfighter beats zoner (superior disjoint range) and heavy (range keeps
+ *   heavies out), loses to grappler (once inside disjoint range, grabs
+ *   bypass a sword) and rushdown is even (mirror of spacing vs. speed).
+ * - grappler beats rushdown (punishes approach with a single grab) and
+ *   swordfighter (closes the disjoint-range gap), loses to zoner (can't
+ *   close distance) and trapper (traps punish the grappler's approach).
+ * - heavy beats grappler (weight/disjoint hitboxes blunt combo-grab
+ *   pressure) even with trapper (both are patient, positional styles),
+ *   loses to rushdown and swordfighter (range/speed exploit poor mobility).
+ * - trapper beats zoner (traps outlast projectiles) and rushdown (setups
+ *   punish predictable approaches), loses to swordfighter (range invalidates
+ *   traps before they matter) and grappler (a single read closes the gap).
+ * - allRounder is even against everything — no single tool defines the
+ *   matchup enough to call a clean edge either way.
+ */
+const COUNTER_MATRIX: Readonly<Record<Archetype, Readonly<Record<Archetype, number>>>> = {
+  zoner: {
+    zoner: 0,
+    rushdown: 1,
+    swordfighter: -1,
+    grappler: 1,
+    heavy: 0,
+    trapper: -1,
+    allRounder: 0,
+  },
+  rushdown: {
+    zoner: -1,
+    rushdown: 0,
+    swordfighter: 0,
+    grappler: -1,
+    heavy: 1,
+    trapper: 1,
+    allRounder: 0,
+  },
+  swordfighter: {
+    zoner: 1,
+    rushdown: 0,
+    swordfighter: 0,
+    grappler: -1,
+    heavy: 1,
+    trapper: 1,
+    allRounder: 0,
+  },
+  grappler: {
+    zoner: -1,
+    rushdown: 1,
+    swordfighter: 1,
+    grappler: 0,
+    heavy: -1,
+    trapper: -1,
+    allRounder: 0,
+  },
+  heavy: {
+    zoner: 0,
+    rushdown: -1,
+    swordfighter: -1,
+    grappler: 1,
+    heavy: 0,
+    trapper: 0,
+    allRounder: 0,
+  },
+  trapper: {
+    zoner: 1,
+    rushdown: -1,
+    swordfighter: -1,
+    grappler: 1,
+    heavy: 0,
+    trapper: 0,
+    allRounder: 0,
+  },
+  allRounder: {
+    zoner: 0,
+    rushdown: 0,
+    swordfighter: 0,
+    grappler: 0,
+    heavy: 0,
+    trapper: 0,
+    allRounder: 0,
+  },
+};
+
+/**
+ * Best archetype-vs-archetype edge for `mine` against `theirs` — when a
+ * fighter has multiple archetypes, takes the most favorable pairing (a
+ * multi-archetype fighter can lean on whichever tool applies best in a given
+ * matchup). Returns a value in [-1, 1].
+ */
+export function archetypeEdge(mine: Archetype[], theirs: Archetype[]): number {
+  let best = 0;
+  let bestAbs = -1;
+  for (const a of mine) {
+    for (const b of theirs) {
+      const value = COUNTER_MATRIX[a][b];
+      if (Math.abs(value) > bestAbs) {
+        bestAbs = Math.abs(value);
+        best = value;
+      }
+    }
+  }
+  return best;
+}

--- a/packages/shared/src/reports.test.ts
+++ b/packages/shared/src/reports.test.ts
@@ -9,7 +9,14 @@ import { generatedScoutReportSchema, scoutReportRecordSchema } from './reports.j
  * it, so a strict schema here would 500 on old data.
  */
 
-const FULL_REPORT = {
+/**
+ * The RTDB-stripped stored shape (V9-B): everything a full report carries
+ * EXCEPT `headToHead` — RTDB deletes null-valued keys on write, so a record
+ * persisted with `headToHead: null` reads back with the field absent.
+ * `FULL_REPORT` (the generation shape, where the field is required) composes
+ * this base with the explicit null.
+ */
+const RTDB_STRIPPED_REPORT = {
   overview: 'A fast-falling Fox/Falco player who plays aggressively.',
   gameplan: ['Punish landing lag hard.'],
   characterStrategy: {
@@ -21,10 +28,11 @@ const FULL_REPORT = {
     picks: ['Battlefield'],
     reasoning: 'They perform best on flat stages.',
   },
-  headToHead: null,
   watchFor: ['Likes to shine spike off stage.'],
   confidenceNotes: 'Only 20 games sampled — treat character splits as light samples.',
 };
+
+const FULL_REPORT = { ...RTDB_STRIPPED_REPORT, headToHead: null };
 
 const PRE_B1_REPORT = {
   overview: 'A fast-falling Fox/Falco player who plays aggressively.',
@@ -73,5 +81,37 @@ describe('scoutReportRecordSchema back-compat', () => {
     // must not throw and must preserve the absence of characterStrategy.
     const roundTripped = scoutReportRecordSchema.parse(JSON.parse(JSON.stringify(parsed)));
     expect(roundTripped).toEqual(parsed);
+  });
+
+  it('V9-B: parses a stored record whose headToHead was RTDB-stripped (key ABSENT, not null)', () => {
+    // RTDB deletes null-valued keys on write, so a record persisted with
+    // `headToHead: null` comes back with the field missing entirely.
+    // Confirmed against production data — a merely-`.nullable()` stored
+    // schema rejects this shape and corrupts the whole record on read.
+    const record = {
+      id: 'report-2',
+      createdAt: 1_700_000_000_000,
+      model: 'claude-opus-4-8',
+      player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' },
+      report: RTDB_STRIPPED_REPORT,
+    };
+    const parsed = scoutReportRecordSchema.parse(record);
+    expect(parsed.report.headToHead).toBeUndefined();
+  });
+
+  it('V9-B: still parses an explicit headToHead: null (records seeded/written before the null-strip fix, read via a null-preserving path)', () => {
+    const record = {
+      id: 'report-3',
+      createdAt: 1_700_000_000_000,
+      model: 'claude-opus-4-8',
+      player: { id: 1802316, gamerTag: 'Pandem1c' },
+      report: FULL_REPORT, // headToHead: null
+    };
+    expect(scoutReportRecordSchema.safeParse(record).success).toBe(true);
+  });
+
+  it('V9-B: the GENERATION schema still requires headToHead to be emitted (nullable, never absent)', () => {
+    expect(generatedScoutReportSchema.safeParse(RTDB_STRIPPED_REPORT).success).toBe(false);
+    expect(generatedScoutReportSchema.safeParse(FULL_REPORT).success).toBe(true);
   });
 });

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -57,15 +57,32 @@ export const generatedScoutReportSchema = z.object({
 export type GeneratedScoutReport = z.infer<typeof generatedScoutReportSchema>;
 
 /**
- * Stored-record variant of the generated report: identical to
- * `generatedScoutReportSchema` except `characterStrategy` is OPTIONAL, so
- * reports written before V7-B.1 (which lack the field entirely) still parse.
- * New reports always have it (the model is required to produce it — see
- * SYSTEM_PROMPT); this schema exists purely for reading old rows back.
+ * Stored-record variant of the generated report — differs from
+ * `generatedScoutReportSchema` in two absence-tolerances, both required for
+ * reading real RTDB rows back:
+ *
+ * - `characterStrategy` is OPTIONAL: reports written before V7-B.1 lack the
+ *   field entirely. New reports always have it (the model is required to
+ *   produce it — see SYSTEM_PROMPT).
+ * - `headToHead` is NULLISH (nullable AND optional), not just nullable:
+ *   Firebase RTDB deletes null-valued keys on write, so a record persisted
+ *   with `headToHead: null` (no head-to-head history — a common, legitimate
+ *   model output) comes back with the key ABSENT, and a merely-`.nullable()`
+ *   schema rejects it ("expected string, received undefined"), corrupting
+ *   the whole stored record. Confirmed against production data (V9-B).
+ *   The GENERATION schema deliberately stays `.nullable()` — the model must
+ *   still emit the field explicitly; only the stored/read shape tolerates
+ *   RTDB having stripped it. This is the general rule for this schema: any
+ *   `.nullable()` field in a STORED record must be `.nullish()` here
+ *   (`headToHead` is currently the only nullable field in the record shape).
  */
-export const storedScoutReportSchema = generatedScoutReportSchema.partial({
-  characterStrategy: true,
-});
+export const storedScoutReportSchema = generatedScoutReportSchema
+  .partial({
+    characterStrategy: true,
+  })
+  .extend({
+    headToHead: z.string().nullish(),
+  });
 export type StoredScoutReport = z.infer<typeof storedScoutReportSchema>;
 
 /**

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { scoutPlayerIdentitySchema } from './startgg.js';
+import { scoutPlayerIdentitySchema, scoutSourceSchema } from './startgg.js';
 
 /**
  * V7-B: AI-generated pre-bracket scouting reports, powered by the Claude API,
@@ -87,9 +87,14 @@ export const scoutReportRecordSchema = z.object({
 });
 export type ScoutReportRecord = z.infer<typeof scoutReportRecordSchema>;
 
-/** POST /api/reports request body — same input semantics as POST /api/scout. */
+/**
+ * POST /api/reports request body — same input semantics as POST /api/scout,
+ * including the same optional `source` (V9-B Feature 4) for bare-query
+ * disambiguation between start.gg and parry.gg.
+ */
 export const generateReportRequestSchema = z.object({
   query: z.string().min(1),
+  source: scoutSourceSchema.optional(),
 });
 export type GenerateReportRequest = z.infer<typeof generateReportRequestSchema>;
 

--- a/packages/shared/src/startgg.test.ts
+++ b/packages/shared/src/startgg.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isParryggIdentity,
+  isStartggIdentity,
+  scoutIdentityKey,
+  scoutPlayerIdentitySchema,
+  scoutRecentEventSchema,
+  type ScoutPlayerIdentity,
+} from './startgg.js';
+
+describe('scoutPlayerIdentitySchema — V9-B back-compat + parry.gg identity design', () => {
+  it('parses a pre-V9-B stored record: numeric id, no source, no parryUserId', () => {
+    const legacy = { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239' };
+    const parsed = scoutPlayerIdentitySchema.parse(legacy);
+    expect(parsed).toEqual(legacy);
+    expect(isStartggIdentity(parsed)).toBe(true);
+    expect(isParryggIdentity(parsed)).toBe(false);
+  });
+
+  it('parses an explicit source: startgg record the same way', () => {
+    const parsed = scoutPlayerIdentitySchema.parse({
+      id: 1802316,
+      gamerTag: 'Pandem1c',
+      source: 'startgg',
+    });
+    expect(isStartggIdentity(parsed)).toBe(true);
+  });
+
+  it('parses a parrygg identity carrying parryUserId', () => {
+    const parsed = scoutPlayerIdentitySchema.parse({
+      gamerTag: 'Pandem1c',
+      source: 'parrygg',
+      parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+    });
+    expect(isParryggIdentity(parsed)).toBe(true);
+    expect(isStartggIdentity(parsed)).toBe(false);
+  });
+
+  it('rejects a parrygg identity missing parryUserId', () => {
+    expect(() =>
+      scoutPlayerIdentitySchema.parse({ gamerTag: 'Pandem1c', source: 'parrygg' }),
+    ).toThrow();
+  });
+
+  it('rejects a startgg identity (explicit or implicit) missing a numeric id', () => {
+    expect(() => scoutPlayerIdentitySchema.parse({ gamerTag: 'Pandem1c' })).toThrow();
+    expect(() =>
+      scoutPlayerIdentitySchema.parse({ gamerTag: 'Pandem1c', source: 'startgg' }),
+    ).toThrow();
+  });
+});
+
+describe('scoutIdentityKey', () => {
+  it('keys a startgg identity by its numeric id', () => {
+    const identity: ScoutPlayerIdentity = { id: 1802316, gamerTag: 'Pandem1c' };
+    expect(scoutIdentityKey(identity)).toBe('startgg:1802316');
+  });
+
+  it('keys a parrygg identity by its parryUserId, distinct from any startgg id namespace', () => {
+    const identity: ScoutPlayerIdentity = {
+      gamerTag: 'Pandem1c',
+      source: 'parrygg',
+      parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+    };
+    expect(scoutIdentityKey(identity)).toBe('parrygg:019ce9ba-debd-7e11-84a2-77258f52644e');
+  });
+
+  it('never collides a startgg id with a parrygg id that happens to look similar', () => {
+    const startgg: ScoutPlayerIdentity = { id: 42, gamerTag: 'A' };
+    const parrygg: ScoutPlayerIdentity = { gamerTag: 'B', source: 'parrygg', parryUserId: '42' };
+    expect(scoutIdentityKey(startgg)).not.toBe(scoutIdentityKey(parrygg));
+  });
+});
+
+describe('scoutRecentEventSchema — V9-B slug/source back-compat', () => {
+  it('parses a pre-V9-B event with neither slug nor source', () => {
+    const legacy = { eventName: 'Ultimate Singles', lastSetAt: 1_700_000_000_000 };
+    expect(scoutRecentEventSchema.parse(legacy)).toEqual(legacy);
+  });
+
+  it('parses a start.gg event carrying a slug + source', () => {
+    const event = {
+      eventName: 'Ultimate Singles',
+      lastSetAt: 1_700_000_000_000,
+      slug: 'tournament/the-big-house-9/event/ultimate-singles',
+      source: 'startgg' as const,
+    };
+    expect(scoutRecentEventSchema.parse(event)).toEqual(event);
+  });
+});

--- a/packages/shared/src/startgg.ts
+++ b/packages/shared/src/startgg.ts
@@ -115,15 +115,86 @@ export type TournamentEntryList = z.infer<typeof tournamentEntryListSchema>;
 // V7-A: scout any start.gg player (server-aggregated public history)
 // ---------------------------------------------------------------------------
 
-/** The identity start.gg resolved from the caller's query string. */
-export const scoutPlayerIdentitySchema = z.object({
-  /** start.gg player id — the key used for the sets query. */
-  id: z.number().int().positive(),
-  gamerTag: z.string().min(1),
-  /** start.gg profile slug, e.g. "user/07dc2239", when start.gg provides one. */
-  userSlug: z.string().optional(),
-});
+/** Which tournament site a scouting query/identity/event resolves against (V9-B Feature 4). Reused everywhere this app needs the same two-value enum. */
+export const scoutSourceSchema = z.enum(['startgg', 'parrygg']);
+export type ScoutSource = z.infer<typeof scoutSourceSchema>;
+
+/**
+ * The identity resolved from the caller's scouting query — start.gg OR (V9-B
+ * Feature 4) parry.gg. Designed additively so every pre-V9-B stored report
+ * (numeric `id`, no `source`, no `parryUserId`) keeps parsing unchanged:
+ *
+ * - `source` is OPTIONAL; its absence means start.gg (the only source that
+ *   ever existed before V9-B) — every consumer must treat `source ?? 'startgg'`
+ *   as the effective source, never assume the field is present.
+ * - `id` (the start.gg numeric player id) is now OPTIONAL rather than
+ *   required, because a parry.gg identity has no such id at all — but is
+ *   ALWAYS present for `source: 'startgg'` (enforced below via `.refine`,
+ *   not by the field's own optionality, since old records may have `source`
+ *   absent while still trivially satisfying "id present").
+ * - `parryUserId` (parry.gg's UUID v7 user id) is optional and is the
+ *   parry.gg equivalent key: present exactly when `source === 'parrygg'`.
+ *
+ * The `.refine` below is the single place that enforces "exactly one of
+ * (id, parryUserId) is present, matching `source`" — every other consumer
+ * can just read `source ?? 'startgg'` and the matching id field without
+ * re-deriving this invariant.
+ */
+export const scoutPlayerIdentitySchema = z
+  .object({
+    /** start.gg player id — the key used for the sets query. Present iff source is start.gg (or absent, pre-V9-B). */
+    id: z.number().int().positive().optional(),
+    gamerTag: z.string().min(1),
+    /** start.gg profile slug, e.g. "user/07dc2239", when start.gg provides one. */
+    userSlug: z.string().optional(),
+    /** Which site resolved this identity. Absent means start.gg (every identity stored before V9-B). */
+    source: scoutSourceSchema.optional(),
+    /** parry.gg user id (UUID v7) — the key used for the matches query. Present iff source is 'parrygg'. */
+    parryUserId: z.string().min(1).optional(),
+  })
+  .refine((identity) => (identity.source === 'parrygg' ? Boolean(identity.parryUserId) : true), {
+    message: 'parrygg identities must carry parryUserId',
+    path: ['parryUserId'],
+  })
+  .refine((identity) => (identity.source !== 'parrygg' ? identity.id !== undefined : true), {
+    message: 'startgg identities must carry a numeric id',
+    path: ['id'],
+  });
 export type ScoutPlayerIdentity = z.infer<typeof scoutPlayerIdentitySchema>;
+
+/** True when `identity` resolves to a start.gg player (the default when `source` is absent — pre-V9-B convention). */
+export function isStartggIdentity(
+  identity: Pick<ScoutPlayerIdentity, 'source'>,
+): identity is ScoutPlayerIdentity & { source?: 'startgg'; id: number } {
+  return (identity.source ?? 'startgg') === 'startgg';
+}
+
+/** True when `identity` resolves to a parry.gg player. */
+export function isParryggIdentity(
+  identity: Pick<ScoutPlayerIdentity, 'source'>,
+): identity is ScoutPlayerIdentity & { source: 'parrygg'; parryUserId: string } {
+  return identity.source === 'parrygg';
+}
+
+/**
+ * Stable string key for a scouted identity — `"(source ?? 'startgg')" +
+ * ":" + the matching id field`. The single place every consumer (the Scout
+ * page's "is there already a stored report for this player" check, the AI
+ * Reports library's per-player grouping) should use to compare identities,
+ * rather than re-deriving `source ?? 'startgg'` and picking `id` vs.
+ * `parryUserId` themselves. Falls back to a gamerTag-based key in the
+ * (should-be-impossible, schema-enforced-against) case neither id is present,
+ * so this never throws on a malformed record.
+ */
+export function scoutIdentityKey(identity: ScoutPlayerIdentity): string {
+  if (isParryggIdentity(identity)) {
+    return `parrygg:${identity.parryUserId}`;
+  }
+  if (identity.id !== undefined) {
+    return `startgg:${identity.id}`;
+  }
+  return `unknown:${identity.gamerTag}`;
+}
 
 /**
  * One character the scouted player has used, from THEIR perspective (their
@@ -147,7 +218,15 @@ export const scoutStageUsageSchema = z.object({
 });
 export type ScoutStageUsage = z.infer<typeof scoutStageUsageSchema>;
 
-/** One recent event the scouted player competed in (most recent activity first). */
+/**
+ * One recent event the scouted player competed in (most recent activity
+ * first). `slug`/`source` (V9-B Feature 2) are OPTIONAL and additive: reports
+ * stored before this field existed have neither, and every consumer must
+ * tolerate that (no deep link rendered — see `ScoutRecentEventsCard`).
+ * `source` currently only appears when `slug` does (start.gg events only, so
+ * far); parry.gg events are deliberately left plain-text for now — see the
+ * code comment on `ScoutRecentEventsCard`'s render branch for why.
+ */
 export const scoutRecentEventSchema = z.object({
   eventName: z.string().min(1),
   tournamentName: z.string().optional(),
@@ -155,6 +234,16 @@ export const scoutRecentEventSchema = z.object({
   numEntrants: z.number().int().positive().optional(),
   /** Epoch ms of the most recent completed set sampled for this event. */
   lastSetAt: z.number().int().nonnegative(),
+  /**
+   * Site-specific event identifier used to build a deep link, e.g. a
+   * start.gg event slug ("tournament/the-big-house-9/event/ultimate-singles")
+   * or (in principle) a parry.gg tournament/event slug pair joined the same
+   * way. Absent for events sampled before V9-B, or when the source site
+   * doesn't provide one.
+   */
+  slug: z.string().optional(),
+  /** Which site `slug` resolves against; absent means start.gg (pre-V9-B convention — every event with a slug was start.gg-sourced). */
+  source: scoutSourceSchema.optional(),
 });
 export type ScoutRecentEvent = z.infer<typeof scoutRecentEventSchema>;
 
@@ -190,8 +279,15 @@ export const scoutReportDataSchema = z.object({
 });
 export type ScoutReportData = z.infer<typeof scoutReportDataSchema>;
 
-/** POST /api/scout request body — a start.gg profile URL, bare slug, or numeric player id. */
+/**
+ * POST /api/scout request body — a profile URL, bare slug/tag, or numeric
+ * player id. `source` (V9-B Feature 4) picks which site resolves a BARE
+ * (non-URL) query; it defaults to `'startgg'` for back-compat with pre-V9-B
+ * clients that never sent it. A pasted URL always auto-detects its own site
+ * (start.gg vs. parry.gg) and overrides `source` — see `parseScoutInput`.
+ */
 export const scoutQuerySchema = z.object({
   query: z.string().min(1),
+  source: scoutSourceSchema.optional(),
 });
 export type ScoutQuery = z.infer<typeof scoutQuerySchema>;


### PR DESCRIPTION
## Summary

Four upgrades to the scouting + AI-reports surface, built on top of V9's profile page:

- **AI Reports library** (`/reports`, new nav item): every stored AI scouting report grouped by scouted player (source-aware — a start.gg id and a parry.gg id never collide), newest report first within a group, groups ordered by most recent. Click a row to expand the full report inline (reuses `ScoutAiReportCard`). Friendly "not enabled" note when AI reports are off for the account; ordinary empty state when enabled but nothing generated yet.
  - Scout page: a compact prev/next history selector ("Report N of total · date") appears above the AI report card when the scouted player has multiple stored reports.
- **Recent events deep-link to their source**: the start.gg sets query now selects `event { slug }`; the scout accumulator captures it and emits `slug`/`source` on each recent event (both optional, back-compat safe). The web card renders start.gg events as external links (`https://www.start.gg/{slug}`); parry.gg events stay plain text — no verified parry.gg **event** page URL exists yet (only the profile URL was confirmed live), with a code comment explaining why.
- **Character Matchup Advisor** (zero added AI cost): a new static SSBU meta dataset (`packages/shared/src/meta.ts`, tier scores + archetypes for all 85 roster entries, sourced from a July 2026 community tier list derived from UltRank's May 2026 rankings — see the module doc for the citation) and a deterministic blending function (`packages/shared/src/matchupAdvisor.ts`) that ranks the user's own characters against each opponent character, confidence-weighting the user's real W/L record against the tier/archetype prior as sample size grows. Rendered on the scout page (`ScoutMatchupAdvisorCard`, between the AI-report area and Character Usage) and computed server-side into the AI report payload (`userContext.matchupAdvisor`), with the system prompt updated to ground `characterStrategy` in it.
- **parry.gg scouting**: scout any parry.gg player by profile URL (`https://parry.gg/profile/{uuid-v7}`, verified live) or gamer tag, alongside start.gg, via a compact source toggle that auto-detects/overrides on a pasted parry.gg URL. `POST /api/scout` and `POST /api/reports` both gain an optional `source` field (default `startgg`, fully back-compat). New `apps/api/src/parrygg/scout.ts` aggregates parry.gg match history into the same `ScoutReportData` shape, reusing V8-A's character/stage mapping and sync helpers.

### Identity back-compat design

`scoutPlayerIdentitySchema` is extended additively: `id` becomes optional (still required for start.gg via `.refine`), plus optional `source` (absent = start.gg) and `parryUserId` (required for parry.gg via `.refine`). A new `scoutIdentityKey()` helper is the single place that derives a collision-free key (`startgg:{id}` / `parrygg:{parryUserId}`), used by both the Scout page's "is there a stored report for this player" check and the Reports library's grouping. Every pre-V9-B stored record (numeric `id`, no `source`) round-trips unchanged — covered by dedicated back-compat tests in `packages/shared/src/startgg.test.ts`.

### Deviations / notes

- parry.gg **event** deep links are intentionally NOT rendered even though a tournament+event slug pair is captured server-side (`{tournamentSlug}/{eventSlug}`, confirmed via a live parry.gg tournament page) — only the **profile** URL shape was empirically verified as a stable, documented pattern. The slug is stored so enabling the link later is a web-only change.
- Both `apps/api/src/app.ts` route registrations were updated to pass through the already-existing `options.parrygg`/`options.parryggClients` — no NEW option was added to `buildApp`, so `index.ts` needed no changes (it already forwards `parrygg` in production).
- No new dependencies were added, so the Dockerfile needed no changes.

## Test plan
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm typecheck` — clean across all 3 packages
- [x] `pnpm test` — 1260 tests passing (93 shared + 380 api + 787 web), including new coverage for the meta/matchupAdvisor blend, parry.gg scout aggregation, source-aware routing, identity back-compat, and every new web component
- [x] `pnpm build` — succeeds
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)