### PR TITLE
Wire up Firebase Analytics (lost in the CRA rewrite)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -13,6 +13,12 @@ VITE_FIREBASE_AUTH_DOMAIN=your-project.web.app
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
 
+# GA4 measurement id from `firebase apps:sdkconfig web` (G-XXXX). Optional —
+# leave unset in local dev so dev sessions never pollute production
+# analytics; set it in apps/web/.env.production to enable Firebase
+# Analytics (realtime users, page views).
+# VITE_FIREBASE_MEASUREMENT_ID=
+
 # Base URL of the Fastify API (apps/api). Defaults to the local dev server
 # when unset.
 #

--- a/apps/web/src/layouts/MainLayout.tsx
+++ b/apps/web/src/layouts/MainLayout.tsx
@@ -1,5 +1,7 @@
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
+import { useLocation } from 'react-router';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { logAnalyticsPageView } from '@/lib/firebase';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 import { Footer } from './Footer';
@@ -13,6 +15,13 @@ import { Footer } from './Footer';
  * page's stage-chip and Advisor Retrospective tooltips).
  */
 export function MainLayout({ children }: { children: ReactNode }) {
+  // GA4 only auto-collects the initial page load; SPA navigations are
+  // reported here. No-ops entirely when analytics isn't configured.
+  const location = useLocation();
+  useEffect(() => {
+    logAnalyticsPageView(location.pathname);
+  }, [location.pathname]);
+
   return (
     <TooltipProvider>
       <div className="flex min-h-svh flex-col">

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -18,6 +18,12 @@ const firebaseConfigSchema = z.object({
   authDomain: z.string().min(1, 'VITE_FIREBASE_AUTH_DOMAIN is required'),
   projectId: z.string().min(1, 'VITE_FIREBASE_PROJECT_ID is required'),
   appId: z.string().min(1, 'VITE_FIREBASE_APP_ID is required'),
+  /**
+   * GA4 measurement id (G-XXXX). Optional: analytics is skipped entirely
+   * when unset (local dev, tests), so unit tests never load
+   * firebase/analytics and dev sessions don't pollute production stats.
+   */
+  measurementId: z.string().optional(),
 });
 
 export type FirebaseConfig = z.infer<typeof firebaseConfigSchema>;
@@ -28,6 +34,7 @@ function readFirebaseConfig(): FirebaseConfig {
     authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
     projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
     appId: import.meta.env.VITE_FIREBASE_APP_ID,
+    measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || undefined,
   });
 
   if (!result.success) {
@@ -56,4 +63,51 @@ export function getFirebaseAuth(): Auth {
 
 export function createGoogleAuthProvider(): GoogleAuthProvider {
   return new GoogleAuthProvider();
+}
+
+// ---------------------------------------------------------------------------
+// Analytics (GA4 via Firebase). The legacy CRA app reported analytics; the
+// rewrite shipped without them, so the Firebase console showed 0 active
+// users despite real traffic. Everything here is lazy + optional:
+// firebase/analytics is dynamically imported only when a measurementId is
+// configured AND the browser supports it (isSupported() is false in jsdom,
+// some privacy modes, and non-browser contexts), so tests and dev builds
+// never touch it.
+
+type AnalyticsContext = {
+  analytics: import('firebase/analytics').Analytics;
+  mod: typeof import('firebase/analytics');
+};
+
+let analyticsInit: Promise<AnalyticsContext | null> | null = null;
+
+function initAnalytics(): Promise<AnalyticsContext | null> {
+  analyticsInit ??= (async () => {
+    const config = readFirebaseConfig();
+    if (!config.measurementId) {
+      return null;
+    }
+    const mod = await import('firebase/analytics');
+    if (!(await mod.isSupported().catch(() => false))) {
+      return null;
+    }
+    return { analytics: mod.getAnalytics(getFirebaseApp()), mod };
+  })().catch(() => null);
+  return analyticsInit;
+}
+
+/**
+ * Records an SPA page view (GA4 auto-collects only the initial load; router
+ * navigations must be logged manually). Fire-and-forget and never throws —
+ * analytics must never break the app. No-op without a measurementId.
+ */
+export function logAnalyticsPageView(pagePath: string): void {
+  void initAnalytics().then((ctx) => {
+    if (ctx) {
+      ctx.mod.logEvent(ctx.analytics, 'page_view', {
+        page_path: pagePath,
+        page_location: window.location.href,
+      });
+    }
+  });
 }

--- a/apps/web/src/test/mockAuth.ts
+++ b/apps/web/src/test/mockAuth.ts
@@ -113,5 +113,6 @@ export function firebaseLibMock() {
     getFirebaseAuth: vi.fn(() => mockAuthInstance),
     getFirebaseApp: vi.fn(() => ({})),
     createGoogleAuthProvider: vi.fn(() => new GoogleAuthProvider()),
+    logAnalyticsPageView: vi.fn(),
   };
 }


### PR DESCRIPTION
Realtime user activity showed 0 despite live traffic because the modernized app never initialized Firebase Analytics — the legacy CRA app had it, the rewrite didn't carry it over.

- Optional `VITE_FIREBASE_MEASUREMENT_ID` in the web config schema (set in `.env.production` only — dev/test sessions never send events)
- Lazy `firebase/analytics` (dynamic import + `isSupported()` guard, fire-and-forget, can never break the app)
- SPA `page_view` on route changes via MainLayout (GA4 only auto-collects the initial load)

781 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)