### PR TITLE
Fix Donate button visibility + AI Reports accordion collapse

### DIFF
--- a/apps/web/src/layouts/Sidebar.tsx
+++ b/apps/web/src/layouts/Sidebar.tsx
@@ -1,10 +1,20 @@
 import { SidebarContent } from './SidebarContent';
 
-/** Persistent desktop sidebar. Hidden below the `lg` breakpoint (mobile uses the Sheet drawer in Topbar instead). */
+/**
+ * Persistent desktop sidebar. Hidden below the `lg` breakpoint (mobile uses
+ * the Sheet drawer in Topbar instead).
+ *
+ * The sticky container sits BELOW the sticky Topbar (h-14), so its height
+ * must be `100svh - 3.5rem` anchored at `top-14` — a plain `top-0 h-svh`
+ * here extends one topbar-height past the viewport bottom, permanently
+ * hiding the last footer item (the Donate button). `overflow-hidden` keeps
+ * the nav (which has its own overflow-y-auto) as the only scroll region so
+ * the profile block and footer stay pinned.
+ */
 export function Sidebar() {
   return (
     <aside className="hidden w-64 shrink-0 border-r bg-card lg:block">
-      <div className="sticky top-0 h-svh overflow-y-auto">
+      <div className="sticky top-14 h-[calc(100svh-3.5rem)] overflow-hidden">
         <SidebarContent />
       </div>
     </aside>

--- a/apps/web/src/pages/Reports/ReportsPage.test.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.test.tsx
@@ -176,4 +176,25 @@ describe('ReportsPage', () => {
     expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
     expect(screen.getAllByText('The overview text').length).toBeGreaterThan(0);
   });
+
+  it('clicking an open report again collapses it (accordion)', async () => {
+    const user = userEvent.setup();
+    reportsConfig.mockResolvedValue({ enabled: true });
+    reportsList.mockResolvedValue([
+      {
+        id: 'r1',
+        createdAt: 1_700_000_000_000,
+        model: 'claude-opus-4-8',
+        player: { id: 1802316, gamerTag: 'Pandem1c' },
+        report: { ...REPORT_SHAPE, overview: 'The overview text' },
+      },
+    ]);
+
+    renderPage();
+    await user.click(await screen.findByText('Pandem1c'));
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Pandem1c'));
+    expect(screen.queryByText('AI Scouting Report')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Reports/ReportsPage.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.tsx
@@ -179,7 +179,11 @@ export function ReportsPage() {
                     key={group.key}
                     group={group}
                     selectedId={selectedId}
-                    onSelect={(record) => setSelectedId(record.id)}
+                    // Accordion semantics: clicking an already-open report
+                    // collapses it instead of being a no-op.
+                    onSelect={(record) =>
+                      setSelectedId((prev) => (prev === record.id ? null : record.id))
+                    }
                   />
                 ))}
               </CardContent>


### PR DESCRIPTION
Two user-reported UI issues:

**Donate button invisible** — the sidebar's sticky container was `top-0 h-svh` but sits below the sticky `h-14` Topbar, so its bottom 56px (exactly the Donate button) hung permanently below the viewport on every browser. Now `top-14 h-[calc(100svh-3.5rem)] overflow-hidden`, keeping V9-C's scrollable-nav/pinned-footer structure actually within the viewport.

**AI Reports accordion** — clicking an already-open report now collapses it (was a no-op). Test added.

807 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)