### PR TITLE
V9-D: Full analysis for scouted players

### DIFF
--- a/apps/api/src/parrygg/scout.test.ts
+++ b/apps/api/src/parrygg/scout.test.ts
@@ -19,6 +19,7 @@ import {
   User,
 } from '@parry-gg/client';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb.js';
+import type { ScoutGame } from '@smash-tracker/shared';
 import { PARRYGG_SSBU_SLUG } from './sync.js';
 import type { ParryggClients, ParryggMatchContext, ParryggUserSummary } from './client.js';
 import {
@@ -310,6 +311,7 @@ describe('accumulateParryMatchContext', () => {
         }
       >(),
       opponents: new Map<string, number>(),
+      games: [] as ScoutGame[],
     };
   }
 
@@ -334,6 +336,29 @@ describe('accumulateParryMatchContext', () => {
       eventName: 'Ultimate Singles',
       tournamentName: 'Test Weekly 42',
     });
+    // V9-D: per-game record, from the scouted player's own perspective.
+    expect(acc.games).toHaveLength(1);
+    expect(acc.games[0]).toMatchObject({
+      win: true,
+      fighterId: 1, // Mario
+      opponentFighterId: 41, // Sonic
+      stageName: 'Battlefield',
+      opponentTag: 'PowPow',
+      eventName: 'Ultimate Singles',
+    });
+  });
+
+  it('skips emitting a game record when the scouted player’s own character is unmapped', () => {
+    const acc = emptyAcc();
+    const game = new MatchGame();
+    game.setStagesList([makeStage('battlefield')]);
+    game.setSlotsList([
+      makeGameSlot(0, MY_USER_ID, 'totally-unknown-character', 1),
+      makeGameSlot(1, OPPONENT_USER_ID, 'sonic', 2),
+    ]);
+    accumulateParryMatchContext(acc, makeMatchContext({ matchGames: [game] }), MY_USER_ID);
+    expect(acc.characters.get(0)).toEqual({ games: 1, wins: 1 });
+    expect(acc.games).toHaveLength(0);
   });
 
   it('skips matches that are not completed', () => {
@@ -376,6 +401,10 @@ describe('accumulateParryMatchContext', () => {
     expect(acc.stages.size).toBe(0);
     // Event/opponent are still recorded even with no game detail.
     expect(acc.opponents.get('PowPow')).toBe(1);
+    // V9-D: a set synthesized from scores alone (no matchGamesList) carries
+    // no character/stage attribution, so it contributes no `games` rows
+    // either — emitting one would pollute the client stats engine.
+    expect(acc.games).toHaveLength(0);
   });
 
   it('groups unmapped characters under fighterId 0', () => {
@@ -488,6 +517,14 @@ describe('buildParryScoutReport / scoutParryPlayer', () => {
     });
     expect(report.sampledSets).toBe(1);
     expect(report.characters[0]).toMatchObject({ fighterId: 1, games: 1, wins: 1 });
+    // V9-D: per-game record present when matchGames carries character detail.
+    expect(report.games).toHaveLength(1);
+    expect(report.games?.[0]).toMatchObject({
+      win: true,
+      fighterId: 1,
+      opponentFighterId: 41,
+      stageName: 'Battlefield',
+    });
   });
 
   it('tolerates empty matchGames everywhere (no character/stage rows, still events + opponents)', async () => {
@@ -497,6 +534,9 @@ describe('buildParryScoutReport / scoutParryPlayer', () => {
     expect(report.stages).toEqual([]);
     expect(report.recentEvents.length).toBeGreaterThan(0);
     expect(report.commonOpponents.length).toBeGreaterThan(0);
+    // V9-D: no game detail means `games` is omitted entirely (back-compat
+    // shape), not an empty array.
+    expect(report.games).toBeUndefined();
   });
 
   it('scoutParryPlayer resolves + builds + caches by parryUserId', async () => {

--- a/apps/api/src/parrygg/scout.ts
+++ b/apps/api/src/parrygg/scout.ts
@@ -1,5 +1,5 @@
 import { MatchState } from '@parry-gg/client';
-import type { ScoutReportData } from '@smash-tracker/shared';
+import type { ScoutGame, ScoutReportData } from '@smash-tracker/shared';
 import {
   getUser,
   getUserMatches,
@@ -139,6 +139,8 @@ interface Accumulators {
     }
   >;
   opponents: Map<string, number>;
+  /** V9-D: per-game records for the web "Full analysis" section — see `scoutGameSchema`. Only ever populated from real `matchGamesList` detail — see the doc on the `games.length === 0` branch below for why synthesized-from-score sets never contribute here. */
+  games: ScoutGame[];
 }
 
 function emptyAccumulators(): Accumulators {
@@ -149,6 +151,7 @@ function emptyAccumulators(): Accumulators {
     stages: new Map(),
     events: new Map(),
     opponents: new Map(),
+    games: [],
   };
 }
 
@@ -255,10 +258,14 @@ export function accumulateParryMatchContext(
   }
 
   const games = match.matchGamesList;
-  // Only "mine" is needed here — unlike sync.ts, the scout accumulator only
-  // ever tracks the scouted player's OWN character/stage picks (their own
-  // perspective), never the opponent's, so there's no opponent slot lookup.
+  // "mine" drives character/stage aggregation (the scout accumulator only
+  // ever tracks the scouted player's OWN picks, their own perspective).
+  // "opponent" is ALSO looked up (V9-D), same shared-slot-number matching
+  // `sync.ts`'s `gamesFromMatchContext` uses, purely to populate each
+  // per-game record's `opponentFighterId` for the client stats engine — it
+  // does not otherwise change what this function aggregates.
   const mySlotEntry = slots.find((s) => s.seedId === mine.id);
+  const opponentSlotEntry = slots.find((s) => s.seedId === opponent.id);
 
   if (games.length === 0) {
     // No per-game detail — same "sparse young data" tolerance as sync.ts:
@@ -286,6 +293,40 @@ export function accumulateParryMatchContext(
     const stageSlug = game.stagesList[0]?.slug;
     const resolvedStage = resolveParryggStage(stageSlug);
     bump(acc.stages, resolvedStage?.id ?? UNKNOWN_STAGE_ID, won);
+
+    // V9-D: per-game record for the web "Full analysis" section. Skipped
+    // entirely when MY character can't be mapped (mirrors start.gg scout's
+    // rule — see scoutGameSchema's doc); the opponent's character falls back
+    // to the fighterId-0 sentinel like `characters` above, since it isn't
+    // the subject of the scouted player's own stats.
+    if (opponentTag && fighterId !== UNMAPPED_FIGHTER_ID) {
+      const opponentGameSlot =
+        opponentSlotEntry != null
+          ? game.slotsList.find((s) => s.slot === opponentSlotEntry.slot)
+          : undefined;
+      const opponentParticipant =
+        opponentGameSlot?.participantsList.find((p) => p.userId === opponentUser?.id) ??
+        opponentGameSlot?.participantsList[0];
+      const opponentCharacterSlug = opponentParticipant?.charactersList[0]?.slug;
+      const opponentFighterId =
+        parryggCharacterSlugToFighterId(opponentCharacterSlug) ?? UNMAPPED_FIGHTER_ID;
+
+      const endedAtSeconds = match.endedAt?.seconds ?? match.stateUpdatedAt?.seconds;
+      const time =
+        typeof endedAtSeconds === 'number'
+          ? endedAtSeconds * 1000
+          : (context.eventStartDate?.seconds ?? 0) * 1000;
+
+      acc.games.push({
+        time,
+        win: won,
+        fighterId,
+        opponentFighterId,
+        ...(resolvedStage ? { stageId: resolvedStage.id, stageName: resolvedStage.name } : {}),
+        opponentTag,
+        ...(eventName ? { eventName } : {}),
+      });
+    }
   });
 }
 
@@ -338,6 +379,7 @@ function toReport(acc: Accumulators, player: ResolvedParryScoutPlayer): ScoutRep
     stages,
     recentEvents,
     commonOpponents,
+    ...(acc.games.length > 0 ? { games: acc.games } : {}),
   };
 }
 

--- a/apps/api/src/reports/generate.test.ts
+++ b/apps/api/src/reports/generate.test.ts
@@ -32,7 +32,10 @@ describe('assembleReportPayload', () => {
       database as unknown as Parameters<typeof assembleReportPayload>[2],
     );
 
-    expect(payload.scout).toBe(SCOUT);
+    // Not `.toBe` (reference equality): `assembleReportPayload` rebuilds
+    // `scout` into a new object that strips `games` (V9-D) before it reaches
+    // Claude — see the doc comment on `ReportPayload.scout`.
+    expect(payload.scout).toEqual(SCOUT);
     expect(payload.headToHead).toEqual([]);
     expect(payload.userContext.vsTopCharacters).toEqual([
       { opponentCharacter: 'Fox', wins: 0, losses: 0, topStages: [] },
@@ -42,6 +45,33 @@ describe('assembleReportPayload', () => {
     expect(payload.notes).toBeNull();
     expect(payload.userContext.myFighters).toEqual({ primary: [], secondary: [] });
     expect(payload.userContext.myCharacterRecords).toEqual([]);
+  });
+
+  it('strips `games` (V9-D) from the scout payload sent to Claude, keeping every other field', async () => {
+    const scoutWithGames: ScoutReportData = {
+      ...SCOUT,
+      games: [
+        {
+          time: 1_700_000_000_000,
+          win: true,
+          fighterId: 8,
+          opponentFighterId: 22,
+          stageId: 1,
+          stageName: 'Battlefield',
+          opponentTag: 'PowPow',
+          eventName: 'Ultimate Singles',
+        },
+      ],
+    };
+    const database = new FakeDatabase();
+    const payload = await assembleReportPayload(
+      UID,
+      scoutWithGames,
+      database as unknown as Parameters<typeof assembleReportPayload>[2],
+    );
+
+    expect(payload.scout).not.toHaveProperty('games');
+    expect(payload.scout).toEqual(SCOUT);
   });
 
   it('maps myFighters sprite ids to character names', async () => {

--- a/apps/api/src/reports/generate.ts
+++ b/apps/api/src/reports/generate.ts
@@ -59,8 +59,16 @@ export interface CharacterRecord {
   vsOpponentCharacter: Array<{ opponentCharacter: string; wins: number; losses: number }>;
 }
 
+/**
+ * `scout` MUST NOT carry `games` (V9-D's per-game records, added for the
+ * web "Full analysis" section) — the payload's own `headToHead`,
+ * `vsTopCharacters`, and `matchupAdvisor` already summarize everything a
+ * per-game list would add for Claude, so including it here would only
+ * inflate token cost for zero grounding benefit. `assembleReportPayload`
+ * strips it unconditionally, even when the incoming `scout` has it.
+ */
 export interface ReportPayload {
-  scout: ScoutReportData;
+  scout: Omit<ScoutReportData, 'games'>;
   headToHead: HeadToHeadMatch[];
   userContext: {
     /** The signed-in user's own primary/secondary character selections (fighter names, not ids). */
@@ -306,8 +314,20 @@ export async function assembleReportPayload(
     })),
   }));
 
+  // Strip `games` (V9-D) before handing the scout data to Claude — see the
+  // doc comment on `ReportPayload.scout`.
+  const scoutForPayload: Omit<ScoutReportData, 'games'> = {
+    player: scout.player,
+    sampledSets: scout.sampledSets,
+    sampledGames: scout.sampledGames,
+    characters: scout.characters,
+    stages: scout.stages,
+    recentEvents: scout.recentEvents,
+    commonOpponents: scout.commonOpponents,
+  };
+
   return {
-    scout,
+    scout: scoutForPayload,
     headToHead,
     userContext: {
       myFighters,

--- a/apps/api/src/startgg/scout.test.ts
+++ b/apps/api/src/startgg/scout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { ScoutGame } from '@smash-tracker/shared';
 import type { StartggSet } from './client.js';
 import {
   accumulateScoutSet,
@@ -238,6 +239,7 @@ describe('accumulateScoutSet', () => {
         }
       >(),
       opponents: new Map<string, number>(),
+      games: [] as ScoutGame[],
     };
   }
 
@@ -260,6 +262,52 @@ describe('accumulateScoutSet', () => {
       numEntrants: 512,
       slug: 'tournament/test-weekly-42/event/ultimate-singles',
     });
+  });
+
+  it('emits a V9-D per-game record for each sampled game, from the scouted player perspective', () => {
+    const acc = emptyAcc();
+    accumulateScoutSet(acc, makeSet(), PLAYER_ID);
+
+    expect(acc.games).toHaveLength(2);
+    expect(acc.games[0]).toEqual({
+      time: 1_700_000_000_000,
+      win: true,
+      fighterId: 67, // Bayonetta
+      opponentFighterId: 41, // Sonic
+      stageId: expect.any(Number),
+      stageName: 'Battlefield',
+      opponentTag: 'PowPow',
+      eventName: 'Ultimate Singles',
+    });
+    expect(acc.games[1]).toMatchObject({
+      win: false,
+      fighterId: 67,
+      opponentFighterId: 41,
+      stageName: 'Pokémon Stadium 2',
+      opponentTag: 'PowPow',
+    });
+  });
+
+  it('skips emitting a game record when the scouted player’s own character is unmapped', () => {
+    const acc = emptyAcc();
+    const set = makeSet({
+      games: [
+        {
+          winnerId: 1,
+          stage: { name: 'Battlefield' },
+          selections: [
+            { character: { id: 1746 }, entrant: { id: 1 } }, // Random Character (unmapped)
+            { character: { id: 1332 }, entrant: { id: 2 } },
+          ],
+        },
+      ],
+    });
+    accumulateScoutSet(acc, set, PLAYER_ID);
+    // The aggregate still counts it under fighterId 0...
+    expect(acc.characters.get(0)).toEqual({ games: 1, wins: 1 });
+    // ...but no per-game record is emitted for it (V9-D: would pollute
+    // per-character client stats with an unattributable game).
+    expect(acc.games).toHaveLength(0);
   });
 
   it('tolerates a set whose event has no slug (back-compat: older start.gg responses / any nullish slug)', () => {
@@ -407,6 +455,36 @@ describe('buildScoutReport', () => {
       slug: 'tournament/test-weekly-42/event/ultimate-singles',
       source: 'startgg',
     });
+    // V9-D: per-game records fold across every paginated set.
+    expect(report.games).toHaveLength(4);
+  });
+
+  it('omits `games` entirely (not an empty array) when no game record could be attributed (V9-D back-compat shape)', async () => {
+    const fetchMock = (async () =>
+      gqlResponse({
+        player: {
+          sets: {
+            pageInfo: { totalPages: 1 },
+            nodes: [
+              makeSet({
+                games: [
+                  {
+                    winnerId: 1,
+                    stage: { name: 'Battlefield' },
+                    selections: [
+                      { character: { id: 1746 }, entrant: { id: 1 } }, // unmapped
+                      { character: { id: 1332 }, entrant: { id: 2 } },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          },
+        },
+      })) as typeof fetch;
+
+    const report = await buildScoutReport('server-token', player, fetchMock);
+    expect(report.games).toBeUndefined();
   });
 
   it('caps pagination at 15 pages even when start.gg reports more', async () => {

--- a/apps/api/src/startgg/scout.ts
+++ b/apps/api/src/startgg/scout.ts
@@ -1,4 +1,4 @@
-import type { ScoutReportData } from '@smash-tracker/shared';
+import type { ScoutGame, ScoutReportData } from '@smash-tracker/shared';
 import {
   fetchPlayerSetsPage,
   resolvePlayerById,
@@ -126,6 +126,8 @@ interface Accumulators {
     }
   >;
   opponents: Map<string, number>;
+  /** V9-D: per-game records for the web "Full analysis" section — see `scoutGameSchema`. */
+  games: ScoutGame[];
 }
 
 function emptyAccumulators(): Accumulators {
@@ -136,6 +138,7 @@ function emptyAccumulators(): Accumulators {
     stages: new Map(),
     events: new Map(),
     opponents: new Map(),
+    games: [],
   };
 }
 
@@ -180,16 +183,14 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
   // Common opponents: one tally per set (not per game), keyed the same way
   // sync.ts derives opponent tags, so scouting stays consistent with how the
   // rest of the app names people.
-  if (opponentEntrant) {
-    const opponentName = opponentEntrant.name?.trim();
-    if (opponentName) {
-      const tag = opponentName.includes('|')
-        ? (opponentName.split('|').pop() ?? opponentName).trim()
-        : opponentName;
-      if (tag) {
-        acc.opponents.set(tag, (acc.opponents.get(tag) ?? 0) + 1);
-      }
-    }
+  const opponentName = opponentEntrant?.name?.trim();
+  const opponentTag = opponentName
+    ? opponentName.includes('|')
+      ? (opponentName.split('|').pop() ?? opponentName).trim()
+      : opponentName
+    : undefined;
+  if (opponentTag) {
+    acc.opponents.set(opponentTag, (acc.opponents.get(opponentTag) ?? 0) + 1);
   }
 
   // Recent events: keep the freshest facts per event id (numEntrants/placement
@@ -235,6 +236,9 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
   games.forEach((game) => {
     const selections = game.selections ?? [];
     const playerSelection = selections.find((s) => s.entrant?.id === playerEntrant.id);
+    const opponentSelection = opponentEntrant
+      ? selections.find((s) => s.entrant?.id === opponentEntrant.id)
+      : undefined;
     const won = game.winnerId === playerEntrant.id;
 
     acc.sampledGames += 1;
@@ -258,6 +262,31 @@ export function accumulateScoutSet(acc: Accumulators, set: StartggSet, playerId:
       game.stage?.name,
     );
     bump(acc.stages, resolvedStage?.id ?? UNKNOWN_STAGE_ID, won);
+
+    // V9-D: per-game record for the web "Full analysis" section. Games whose
+    // OWN character can't be mapped are skipped entirely (mirroring the
+    // per-character usage-aggregation rule above, but as an omission rather
+    // than a fighterId-0 row — see scoutGameSchema's doc) — an unmapped-
+    // character game has nothing meaningful to attribute a per-character
+    // stat to on the client. The opponent's character, by contrast, still
+    // uses the fighterId-0 sentinel (matching `characters` above) since it
+    // isn't the subject of the scouted player's own stats.
+    if (opponentTag && fighterId !== UNMAPPED_FIGHTER_ID) {
+      const opponentCharacterId = opponentSelection?.character?.id;
+      const opponentFighterId =
+        opponentCharacterId != null
+          ? (startggCharacterToFighterId.get(opponentCharacterId) ?? UNMAPPED_FIGHTER_ID)
+          : UNMAPPED_FIGHTER_ID;
+      acc.games.push({
+        time: completedAt * 1000,
+        win: won,
+        fighterId,
+        opponentFighterId,
+        ...(resolvedStage ? { stageId: resolvedStage.id, stageName: resolvedStage.name } : {}),
+        opponentTag,
+        ...(eventName ? { eventName } : {}),
+      });
+    }
   });
 }
 
@@ -299,6 +328,7 @@ function toReport(acc: Accumulators, player: ResolvedScoutPlayer): ScoutReportDa
     stages,
     recentEvents,
     commonOpponents,
+    ...(acc.games.length > 0 ? { games: acc.games } : {}),
   };
 }
 

--- a/apps/web/src/pages/FighterAnalysis/components/StageMastery.tsx
+++ b/apps/web/src/pages/FighterAnalysis/components/StageMastery.tsx
@@ -18,15 +18,26 @@ const TINT_CLASSES: Record<MasteryTintBucket, string> = {
  * Wilson bucket. A "Best pick / Ban-worthy" caption row up top calls out the
  * standout stages (folds in the retired BestWorstMap card per
  * docs/analytics-vision.md V4 Phase E).
+ *
+ * `title` defaults to "Stage Mastery" (its original framing here); pass a
+ * more specific title to reuse this same tile grid for a different subject,
+ * e.g. the Scout page's "Full analysis" section rendering it once for a
+ * scouted player's whole sample and again for just their top character.
  */
-export function StageMastery({ fighterMatches }: { fighterMatches: Match[] }) {
+export function StageMastery({
+  fighterMatches,
+  title = 'Stage Mastery',
+}: {
+  fighterMatches: Match[];
+  title?: string;
+}) {
   const tiles = buildStageMasteryTiles(fighterMatches);
   const { bestPick, banWorthy } = buildStageMasteryCaption(fighterMatches);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Stage Mastery</CardTitle>
+        <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {(bestPick || banWorthy) && (

--- a/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
@@ -18,14 +18,26 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip,
 
 const ROLLING_WINDOW = 5;
 
-/** Rolling (trailing-5) win-rate trend across all matches vs this opponent. */
-export function ScoutingTrendChart({ matches }: { matches: Match[] }) {
+/**
+ * Rolling (trailing-5) win-rate trend across the given matches. Defaults to
+ * "H2H Trend" (its original head-to-head-vs-one-opponent framing on the
+ * Opponent Detail page); pass `title` to reuse it for a different framing,
+ * e.g. the Scout page's "Full analysis" section, where `matches` is a
+ * scouted player's OWN game history rather than a head-to-head slice.
+ */
+export function ScoutingTrendChart({
+  matches,
+  title = 'H2H Trend',
+}: {
+  matches: Match[];
+  title?: string;
+}) {
   const series = getRollingWinRate(matches, ROLLING_WINDOW);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>H2H Trend</CardTitle>
+        <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent>
         {series.length === 0 ? (

--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -216,6 +216,46 @@ describe('ScoutPage', () => {
     await screen.findByText('Pandem1c');
     expect(screen.queryByText('Your History vs Them')).not.toBeInTheDocument();
   });
+
+  it('shows the "re-scout" full-analysis empty state for a report with no `games` (pre-V9-D)', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    await screen.findByText('Pandem1c');
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+    expect(screen.getByText('Re-scout to enable full analysis.')).toBeInTheDocument();
+  });
+
+  it('renders the Full analysis section once expanded, for a report carrying V9-D `games`', async () => {
+    const user = userEvent.setup();
+    scoutLookup.mockResolvedValue({
+      ...REPORT,
+      games: [
+        {
+          time: 1_700_000_000_000,
+          win: true,
+          fighterId: 67,
+          opponentFighterId: 41,
+          stageId: 1,
+          stageName: 'Battlefield',
+          opponentTag: 'PowPow',
+          eventName: 'Ultimate Singles',
+        },
+      ],
+    });
+
+    renderPage();
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    await screen.findByText('Pandem1c');
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+    expect(screen.getByText('Stage Mastery — Overall')).toBeInTheDocument();
+  });
 });
 
 const GENERATED_RECORD = {
@@ -420,6 +460,59 @@ describe('ScoutPage — AI reports feature enabled', () => {
     await screen.findByText('Pandem1c');
 
     expect(screen.queryByText('Past AI Reports')).not.toBeInTheDocument();
+  });
+
+  it('clicking a past report with NO active scout result on screen renders that report', async () => {
+    const user = userEvent.setup();
+    reportsList.mockResolvedValue([OTHER_PLAYER_RECORD]);
+
+    renderPage();
+
+    expect(await screen.findByText('Past AI Reports')).toBeInTheDocument();
+    // No scout has ever been submitted this session — `report` is undefined.
+    expect(screen.queryByRole('heading', { name: 'Pandem1c' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /PowPow/ }));
+
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+    expect(screen.getAllByText(OTHER_PLAYER_RECORD.report.overview).length).toBeGreaterThan(0);
+  });
+
+  it('clicking the same past report again toggles it back off', async () => {
+    const user = userEvent.setup();
+    reportsList.mockResolvedValue([OTHER_PLAYER_RECORD]);
+
+    renderPage();
+    await screen.findByText('Past AI Reports');
+
+    await user.click(screen.getByRole('button', { name: /PowPow/ }));
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /PowPow/ }));
+    expect(screen.queryByText('AI Scouting Report')).not.toBeInTheDocument();
+    // The empty-prompt placeholder returns once nothing is selected/scouted.
+    expect(
+      screen.getByText(/Paste a start\.gg profile URL, slug, or player id above/),
+    ).toBeInTheDocument();
+  });
+
+  it('submitting a fresh scout clears a previously selected past report', async () => {
+    const user = userEvent.setup();
+    reportsList.mockResolvedValue([OTHER_PLAYER_RECORD]);
+    scoutLookup.mockResolvedValue(REPORT);
+
+    renderPage();
+    await screen.findByText('Past AI Reports');
+    await user.click(screen.getByRole('button', { name: /PowPow/ }));
+    expect(await screen.findByText('AI Scouting Report')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    await screen.findByRole('heading', { name: 'Pandem1c' });
+    // The stale selection from before scouting must not leak into the
+    // freshly scouted player's screen (Pandem1c has no stored report here).
+    expect(screen.queryByText('AI Scouting Report')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -23,6 +23,7 @@ import { ScoutStagesCard } from './components/ScoutStagesCard';
 import { ScoutRecentEventsCard } from './components/ScoutRecentEventsCard';
 import { ScoutCommonOpponentsCard } from './components/ScoutCommonOpponentsCard';
 import { ScoutMatchupAdvisorCard } from './components/ScoutMatchupAdvisorCard';
+import { FullAnalysisSection } from './components/FullAnalysisSection';
 import { YourHistoryStrip } from './components/YourHistoryStrip';
 import { ScoutAiReportCard } from './components/ScoutAiReportCard';
 import { ScoutReportHistorySelector } from './components/ScoutReportHistorySelector';
@@ -194,6 +195,12 @@ export function ScoutPage() {
     scout.mutate({ query, source });
   };
 
+  // Clicking a past-reports row toggles it: selecting the same record again
+  // deselects (hides it), rather than being a no-op re-select.
+  const handleSelectPastReport = (record: ScoutReportRecord) => {
+    setSelectedRecord((current) => (current?.id === record.id ? null : record));
+  };
+
   const handleGenerateReport = () => {
     if (!lastQuery) {
       return;
@@ -342,6 +349,8 @@ export function ScoutPage() {
 
           <ScoutMatchupAdvisorCard scoutedCharacters={report.characters} matches={matches} />
 
+          <FullAnalysisSection games={report.games} gamerTag={report.player.gamerTag} />
+
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <ScoutCharactersCard characters={report.characters} />
             <ScoutStagesCard stages={report.stages} />
@@ -353,14 +362,21 @@ export function ScoutPage() {
         </div>
       )}
 
+      {/* Selecting a past report with NO active scout result on screen (e.g.
+          straight off a page load, before ever scouting anyone this
+          session) has nowhere to render inside the `{report && (...)}`
+          block above, since that block doesn't exist yet — this slot covers
+          exactly that case. Once a scout result IS on screen, the report
+          renders inside that block instead (via `displayedRecord`), so this
+          slot intentionally stays silent then to avoid rendering the same
+          report twice. */}
+      {selectedRecord && !report && <ScoutAiReportCard record={selectedRecord} />}
+
       {aiReportsEnabled && otherPastReports.length > 0 && (
-        <ScoutPastReportsCard
-          reports={otherPastReports}
-          onSelect={(record) => setSelectedRecord(record)}
-        />
+        <ScoutPastReportsCard reports={otherPastReports} onSelect={handleSelectPastReport} />
       )}
 
-      {!report && !scout.isError && !scout.isPending && (
+      {!report && !selectedRecord && !scout.isError && !scout.isPending && (
         <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
           {parryggEnabled
             ? 'Paste a start.gg or parry.gg profile URL, slug/tag, or player id above to pull up their public tournament history.'

--- a/apps/web/src/pages/Scout/components/FullAnalysisSection.test.tsx
+++ b/apps/web/src/pages/Scout/components/FullAnalysisSection.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ScoutGame } from '@smash-tracker/shared';
+import { FullAnalysisSection } from './FullAnalysisSection';
+
+// jsdom has no canvas implementation, and chart.js's render pipeline touches
+// real canvas APIs — mocked the same way MatchupChart.test.tsx does, since
+// this suite is verifying the section's own composition/empty-state logic,
+// not chart.js's rendering.
+vi.mock('react-chartjs-2', () => ({
+  Line: () => null,
+}));
+
+function makeGame(overrides: Partial<ScoutGame> = {}): ScoutGame {
+  return {
+    time: 1_700_000_000_000,
+    win: true,
+    fighterId: 1, // Mario
+    opponentFighterId: 41, // Sonic
+    stageId: 1,
+    stageName: 'Battlefield',
+    opponentTag: 'PowPow',
+    eventName: 'Ultimate Singles',
+    ...overrides,
+  };
+}
+
+describe('FullAnalysisSection', () => {
+  it('shows the "re-scout" empty state when games is undefined (pre-V9-D stored report)', async () => {
+    const user = userEvent.setup();
+    render(<FullAnalysisSection games={undefined} gamerTag="Pandem1c" />);
+
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+    expect(screen.getByText('Re-scout to enable full analysis.')).toBeInTheDocument();
+  });
+
+  it('shows the "no per-game data" empty state when games is an empty array', async () => {
+    const user = userEvent.setup();
+    render(<FullAnalysisSection games={[]} gamerTag="Pandem1c" />);
+
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+    expect(
+      screen.getByText('No per-game data available from this source yet.'),
+    ).toBeInTheDocument();
+  });
+
+  it('is collapsed by default', () => {
+    render(<FullAnalysisSection games={[makeGame()]} gamerTag="Pandem1c" />);
+    expect(screen.queryByText('Stage Mastery — Overall')).not.toBeInTheDocument();
+  });
+
+  it('renders the full analysis once expanded, with games adapted to the stats engine', async () => {
+    const user = userEvent.setup();
+    const games = [
+      makeGame({ time: 1, win: true }),
+      makeGame({ time: 2, win: false }),
+      makeGame({ time: 3, win: true }),
+    ];
+    render(<FullAnalysisSection games={games} gamerTag="Pandem1c" />);
+
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+
+    expect(screen.getByText('Stage Mastery — Overall')).toBeInTheDocument();
+    expect(screen.getByText('What They Play')).toBeInTheDocument();
+    expect(screen.getByText("Pandem1c's Recent Form")).toBeInTheDocument();
+    expect(screen.getByText('Opponents')).toBeInTheDocument();
+    // The opponent table groups by human opponent tag, verbatim as scouted
+    // (the adapter doesn't lowercase it the way manually-entered matches do).
+    expect(screen.getByText('PowPow')).toBeInTheDocument();
+  });
+
+  it('does not duplicate the top-character Stage Mastery card when every game is the same character', async () => {
+    const user = userEvent.setup();
+    const games = [makeGame(), makeGame({ time: 2 }), makeGame({ time: 3 })];
+    render(<FullAnalysisSection games={games} gamerTag="Pandem1c" />);
+
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+
+    expect(screen.getByText('Stage Mastery — Overall')).toBeInTheDocument();
+    expect(screen.queryByText(/Stage Mastery — Mario/)).not.toBeInTheDocument();
+  });
+
+  it('shows a per-top-character Stage Mastery card when multiple characters are present', async () => {
+    const user = userEvent.setup();
+    const games = [
+      makeGame({ fighterId: 1, time: 1 }),
+      makeGame({ fighterId: 1, time: 2 }),
+      makeGame({ fighterId: 1, time: 3 }),
+      makeGame({ fighterId: 2, time: 4 }), // Donkey Kong, a rarer pick
+    ];
+    render(<FullAnalysisSection games={games} gamerTag="Pandem1c" />);
+
+    await user.click(screen.getByRole('button', { name: /full analysis/i }));
+
+    expect(screen.getByText('Stage Mastery — Overall')).toBeInTheDocument();
+    expect(screen.getByText('Stage Mastery — Mario')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Scout/components/FullAnalysisSection.tsx
+++ b/apps/web/src/pages/Scout/components/FullAnalysisSection.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import type { ScoutGame } from '@smash-tracker/shared';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import { filterByFighter, rankMatchupsByEvidence } from '@/lib/stats';
+import { StageMastery } from '@/pages/FighterAnalysis/components/StageMastery';
+import { OpponentTable } from '@/pages/FighterAnalysis/components/OpponentTable';
+import { WhatTheyPlayTable } from '@/pages/Opponents/components/WhatTheyPlayTable';
+import { ScoutingTrendChart } from '@/pages/Opponents/components/ScoutingTrendChart';
+import { getFighterById } from '@/data/sprites';
+import { scoutGamesToMatches } from '../lib/fullAnalysis';
+
+/**
+ * V9-D: "Fighter Analysis, but for the player you're scouting" — reuses the
+ * exact stats engine (`@/lib/stats`) and Fighter Analysis / Opponents
+ * components the tracked user's own analytics pages already render, just
+ * pointed at the scouted player's own per-game history
+ * (`ScoutReportData.games`) instead of the caller's own matches.
+ *
+ * Renders nothing meaningful (an empty-state message instead) when `games`
+ * is absent — either an older stored report generated before V9-D, or a
+ * live scout from a source/set that never carried per-game detail (e.g.
+ * parry.gg sets synthesized from scores alone). Collapsed by default so it
+ * doesn't push the AI-report / character-usage cards further down the page
+ * for players who don't care to expand it.
+ */
+export function FullAnalysisSection({
+  games,
+  gamerTag,
+}: {
+  games: ScoutGame[] | undefined;
+  gamerTag: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+        >
+          <span>Full analysis</span>
+          <ChevronDown
+            className={cn('size-4 shrink-0 transition-transform', open && 'rotate-180')}
+            aria-hidden="true"
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="flex flex-col gap-4 border-t p-4">
+        {games && games.length > 0 ? (
+          <FullAnalysisContent games={games} gamerTag={gamerTag} />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {games === undefined
+              ? 'Re-scout to enable full analysis.'
+              : 'No per-game data available from this source yet.'}
+          </p>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+const MIN_MATCHUP_GAMES = 3;
+
+function FullAnalysisContent({ games, gamerTag }: { games: ScoutGame[]; gamerTag: string }) {
+  const matches = scoutGamesToMatches(games);
+
+  // "Their top character" — the character with the most sampled games,
+  // i.e. whichever fighter_id appears most often once adapted to Match[]
+  // (mirrors how `report.characters` is already sorted server-side, but
+  // derived independently here since this component only receives `games`).
+  const gamesByCharacter = new Map<number, number>();
+  for (const match of matches) {
+    gamesByCharacter.set(match.fighter_id, (gamesByCharacter.get(match.fighter_id) ?? 0) + 1);
+  }
+  const topCharacterId = [...gamesByCharacter.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
+  const topCharacterMatches =
+    topCharacterId != null ? filterByFighter(matches, topCharacterId) : [];
+  const topCharacterSprite = topCharacterId != null ? getFighterById(topCharacterId) : null;
+  // Only worth a second, character-scoped card when it's a strict subset of
+  // the overall sample — a one-character scouted player would otherwise see
+  // the exact same tile grid twice.
+  const showTopCharacterCard =
+    topCharacterId != null &&
+    topCharacterMatches.length > 0 &&
+    topCharacterMatches.length < matches.length;
+
+  const matchupSpread = rankMatchupsByEvidence(matches, MIN_MATCHUP_GAMES);
+
+  return (
+    <>
+      <StageMastery fighterMatches={matches} title="Stage Mastery — Overall" />
+
+      {showTopCharacterCard && (
+        <StageMastery
+          fighterMatches={topCharacterMatches}
+          title={`Stage Mastery — ${topCharacterSprite?.name ?? 'Top character'}`}
+        />
+      )}
+
+      <WhatTheyPlayTable byTheirFighter={matchupSpread} />
+
+      <ScoutingTrendChart matches={matches} title={`${gamerTag}'s Recent Form`} />
+
+      <OpponentTable fighterMatches={matches} />
+    </>
+  );
+}

--- a/apps/web/src/pages/Scout/lib/fullAnalysis.test.ts
+++ b/apps/web/src/pages/Scout/lib/fullAnalysis.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { ScoutGame } from '@smash-tracker/shared';
+import { scoutGamesToMatches } from './fullAnalysis';
+
+function makeGame(overrides: Partial<ScoutGame> = {}): ScoutGame {
+  return {
+    time: 1_700_000_000_000,
+    win: true,
+    fighterId: 67,
+    opponentFighterId: 41,
+    stageId: 1,
+    stageName: 'Battlefield',
+    opponentTag: 'PowPow',
+    eventName: 'Ultimate Singles',
+    ...overrides,
+  };
+}
+
+describe('scoutGamesToMatches', () => {
+  it('maps every field to its Match equivalent', () => {
+    const matches = scoutGamesToMatches([makeGame()]);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      fighter_id: 67,
+      opponent_id: 41,
+      time: 1_700_000_000_000,
+      win: true,
+      opponent: 'PowPow',
+      matchType: 'none',
+      map: { id: 1, name: 'Battlefield' },
+      eventName: 'Ultimate Singles',
+    });
+  });
+
+  it('assigns each game a unique, stable-order synthetic id', () => {
+    const matches = scoutGamesToMatches([makeGame(), makeGame({ win: false })]);
+    expect(matches[0]?.id).not.toBe(matches[1]?.id);
+  });
+
+  it('omits `map` entirely when the game has no resolved stage', () => {
+    const matches = scoutGamesToMatches([makeGame({ stageId: undefined, stageName: undefined })]);
+    expect(matches[0]?.map).toBeUndefined();
+  });
+
+  it('omits `eventName` when absent', () => {
+    const matches = scoutGamesToMatches([makeGame({ eventName: undefined })]);
+    expect(matches[0]?.eventName).toBeUndefined();
+  });
+
+  it('preserves the fighterId-0 / opponentFighterId-0 sentinels as plain numbers', () => {
+    const matches = scoutGamesToMatches([makeGame({ opponentFighterId: 0 })]);
+    expect(matches[0]?.opponent_id).toBe(0);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(scoutGamesToMatches([])).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Scout/lib/fullAnalysis.ts
+++ b/apps/web/src/pages/Scout/lib/fullAnalysis.ts
@@ -1,0 +1,39 @@
+import type { Match, ScoutGame } from '@smash-tracker/shared';
+
+/**
+ * V9-D: adapts a scouted player's per-game records (`ScoutReportData.games`,
+ * always from THEIR own perspective — see scoutGameSchema's doc) into the
+ * same `Match[]` shape `apps/web/src/lib/stats.ts` operates on, so the Scout
+ * page's "Full analysis" section can reuse the exact stats engine and
+ * Fighter Analysis components the tracked user's own analysis uses, just
+ * pointed at the scouted player's own history instead.
+ *
+ * This is a client-side, in-memory-only adapter: the resulting `Match[]` is
+ * never sent through `matchSchema.parse` or persisted, so the synthetic `id`
+ * and any `fighter_id`/`opponent_id` of `0` (the unknown-character/opponent
+ * sentinel — see scoutGameSchema) are fine even though `matchSchema` itself
+ * requires positive ids for STORED records; nothing here writes to RTDB.
+ *
+ * Field mapping:
+ * - `fighterId` -> `fighter_id`, `opponentFighterId` -> `opponent_id`.
+ * - `stageId`/`stageName` -> `map` (present only when the game's stage
+ *   resolved to one — omitted otherwise, matching how `getStageRecords`
+ *   already treats a missing `map` as "unknown stage").
+ * - `opponentTag` -> `opponent`.
+ * - `matchType` is a constant sentinel ('none') — scouted games have no
+ *   online/offline signal to carry over, and the stats engine only reads
+ *   `matchType` for the (unused here) online/offline split.
+ */
+export function scoutGamesToMatches(games: ScoutGame[]): Match[] {
+  return games.map((game, index) => ({
+    id: `scout-game-${index}`,
+    fighter_id: game.fighterId,
+    opponent_id: game.opponentFighterId,
+    time: game.time,
+    win: game.win,
+    opponent: game.opponentTag,
+    matchType: 'none',
+    ...(game.stageId != null ? { map: { id: game.stageId, name: game.stageName ?? '' } } : {}),
+    ...(game.eventName ? { eventName: game.eventName } : {}),
+  }));
+}

--- a/packages/shared/src/startgg.test.ts
+++ b/packages/shared/src/startgg.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   isParryggIdentity,
   isStartggIdentity,
+  scoutGameSchema,
   scoutIdentityKey,
   scoutPlayerIdentitySchema,
   scoutRecentEventSchema,
+  scoutReportDataSchema,
   type ScoutPlayerIdentity,
 } from './startgg.js';
 
@@ -86,5 +88,50 @@ describe('scoutRecentEventSchema — V9-B slug/source back-compat', () => {
       source: 'startgg' as const,
     };
     expect(scoutRecentEventSchema.parse(event)).toEqual(event);
+  });
+});
+
+describe('scoutReportDataSchema — V9-D `games` back-compat', () => {
+  const baseReport = {
+    player: { id: 1802316, gamerTag: 'Pandem1c' },
+    sampledSets: 3,
+    sampledGames: 6,
+    characters: [{ fighterId: 67, games: 6, wins: 4 }],
+    stages: [{ stageId: 1, games: 6, wins: 4 }],
+    recentEvents: [],
+    commonOpponents: [],
+  };
+
+  it('parses a pre-V9-D stored report with no `games` field at all', () => {
+    const parsed = scoutReportDataSchema.parse(baseReport);
+    expect(parsed.games).toBeUndefined();
+  });
+
+  it('parses a V9-D report carrying `games`', () => {
+    const game = {
+      time: 1_700_000_000_000,
+      win: true,
+      fighterId: 67,
+      opponentFighterId: 41,
+      stageId: 1,
+      stageName: 'Battlefield',
+      opponentTag: 'PowPow',
+      eventName: 'Ultimate Singles',
+    };
+    const parsed = scoutReportDataSchema.parse({ ...baseReport, games: [game] });
+    expect(parsed.games).toEqual([game]);
+  });
+
+  it('scoutGameSchema tolerates a game with no resolved stage (stageId/stageName both absent)', () => {
+    const parsed = scoutGameSchema.parse({
+      time: 1_700_000_000_000,
+      win: false,
+      fighterId: 67,
+      opponentFighterId: 0,
+      opponentTag: 'PowPow',
+    });
+    expect(parsed.stageId).toBeUndefined();
+    expect(parsed.stageName).toBeUndefined();
+    expect(parsed.eventName).toBeUndefined();
   });
 });

--- a/packages/shared/src/startgg.ts
+++ b/packages/shared/src/startgg.ts
@@ -255,6 +255,45 @@ export const scoutCommonOpponentSchema = z.object({
 export type ScoutCommonOpponent = z.infer<typeof scoutCommonOpponentSchema>;
 
 /**
+ * V9-D: one individual game from the sampled sets, entirely from the
+ * scouted player's own perspective — enough to adapt into a client-side
+ * `Match[]` (see apps/web's `FullAnalysisSection`) and run the SAME stats
+ * engine (`apps/web/src/lib/stats.ts`) Fighter Analysis uses, for the
+ * scouted player instead of the tracked user.
+ *
+ * OPTIONAL and additive on `scoutReportDataSchema`: every report generated
+ * before V9-D (and every stored AI report, which never embedded the full
+ * scout payload's `games` in the first place) has no such field at all, so
+ * every consumer must render a "no per-game data" empty state rather than
+ * assume presence.
+ *
+ * Games whose character couldn't be mapped to this app's roster are
+ * SKIPPED here (never emitted with a fighterId of 0) — unlike
+ * `scoutCharacterUsageSchema`'s aggregate rows, an unmapped-character game
+ * would pollute the client stats engine's per-character breakdowns (e.g.
+ * "their best stage on their top character") with games that aren't
+ * actually attributable to a real character.
+ */
+export const scoutGameSchema = z.object({
+  /** Epoch ms this game was played (set-level `completedAt`/`endedAt`, duplicated per game — same convention as match records' server-set event fields). */
+  time: z.number().int().nonnegative(),
+  win: z.boolean(),
+  /** The scouted player's own character (mapped sprite id) for this game. */
+  fighterId: z.number().int().nonnegative(),
+  /** The opponent's character (mapped sprite id) for this game; `0` when unmapped (unlike `fighterId`, the opponent's character isn't the scouted player's own stats subject, so this follows the usual "unknown sentinel" convention instead of being skipped). */
+  opponentFighterId: z.number().int().nonnegative(),
+  /** This app's stage id, when the played stage resolved to one. */
+  stageId: z.number().int().nonnegative().optional(),
+  /** The stage's display name, when known. */
+  stageName: z.string().optional(),
+  /** The human opponent's gamer tag for this set. */
+  opponentTag: z.string().min(1),
+  /** The event name this set belonged to, when known. */
+  eventName: z.string().optional(),
+});
+export type ScoutGame = z.infer<typeof scoutGameSchema>;
+
+/**
  * POST /api/scout response — a server-aggregated scouting summary for ANY
  * start.gg player (not just linked accounts), built entirely from public
  * data reachable via the server's own API token. Every field below is from
@@ -276,6 +315,12 @@ export const scoutReportDataSchema = z.object({
   recentEvents: z.array(scoutRecentEventSchema).max(10),
   /** Opponents they've faced most often in the sample, most sets first (capped to 10). */
   commonOpponents: z.array(scoutCommonOpponentSchema).max(10),
+  /**
+   * V9-D: per-game records from the sampled sets, for the web "Full
+   * analysis" section. OPTIONAL — see `scoutGameSchema`'s doc for the
+   * back-compat rule every consumer must follow.
+   */
+  games: z.array(scoutGameSchema).optional(),
 });
 export type ScoutReportData = z.infer<typeof scoutReportDataSchema>;
 


### PR DESCRIPTION
## Summary
- Extend `scoutReportDataSchema` with an optional `games: ScoutGame[]` — per-game records (time, win, own/opponent character, stage, opponent tag, event) from the scouted player's own perspective. Both scout engines (`apps/api/src/startgg/scout.ts`, `apps/api/src/parrygg/scout.ts`) emit it from the sets/matches they already sample (no extra API calls); games whose own character can't be mapped are skipped entirely rather than polluting per-character stats. Fully additive/optional — old stored reports and non-detailed sources (e.g. parry.gg sets synthesized from scores) simply omit it.
- The AI report payload (`apps/api/src/reports/generate.ts`) strips `games` before it reaches Claude — the existing head-to-head/matchup-advisor aggregates already summarize it, so including the raw list would only inflate token cost.
- On the web, add a collapsible **"Full analysis"** section to the Scout page (below the matchup advisor, above Character Usage) that adapts `games` into `Match[]` and reuses Fighter Analysis's own components/stats engine — `StageMastery` (overall + top-character), `WhatTheyPlayTable` (evidence-ranked matchup spread), `ScoutingTrendChart` (recent form), and `OpponentTable` (most-faced opponents) — pointed at the scouted player's history instead of the tracked user's. Clear empty states distinguish "re-scout to enable" (no `games` at all) from "no per-game data from this source" (empty `games`).
- **Folded in per a mid-review bug report**: selecting a report from "Past AI Reports" did nothing unless a scout result was already on screen (the render slot lived inside the `{report && ...}` block). Fixed by adding a render slot for the selected past report outside that block, and clicking the same report again now toggles it back off.

## Test plan
- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] `pnpm typecheck` — clean across all workspaces
- [x] `pnpm test` — 1313 tests passing (99 shared, 391 api, 823 web), including new coverage for: per-game emission/skip rules in both scout engines, back-compat schema parsing, payload stripping, the `Match[]` adapter, the `FullAnalysisSection` component (empty states, collapse-by-default, top-character dedup), and the past-reports selection/toggle bug fix
- [x] `pnpm build` — clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)