### PR TITLE
V10: GSP tracker — per-fighter curve, Elite projection, Glicko overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Live demo: https://smash-tracker-f97b7.web.app/
 
 Smash Tracker is a match-tracking app for **Super Smash Bros. Ultimate**. Sign in, pick a
 primary/secondary fighter, log wins and losses (opponent, stage, match type, notes) after each
-set, and review your results: win/loss trends, best/worst matchups, per-stage performance, and
-per-opponent history.
+set, and review your results: win/loss trends, best/worst matchups, per-stage performance,
+per-opponent history, and a per-fighter GSP (Global Smash Power) tracker with an Elite Smash
+projection.
 
 This repo is a full rewrite of an older Create React App + Redux + Firebase client-only app into
 a typed monorepo with a real API layer in front of Firebase, kept as a portfolio piece.
@@ -342,6 +343,12 @@ writes (`users/{uid}`, `primaryFighters/{uid}`, `secondaryFighters/{uid}`, `matc
 `opponents/{uid}`), reverse-engineered field-for-field from the legacy app so existing production
 data keeps working. See [`packages/shared/README.md`](./packages/shared/README.md) for the full
 shape reference and provenance notes.
+
+GSP (Global Smash Power) tracking works the same way: matches optionally carry a `gsp` reading,
+and the per-fighter Elite Smash entry threshold (`gspSettings/{uid}`) is **user-maintained** —
+there is no public Elite Smash API, so the GSP page links out to
+[elitegsp.com](https://elitegsp.com)'s crowd-sourced estimate for reference and lets you type in
+(and update) the number yourself.
 
 ### Disclaimer
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import matchesRoutes from './routes/matches.js';
 import opponentsRoutes from './routes/opponents.js';
 import opponentAliasesRoutes from './routes/opponentAliases.js';
 import opponentNotesRoutes from './routes/opponentNotes.js';
+import gspSettingsRoutes from './routes/gspSettings.js';
 import startggRoutes from './routes/startgg.js';
 import parryggRoutes from './routes/parrygg.js';
 import parryggAuthRoutes from './routes/parryggAuth.js';
@@ -138,6 +139,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(opponentsRoutes);
       await api.register(opponentAliasesRoutes);
       await api.register(opponentNotesRoutes);
+      await api.register(gspSettingsRoutes);
       await api.register(tournamentsRoutes);
       await api.register(groupsRoutes);
       await api.register(startggRoutes, {

--- a/apps/api/src/routes/gspSettings.test.ts
+++ b/apps/api/src/routes/gspSettings.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ELITE_THRESHOLD } from '@smash-tracker/shared';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+describe('GET /api/gsp-settings', () => {
+  it('returns the placeholder default when the user has never saved settings', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ eliteThreshold: DEFAULT_ELITE_THRESHOLD, updatedAt: 0 });
+  });
+
+  it('returns the saved settings when present', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`gspSettings/${TEST_UID}`, { eliteThreshold: 12_000_000, updatedAt: 555 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ eliteThreshold: 12_000_000, updatedAt: 555 });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-settings' });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/gsp-settings', () => {
+  it('saves a new threshold and stamps updatedAt server-side', async () => {
+    const { app, database } = buildTestApp();
+    const before = Date.now();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+      payload: { eliteThreshold: 11_500_000 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.eliteThreshold).toBe(11_500_000);
+    expect(body.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(database.dump()).toMatchObject({
+      gspSettings: { [TEST_UID]: { eliteThreshold: 11_500_000 } },
+    });
+  });
+
+  it('overwrites a previously-saved threshold', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`gspSettings/${TEST_UID}`, { eliteThreshold: 9_000_000, updatedAt: 1 });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+      payload: { eliteThreshold: 13_000_000 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().eliteThreshold).toBe(13_000_000);
+  });
+
+  it('rejects a non-positive threshold', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+      payload: { eliteThreshold: 0 },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects a missing body', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/gsp-settings',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/gsp-settings',
+      payload: { eliteThreshold: 10_000_000 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/apps/api/src/routes/gspSettings.ts
+++ b/apps/api/src/routes/gspSettings.ts
@@ -1,0 +1,54 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { gspSettingsSchema, upsertGspSettingsInputSchema } from '@smash-tracker/shared';
+import { RtdbService } from '../services/rtdb.js';
+
+/**
+ * V10: `gspSettings/{uid}` — a single per-user setting, the Elite Smash entry
+ * threshold the player is tracking their fighter's GSP against. There is no
+ * public Elite Smash API (elitegsp.com estimates it from crowd-sourced
+ * submissions and we intentionally don't scrape it), so this is entirely
+ * user-maintained.
+ *
+ * GET returns a synthesized default (see `RtdbService.getGspSettings`) rather
+ * than 404ing when the user hasn't saved anything yet — simpler for the web
+ * hook than branching on response status, and the placeholder default is
+ * clearly labeled as such in the UI.
+ */
+const gspSettingsRoutes: FastifyPluginAsyncZod = async (app) => {
+  const rtdb = new RtdbService(app.firebase.database);
+
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/gsp-settings
+  app.get(
+    '/gsp-settings',
+    {
+      schema: {
+        response: {
+          200: gspSettingsSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.getGspSettings(request.uid);
+    },
+  );
+
+  // PUT /api/gsp-settings
+  app.put(
+    '/gsp-settings',
+    {
+      schema: {
+        body: upsertGspSettingsInputSchema,
+        response: {
+          200: gspSettingsSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.setGspSettings(request.uid, request.body);
+    },
+  );
+};
+
+export default gspSettingsRoutes;

--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -259,6 +259,70 @@ describe('POST /api/matches', () => {
     expect(body).not.toHaveProperty('source');
     expect(body).not.toHaveProperty('externalId');
   });
+
+  it('accepts and stores a gsp reading', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput, matchType: 'quickplay', gsp: 9_420_000 },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({ gsp: 9_420_000 });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({ gsp: 9_420_000 });
+  });
+
+  it('omits gsp from the stored record when not provided', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: validCreateInput,
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).not.toHaveProperty('gsp');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).not.toHaveProperty('gsp');
+  });
+
+  it('returns 400 when gsp is negative', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput, gsp: -1 },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 when gsp is not an integer', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput, gsp: 123.45 },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
 });
 
 describe('PATCH /api/matches/:id', () => {
@@ -559,6 +623,93 @@ describe('PATCH /api/matches/:id', () => {
         vodUrl: 'https://youtube.com/watch?v=abc123',
         vodTimestamps: [{ seconds: -5, note: 'negative seconds' }],
       },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('sets a gsp reading', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, matchType: 'quickplay', gsp: 8_500_000 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ gsp: 8_500_000 });
+  });
+
+  it('updates an existing gsp reading', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      gsp: 8_000_000,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, matchType: 'quickplay', gsp: 8_100_000 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ gsp: 8_100_000 });
+  });
+
+  it('clears gsp when omitted from the update payload', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      gsp: 8_000_000,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: validCreateInput,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).not.toHaveProperty('gsp');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = matches[TEST_UID]!.existingKey!;
+    expect(stored).not.toHaveProperty('gsp');
+  });
+
+  it('returns 400 when gsp is negative', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, gsp: -1 },
     });
 
     expect(response.statusCode).toBe(400);

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -1,5 +1,7 @@
 import type { Database } from 'firebase-admin/database';
 import {
+  DEFAULT_ELITE_THRESHOLD,
+  gspSettingsSchema,
   matchRecordSchema,
   opponentAliasMapSchema,
   opponentMapSchema,
@@ -8,12 +10,14 @@ import {
   userSchema,
   type CreateMatchInput,
   type FighterSelectionInput,
+  type GspSettings,
   type Match,
   type MatchRecord,
   type OpponentAliasMap,
   type OpponentNote,
   type OpponentNoteMap,
   type UpdateMatchInput,
+  type UpsertGspSettingsInput,
   type UpsertOpponentNoteInput,
   type User,
 } from '@smash-tracker/shared';
@@ -109,6 +113,7 @@ export class RtdbService {
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
       ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
+      ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
     };
 
     const ref = this.database.ref(`matches/${uid}`).push();
@@ -141,13 +146,14 @@ export class RtdbService {
       win: input.win,
       // See createMatch — RTDB rejects `undefined` values, so these are
       // only included when the input actually set them. Omitting
-      // vodUrl/vodTimestamps from the input is how a caller clears them,
+      // vodUrl/vodTimestamps/gsp from the input is how a caller clears them,
       // since this is a full overwrite (`.set()`, not a partial patch).
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
       ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
+      ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
     };
 
     await ref.set(record);
@@ -278,5 +284,34 @@ export class RtdbService {
       throw new NotFoundError(`Note for ${name} not found`);
     }
     await ref.remove();
+  }
+
+  // ---- gspSettings/{uid} --------------------------------------------------
+
+  /**
+   * Returns the user's saved GSP settings, or a synthesized default
+   * (`DEFAULT_ELITE_THRESHOLD`, `updatedAt: 0`) when they haven't saved any
+   * yet — chosen over a 404 so every caller (web hook included) can treat
+   * "no settings saved" and "settings saved" uniformly instead of branching
+   * on response status; `updatedAt: 0` lets the UI still detect "never
+   * actually saved" if it needs to (a real save always produces `Date.now()`,
+   * which is enormously larger).
+   */
+  async getGspSettings(uid: string): Promise<GspSettings> {
+    const snapshot = await this.database.ref(`gspSettings/${uid}`).get();
+    if (!snapshot.exists()) {
+      return { eliteThreshold: DEFAULT_ELITE_THRESHOLD, updatedAt: 0 };
+    }
+    return gspSettingsSchema.parse(snapshot.val());
+  }
+
+  /** Writes (fully replaces) the user's GSP settings, stamping `updatedAt` server-side (same convention as `setOpponentNote`). */
+  async setGspSettings(uid: string, input: UpsertGspSettingsInput): Promise<GspSettings> {
+    const settings: GspSettings = {
+      eliteThreshold: input.eliteThreshold,
+      updatedAt: Date.now(),
+    };
+    await this.database.ref(`gspSettings/${uid}`).set(gspSettingsSchema.parse(settings));
+    return settings;
   }
 }

--- a/apps/web/src/hooks/useGspSettings.test.tsx
+++ b/apps/web/src/hooks/useGspSettings.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useGspSettings, useUpdateGspSettings } from './useGspSettings';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+import { AuthProvider } from '@/context/AuthContext';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = [new QueryClient({ defaultOptions: { queries: { retry: false } } })];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function SettingsProbe() {
+  const { data, isSuccess } = useGspSettings();
+  const update = useUpdateGspSettings();
+  if (!isSuccess) {
+    return <div>loading</div>;
+  }
+  return (
+    <div>
+      <div>eliteThreshold: {data.eliteThreshold}</div>
+      <button onClick={() => update.mutate({ eliteThreshold: 12_000_000 })}>Update</button>
+    </div>
+  );
+}
+
+describe('useGspSettings', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches settings with a Bearer auth header and validates against the shared schema', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ eliteThreshold: 10_300_000, updatedAt: 0 }),
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <SettingsProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('eliteThreshold: 10300000')).toBeInTheDocument());
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(fetch).mock.calls[0];
+    if (!call) {
+      throw new Error('expected fetch to have been called');
+    }
+    const [url, init] = call;
+    expect(String(url)).toContain('/api/gsp-settings');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer mock-id-token');
+  });
+
+  it('PUTs the update and invalidates the settings query', async () => {
+    let stored = { eliteThreshold: 10_300_000, updatedAt: 0 };
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        stored = { eliteThreshold: 12_000_000, updatedAt: 999 };
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify(stored),
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <Wrapper>
+        <SettingsProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('eliteThreshold: 10300000')).toBeInTheDocument());
+
+    screen.getByRole('button', { name: 'Update' }).click();
+
+    await waitFor(() => expect(screen.getByText('eliteThreshold: 12000000')).toBeInTheDocument());
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(putCall).toBeDefined();
+    expect(JSON.parse((putCall![1] as RequestInit).body as string)).toEqual({
+      eliteThreshold: 12_000_000,
+    });
+  });
+});

--- a/apps/web/src/hooks/useGspSettings.ts
+++ b/apps/web/src/hooks/useGspSettings.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UpsertGspSettingsInput } from '@smash-tracker/shared';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const gspSettingsQueryKey = ['gspSettings'] as const;
+
+/**
+ * GET /api/gsp-settings — the signed-in user's Elite Smash threshold (V10).
+ * The API always returns a value (synthesizing `DEFAULT_ELITE_THRESHOLD`
+ * when the user hasn't saved one yet), so callers never need to handle a
+ * missing-settings case themselves.
+ */
+export function useGspSettings() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: gspSettingsQueryKey,
+    queryFn: () => api.gspSettings.get(),
+    enabled: Boolean(user),
+  });
+}
+
+/** PUT /api/gsp-settings. Invalidates the settings query on success. */
+export function useUpdateGspSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpsertGspSettingsInput) => api.gspSettings.update(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: gspSettingsQueryKey });
+    },
+  });
+}

--- a/apps/web/src/layouts/nav.ts
+++ b/apps/web/src/layouts/nav.ts
@@ -11,6 +11,7 @@ import {
   TrendingUp,
   Trophy,
   Sparkles,
+  Gauge,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -32,6 +33,7 @@ export const navItems: NavItem[] = [
   { title: 'AI Reports', href: '/reports', icon: Sparkles },
   { title: 'Match Data', href: '/match-data', icon: LineChart },
   { title: 'Trends', href: '/trends', icon: TrendingUp },
+  { title: 'GSP', href: '/gsp', icon: Gauge },
   { title: 'Groups', href: '/groups', icon: Trophy },
   { title: 'Integrations', href: '/settings/integrations', icon: Plug },
 ];

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,7 @@ import {
   groupLeaderboardSchema,
   groupListSchema,
   groupRecordSchema,
+  gspSettingsSchema,
   joinGroupRequestSchema,
   matchSchema,
   opponentAliasMapSchema,
@@ -47,6 +48,7 @@ import {
   type ParryggLoginStartRequest,
   type ScoutQuery,
   type UpdateMatchInput,
+  type UpsertGspSettingsInput,
   type UpsertOpponentAliasInput,
   type UpsertOpponentNoteInput,
 } from '@smash-tracker/shared';
@@ -400,6 +402,13 @@ export const api = {
         method: 'POST',
         body: checkoutRequestSchema.parse({ packId }),
       }),
+  },
+  gspSettings: {
+    /** GET /api/gsp-settings — the signed-in user's Elite Smash threshold setting (defaults are synthesized server-side, never 404s). */
+    get: () => apiRequestParsed('/api/gsp-settings', gspSettingsSchema),
+    /** PUT /api/gsp-settings */
+    update: (input: UpsertGspSettingsInput) =>
+      apiRequestParsed('/api/gsp-settings', gspSettingsSchema, { method: 'PUT', body: input }),
   },
 };
 

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import { GspPage } from './GspPage';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+import { SpriteList } from '@/data/sprites';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const getFighters = vi.fn();
+const listMatches = vi.fn();
+const createMatch = vi.fn();
+const getGspSettings = vi.fn();
+const updateGspSettings = vi.fn();
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    users: {
+      upsertMe: (...args: unknown[]) => upsertMe(...args),
+      getFighters: (...args: unknown[]) => getFighters(...args),
+    },
+    matches: {
+      list: (...args: unknown[]) => listMatches(...args),
+      create: (...args: unknown[]) => createMatch(...args),
+    },
+    gspSettings: {
+      get: (...args: unknown[]) => getGspSettings(...args),
+      update: (...args: unknown[]) => updateGspSettings(...args),
+    },
+  },
+}));
+
+const mario = SpriteList.find((s) => s.id === 1)!;
+const luigi = SpriteList.find((s) => s.id === 10)!;
+
+function makeMatch(
+  overrides: Partial<Record<string, unknown>> & { id: string; time: number; win: boolean },
+) {
+  return {
+    fighter_id: mario.id,
+    opponent_id: luigi.id,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'quickplay',
+    ...overrides,
+  };
+}
+
+function renderGspPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/gsp']}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/gsp" element={<GspPage />} />
+            <Route path="/dashboard" element={<div>Dashboard page</div>} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('GspPage', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    setMockUser(makeMockUser());
+    getFighters.mockResolvedValue({ primary: [], secondary: [] });
+    listMatches.mockResolvedValue([]);
+    getGspSettings.mockResolvedValue({ eliteThreshold: 10_000_000, updatedAt: 0 });
+    updateGspSettings.mockResolvedValue({ eliteThreshold: 11_000_000, updatedAt: Date.now() });
+    createMatch.mockResolvedValue({
+      id: 'new-match',
+      fighter_id: mario.id,
+      opponent_id: luigi.id,
+      time: Date.now(),
+      map: { id: 0, name: 'no selection' },
+      opponent: '',
+      notes: '',
+      matchType: 'quickplay',
+      win: true,
+      gsp: 9_500_000,
+    });
+  });
+
+  it('shows an explanatory empty state with no gsp-bearing matches and no fighter selections', async () => {
+    renderGspPage();
+
+    expect(await screen.findByText('Track your GSP climb')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Log a match on the Dashboard' })).toBeInTheDocument();
+  });
+
+  it('offers primary/secondary fighters as suggestions even with no gsp matches yet', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+
+    renderGspPage();
+
+    expect(await screen.findByRole('heading', { name: 'GSP Tracker' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Select fighter' })).toBeInTheDocument();
+    expect(
+      within(screen.getByRole('group', { name: 'Select fighter' })).getByText(mario.name),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the hero row and curve once GSP matches exist', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([
+      makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+      makeMatch({ id: 'm2', time: 2, win: true, gsp: 9_100_000 }),
+      makeMatch({ id: 'm3', time: 3, win: false, gsp: 9_050_000 }),
+    ]);
+
+    renderGspPage();
+
+    expect(await screen.findByText('9,050,000')).toBeInTheDocument(); // current GSP
+    expect(screen.getByText('GSP Curve')).toBeInTheDocument();
+    expect(screen.getByText('10,000,000')).toBeInTheDocument(); // elite threshold
+  });
+
+  it('shows the ELITE badge once current GSP reaches the threshold', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    getGspSettings.mockResolvedValue({ eliteThreshold: 9_000_000, updatedAt: 0 });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_500_000 })]);
+
+    renderGspPage();
+
+    expect(await screen.findByText('ELITE')).toBeInTheDocument();
+    expect(screen.getByText(/already in Elite Smash/)).toBeInTheDocument();
+  });
+
+  it('logs a match through the Quick Logger and shows the delta toast', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+
+    await screen.findByText('Quick Logger');
+
+    await user.click(screen.getByRole('combobox', { name: 'Opponent Character' }));
+    await user.click(await screen.findByRole('option', { name: luigi.name }));
+
+    await user.click(screen.getByRole('radio', { name: 'Win' }));
+
+    const gspInput = screen.getByLabelText('GSP After Match');
+    await user.clear(gspInput);
+    await user.type(gspInput, '9500000');
+
+    await user.click(screen.getByRole('button', { name: 'Log Match' }));
+
+    await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(1));
+    expect(createMatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fighter_id: mario.id,
+        opponent_id: luigi.id,
+        matchType: 'quickplay',
+        win: true,
+        gsp: 9_500_000,
+      }),
+    );
+  });
+
+  it('requires an opponent character and result before submitting from the Quick Logger', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('Quick Logger');
+
+    await user.click(screen.getByRole('button', { name: 'Log Match' }));
+
+    expect(createMatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/Gsp/GspPage.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import type { Fighter } from '@smash-tracker/shared';
+import { getGspGainStats, getGspSeries } from '@smash-tracker/shared';
+import { Button } from '@/components/ui/button';
+import { useMatches } from '@/hooks/useMatches';
+import { useFighters } from '@/hooks/useFighters';
+import { useGspSettings } from '@/hooks/useGspSettings';
+import { getGspFighterOptions } from './lib/gspFighters';
+import { GspFighterSelect } from './components/GspFighterSelect';
+import { GspHero } from './components/GspHero';
+import { GspCurve } from './components/GspCurve';
+import { QuickLogger } from './components/QuickLogger';
+import { GainsAnalysis } from './components/GainsAnalysis';
+import { RoadToElite } from './components/RoadToElite';
+import { GspVsGlicko } from './components/GspVsGlicko';
+
+/**
+ * V10: GSP (Global Smash Power) tracker for online quickplay. GSP is
+ * per-character (see packages/shared/src/gsp.ts), so — unlike Trends —
+ * everything on this page below the fighter selector is scoped to whichever
+ * sprite is currently selected. Design language mirrors Fighter
+ * Analysis/Trends: a hero stat row followed by a responsive card grid.
+ *
+ * All GSP data is just regular matches carrying an optional `gsp` field
+ * (logged via the same `POST /api/matches` path as everything else, with
+ * `matchType: 'quickplay'`) — there is no separate GSP-only record type.
+ */
+export function GspPage() {
+  const { data: matches = [], isLoading: matchesLoading } = useMatches();
+  const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
+  const { data: gspSettings, isLoading: settingsLoading } = useGspSettings();
+
+  const fighterOptions = useMemo(
+    () =>
+      getGspFighterOptions(
+        matches,
+        fighterSelection?.primary ?? [],
+        fighterSelection?.secondary ?? [],
+      ),
+    [matches, fighterSelection],
+  );
+
+  const [selectedFighterId, setSelectedFighterId] = useState<number | undefined>(undefined);
+  const fighter: Fighter | undefined =
+    fighterOptions.find((f) => f.id === selectedFighterId) ?? fighterOptions[0] ?? undefined;
+
+  const isLoading = matchesLoading || fightersLoading || settingsLoading;
+
+  if (isLoading) {
+    return <div className="text-muted-foreground">Loading GSP tracker...</div>;
+  }
+
+  if (fighterOptions.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Track your GSP climb</h1>
+        <p className="max-w-md text-muted-foreground">
+          GSP (Global Smash Power) is Smash Ultimate&apos;s online quickplay ranking, tracked
+          per-character. Log a quickplay match with the GSP shown on the results screen and this
+          page will chart your climb, break down your win/loss gains, and estimate how far you are
+          from Elite Smash.
+        </p>
+        <Button asChild className="mt-2">
+          <Link to="/dashboard">Log a match on the Dashboard</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (!fighter || !gspSettings) {
+    return <div className="text-muted-foreground">Loading GSP tracker...</div>;
+  }
+
+  const series = getGspSeries(matches, fighter.id);
+  const gainStats = getGspGainStats(series);
+  const lastGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">GSP Tracker</h1>
+        <p className="max-w-lg text-sm text-muted-foreground">
+          Global Smash Power is per-character and its exact formula is never published by Nintendo —
+          everything below is an estimate built from your own logged matches.
+        </p>
+        <GspFighterSelect
+          fighter={fighter}
+          fighterOptions={fighterOptions}
+          onChange={(next) => setSelectedFighterId(next.id)}
+        />
+      </div>
+
+      <GspHero series={series} settings={gspSettings} />
+
+      <GspCurve series={series} eliteThreshold={gspSettings.eliteThreshold} />
+
+      <QuickLogger fighter={fighter} lastGsp={lastGsp} />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <GainsAnalysis stats={gainStats} />
+        <RoadToElite series={series} eliteThreshold={gspSettings.eliteThreshold} />
+      </div>
+
+      <GspVsGlicko gspSeries={series} allMatches={matches} />
+    </div>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/GainsAnalysis.tsx
+++ b/apps/web/src/pages/Gsp/components/GainsAnalysis.tsx
@@ -1,0 +1,134 @@
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import type { GspGainStats } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartColors, darkChartOptions } from '@/lib/chartTheme';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+function buildPerWinGainsData(perWinGains: number[]) {
+  return {
+    labels: perWinGains.map((_, i) => String(i + 1)),
+    datasets: [
+      {
+        label: 'GSP gained',
+        data: perWinGains,
+        backgroundColor: chartColors.red,
+        borderRadius: 2,
+      },
+    ],
+  };
+}
+
+function buildPerWinGainsOptions(): ChartOptions<'bar'> {
+  const theme = darkChartOptions();
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { ...theme.scales?.x, display: false },
+      y: {
+        ...theme.scales?.y,
+        ticks: { ...theme.scales?.y?.ticks, callback: (value) => Number(value).toLocaleString() },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: chartColors.tooltipBg,
+        borderColor: chartColors.tooltipBorder,
+        borderWidth: 1,
+        callbacks: {
+          title: (items) => `Win #${items[0]?.label ?? ''}`,
+          label: (item) => `+${Number(item.parsed.y).toLocaleString()} GSP`,
+        },
+      },
+    },
+  };
+}
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function formatGsp(value: number | null): string {
+  return value === null ? '—' : Math.round(value).toLocaleString();
+}
+
+/**
+ * Win/loss GSP gain analysis for the selected fighter: lifetime vs. last-20
+ * average gain/drop, the single biggest gain observed, and a bar of per-win
+ * gains over time visualizing the shrink documented at the top of
+ * `packages/shared/src/gsp.ts` (gains per win shrink as GSP climbs — the
+ * bell-curve tail effect).
+ */
+export function GainsAnalysis({ stats }: { stats: GspGainStats }) {
+  const hasData = stats.perWinGains.length > 0 || stats.avgDropPerLossLifetime !== null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Gains Analysis</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {hasData ? (
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+              <StatBlock
+                label="Avg gain/win (lifetime)"
+                value={formatGsp(stats.avgGainPerWinLifetime)}
+              />
+              <StatBlock
+                label="Avg drop/loss (lifetime)"
+                value={formatGsp(stats.avgDropPerLossLifetime)}
+              />
+              <StatBlock label="Biggest single gain" value={formatGsp(stats.biggestGain)} />
+              <StatBlock
+                label="Avg gain/win (last 20)"
+                value={formatGsp(stats.avgGainPerWinLast20)}
+              />
+              <StatBlock
+                label="Avg drop/loss (last 20)"
+                value={formatGsp(stats.avgDropPerLossLast20)}
+              />
+              <StatBlock label="Biggest single drop" value={formatGsp(stats.biggestDrop)} />
+            </div>
+
+            {stats.perWinGains.length > 0 && (
+              <div>
+                <p className="mb-1 text-sm font-medium text-muted-foreground">
+                  Per-win gains over time
+                  {stats.gainTrend === 'shrinking' && ' — shrinking as your GSP climbs'}
+                  {stats.gainTrend === 'growing' && ' — trending up'}
+                </p>
+                <div className="h-32">
+                  <Bar
+                    data={buildPerWinGainsData(stats.perWinGains)}
+                    options={buildPerWinGainsOptions()}
+                  />
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Log a few wins and losses with GSP readings to see your gain/loss trends.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/GspCurve.test.ts
+++ b/apps/web/src/pages/Gsp/components/GspCurve.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import type { GspPoint } from '@smash-tracker/shared';
+import { buildGspCurveData } from './GspCurve';
+
+describe('buildGspCurveData', () => {
+  it('builds a GSP dataset and a flat threshold line of the same length', () => {
+    const series: GspPoint[] = [
+      { time: 1, gsp: 9_000_000, win: true },
+      { time: 2, gsp: 9_100_000, win: true },
+    ];
+
+    const data = buildGspCurveData(series, 10_000_000);
+
+    expect(data.labels).toHaveLength(2);
+    expect(data.datasets[0]!.data).toEqual([9_000_000, 9_100_000]);
+    expect(data.datasets[1]!.data).toEqual([10_000_000, 10_000_000]);
+    expect(data.datasets[1]!.label).toBe('Elite threshold');
+  });
+
+  it('handles an empty series', () => {
+    const data = buildGspCurveData([], 10_000_000);
+    expect(data.labels).toEqual([]);
+    expect(data.datasets[0]!.data).toEqual([]);
+    expect(data.datasets[1]!.data).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Gsp/components/GspCurve.tsx
+++ b/apps/web/src/pages/Gsp/components/GspCurve.tsx
@@ -1,0 +1,133 @@
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import type { GspPoint } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+/** Minimum GSP readings before the curve renders instead of the locked/empty state. */
+export const GSP_CURVE_UNLOCK_THRESHOLD = 2;
+
+function formatPointLabel(time: number): string {
+  return new Date(time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Builds the chart.js dataset: the GSP line plus a flat "Elite threshold"
+ * reference line at the same value across every point, so it renders as a
+ * horizontal line regardless of x-axis spacing. Exported as a pure builder so
+ * it's unit-testable without rendering chart.js.
+ */
+export function buildGspCurveData(series: GspPoint[], eliteThreshold: number) {
+  const labels = series.map((p) => formatPointLabel(p.time));
+  return {
+    labels,
+    datasets: [
+      {
+        label: 'GSP',
+        ...redLineDataset(),
+        data: series.map((p) => p.gsp),
+      },
+      {
+        label: 'Elite threshold',
+        data: series.map(() => eliteThreshold),
+        borderColor: chartColors.grid,
+        backgroundColor: chartColors.grid,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        borderWidth: 1.5,
+        fill: false,
+        tension: 0,
+      },
+    ],
+  };
+}
+
+function buildGspCurveOptions(series: GspPoint[]): ChartOptions<'line'> {
+  const theme = darkChartOptions();
+  return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
+    scales: {
+      x: theme.scales?.x,
+      y: {
+        ...theme.scales?.y,
+        ticks: {
+          ...theme.scales?.y?.ticks,
+          callback: (value) => Number(value).toLocaleString(),
+        },
+      },
+    },
+    plugins: {
+      legend: { display: true, labels: theme.plugins?.legend?.labels },
+      tooltip: {
+        ...theme.plugins?.tooltip,
+        mode: 'index',
+        intersect: false,
+        callbacks: {
+          title: (items) => {
+            const point = series[items[0]?.dataIndex ?? -1];
+            return point ? new Date(point.time).toLocaleDateString('en-US') : '';
+          },
+          label: (item) => `${item.dataset.label}: ${Number(item.parsed.y).toLocaleString()}`,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * GSP-over-time line chart for the selected fighter, with a dashed horizontal
+ * line at the user's Elite Smash threshold setting (V10). Responsive per
+ * `chartTheme`'s `maintainAspectRatio: false` convention (V9-C) — needs a
+ * fixed-height wrapper div to actually fill.
+ */
+export function GspCurve({
+  series,
+  eliteThreshold,
+}: {
+  series: GspPoint[];
+  eliteThreshold: number;
+}) {
+  const hasEnoughReadings = series.length >= GSP_CURVE_UNLOCK_THRESHOLD;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>GSP Curve</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {hasEnoughReadings ? (
+          <>
+            <div className="h-64">
+              <Line
+                data={buildGspCurveData(series, eliteThreshold)}
+                options={buildGspCurveOptions(series)}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Every point is a logged post-match GSP reading for this fighter. The dashed line is
+              your Elite Smash threshold setting — an estimate, not a Nintendo-published value.
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Log at least {GSP_CURVE_UNLOCK_THRESHOLD} matches with a GSP reading for this fighter to
+            see the curve.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/GspFighterSelect.tsx
+++ b/apps/web/src/pages/Gsp/components/GspFighterSelect.tsx
@@ -1,0 +1,48 @@
+import type { Fighter } from '@smash-tracker/shared';
+import { cn } from '@/lib/utils';
+
+/**
+ * Sprite row fighter selector across the top of the GSP page — every fighter
+ * with a GSP-bearing match, plus the user's primary/secondary picks as
+ * always-available suggestions (see `getGspFighterOptions`). GSP is tracked
+ * per-character, so unlike most of this app's pages the rest of the GSP page
+ * is entirely scoped to whichever sprite is active here.
+ */
+export function GspFighterSelect({
+  fighter,
+  fighterOptions,
+  onChange,
+}: {
+  fighter: Fighter | undefined;
+  fighterOptions: Fighter[];
+  onChange: (fighter: Fighter) => void;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center justify-center gap-2"
+      role="group"
+      aria-label="Select fighter"
+    >
+      {fighterOptions.map((option) => {
+        const selected = option.id === fighter?.id;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onChange(option)}
+            aria-pressed={selected}
+            className={cn(
+              'flex flex-col items-center gap-1 rounded-md border px-2 py-1.5 transition-colors',
+              selected
+                ? 'border-primary bg-primary/10'
+                : 'border-transparent hover:border-border hover:bg-accent',
+            )}
+          >
+            <img src={option.url} alt="" className="size-12 object-contain" />
+            <span className="max-w-16 truncate text-xs text-muted-foreground">{option.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/GspHero.test.ts
+++ b/apps/web/src/pages/Gsp/components/GspHero.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { GspPoint } from '@smash-tracker/shared';
+import { getRecentGspWinRate } from './GspHero';
+
+describe('getRecentGspWinRate', () => {
+  it('returns null for an empty series', () => {
+    expect(getRecentGspWinRate([])).toBeNull();
+  });
+
+  it('computes the win rate over the whole series when shorter than the window', () => {
+    const series: GspPoint[] = [
+      { time: 1, gsp: 1000, win: true },
+      { time: 2, gsp: 1100, win: false },
+    ];
+    expect(getRecentGspWinRate(series)).toBeCloseTo(0.5);
+  });
+
+  it('restricts to the trailing window size', () => {
+    const series: GspPoint[] = [
+      { time: 1, gsp: 1000, win: false },
+      { time: 2, gsp: 1100, win: false },
+      { time: 3, gsp: 1200, win: true },
+      { time: 4, gsp: 1300, win: true },
+    ];
+    // window of 2 -> only the last two (both wins) count.
+    expect(getRecentGspWinRate(series, 2)).toBeCloseTo(1);
+  });
+});

--- a/apps/web/src/pages/Gsp/components/GspHero.tsx
+++ b/apps/web/src/pages/Gsp/components/GspHero.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { Pencil, Check, X } from 'lucide-react';
+import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import { toast } from 'sonner';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useUpdateGspSettings } from '@/hooks/useGspSettings';
+
+const ELITEGSP_URL = 'https://elitegsp.com';
+
+function HeroCard({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1">{children}</CardContent>
+    </Card>
+  );
+}
+
+/** Recent-window win rate (as a 0-1 fraction) over the trailing `windowSize` GSP-bearing matches. */
+export function getRecentGspWinRate(series: GspPoint[], windowSize = 20): number | null {
+  if (series.length === 0) return null;
+  const recent = series.slice(-windowSize);
+  const wins = recent.filter((p) => p.win).length;
+  return wins / recent.length;
+}
+
+/**
+ * GSP page hero row: current GSP reading, the user-editable Elite Smash
+ * threshold (V10 — no public API for this, so the user maintains it, linking
+ * out to elitegsp.com's crowd-sourced estimate for reference), distance to
+ * Elite (or a celebration badge once at/above it), and recent GSP win rate.
+ */
+export function GspHero({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
+  const currentGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+  const winRate = getRecentGspWinRate(series);
+  const isElite = currentGsp !== null && currentGsp >= settings.eliteThreshold;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <HeroCard label="Current GSP">
+        {currentGsp !== null ? (
+          <>
+            <span className="text-3xl font-bold">{currentGsp.toLocaleString()}</span>
+            <p className="text-sm text-muted-foreground">latest reading</p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+        )}
+      </HeroCard>
+
+      <EliteThresholdCard settings={settings} />
+
+      <HeroCard label="Distance to Elite">
+        {currentGsp === null ? (
+          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+        ) : isElite ? (
+          <span className="w-fit rounded-full bg-emerald-500/15 px-2 py-0.5 text-sm font-semibold text-emerald-500">
+            ELITE
+          </span>
+        ) : (
+          <>
+            <span className="text-3xl font-bold">
+              {(settings.eliteThreshold - currentGsp).toLocaleString()}
+            </span>
+            <p className="text-sm text-muted-foreground">GSP to go (estimate)</p>
+          </>
+        )}
+      </HeroCard>
+
+      <HeroCard label="Recent Win Rate">
+        {winRate !== null ? (
+          <>
+            <span className="text-3xl font-bold">{Math.round(winRate * 100)}%</span>
+            <p className="text-sm text-muted-foreground">
+              last {Math.min(series.length, 20)} games
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+        )}
+      </HeroCard>
+    </div>
+  );
+}
+
+function EliteThresholdCard({ settings }: { settings: GspSettings }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(settings.eliteThreshold));
+  const updateSettings = useUpdateGspSettings();
+
+  const lastUpdatedLabel =
+    settings.updatedAt > 0 ? new Date(settings.updatedAt).toLocaleDateString() : 'never set';
+
+  async function save() {
+    const parsed = Number(draft);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      toast.error('Enter a positive whole number for the Elite threshold.');
+      return;
+    }
+    try {
+      await updateSettings.mutateAsync({ eliteThreshold: parsed });
+      toast.success('Elite threshold updated!');
+      setEditing(false);
+    } catch {
+      toast.error('Failed to save the Elite threshold. Please try again.');
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">Elite Threshold</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1">
+        {editing ? (
+          <div className="flex items-center gap-1">
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              aria-label="Elite Smash threshold"
+              className="h-8 w-32"
+              autoFocus
+            />
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              aria-label="Save threshold"
+              onClick={() => void save()}
+              disabled={updateSettings.isPending}
+            >
+              <Check className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              aria-label="Cancel editing threshold"
+              onClick={() => {
+                setDraft(String(settings.eliteThreshold));
+                setEditing(false);
+              }}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1.5">
+            <span className="text-3xl font-bold">{settings.eliteThreshold.toLocaleString()}</span>
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              aria-label="Edit Elite threshold"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          As of {lastUpdatedLabel} &middot;{' '}
+          <a
+            href={ELITEGSP_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            check elitegsp.com
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
+++ b/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
@@ -1,0 +1,117 @@
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  type ChartOptions,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import type { GspPoint, Match } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
+import { computeRatingHistory } from '@/lib/glicko';
+import { GSP_VS_GLICKO_MIN_POINTS, buildGspVsGlickoData } from '../lib/gspVsGlicko';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+function buildChartData(
+  gsp: { time: number; value: number }[],
+  glicko: { time: number; value: number }[],
+) {
+  const allTimes = [...new Set([...gsp.map((p) => p.time), ...glicko.map((p) => p.time)])].sort(
+    (a, b) => a - b,
+  );
+  const labels = allTimes.map((t) =>
+    new Date(t).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  );
+
+  const gspByTime = new Map(gsp.map((p) => [p.time, p.value]));
+  const glickoByTime = new Map(glicko.map((p) => [p.time, p.value]));
+
+  return {
+    labels,
+    datasets: [
+      {
+        label: 'GSP (normalized)',
+        ...redLineDataset(),
+        spanGaps: true,
+        data: allTimes.map((t) => gspByTime.get(t) ?? null),
+      },
+      {
+        label: 'Glicko-2 (normalized)',
+        borderColor: chartColors.tick,
+        backgroundColor: chartColors.tick,
+        pointBackgroundColor: chartColors.tick,
+        pointBorderColor: chartColors.tick,
+        borderDash: [4, 4],
+        pointRadius: 3,
+        fill: false,
+        tension: 0.1,
+        spanGaps: true,
+        data: allTimes.map((t) => glickoByTime.get(t) ?? null),
+      },
+    ],
+  };
+}
+
+function buildChartOptions(): ChartOptions<'line'> {
+  const theme = darkChartOptions();
+  return {
+    responsive: theme.responsive,
+    maintainAspectRatio: theme.maintainAspectRatio,
+    scales: {
+      x: theme.scales?.x,
+      y: { ...theme.scales?.y, min: 0, max: 100 },
+    },
+    plugins: {
+      legend: { display: true, labels: theme.plugins?.legend?.labels },
+      tooltip: { ...theme.plugins?.tooltip, mode: 'index', intersect: false },
+    },
+  };
+}
+
+/**
+ * Dual-line overlay of the selected fighter's GSP curve against the player's
+ * OVERALL Glicko-2 rating history (all fighters — `computeRatingHistory`),
+ * both independently min-max normalized to 0-100 (see `buildGspVsGlickoData`)
+ * so they're visually comparable despite being on completely different
+ * scales. Skipped entirely when either series has fewer than
+ * `GSP_VS_GLICKO_MIN_POINTS` points — there's nothing meaningful to compare
+ * yet.
+ */
+export function GspVsGlicko({
+  gspSeries,
+  allMatches,
+}: {
+  gspSeries: GspPoint[];
+  allMatches: Match[];
+}) {
+  const { periods } = computeRatingHistory(allMatches);
+
+  if (gspSeries.length < GSP_VS_GLICKO_MIN_POINTS || periods.length < GSP_VS_GLICKO_MIN_POINTS) {
+    return null;
+  }
+
+  const { gsp, glicko } = buildGspVsGlickoData(gspSeries, periods);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>GSP vs Glicko-2</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="h-64">
+          <Line data={buildChartData(gsp, glicko)} options={buildChartOptions()} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Both lines are normalized to 0-100 over this window so their shapes are comparable despite
+          very different scales. Divergence usually means your quickplay form (GSP, this fighter
+          only) differs from your overall form (Glicko-2, across every fighter/session).
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import type { Fighter } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { alphaSpriteList } from '@/components/match-form/MatchForm';
+import { NO_SELECTION_STAGE } from '@/data/stages';
+import { alphaStageList, stageOptions } from '@/lib/stageOptions';
+import { StageOption } from '@/components/StageOption';
+import { useCreateMatch } from '@/hooks/useCreateMatch';
+
+/**
+ * Quick-log the core online-quickplay session loop: pick the opponent's
+ * character, mark Win/Loss, type in the GSP shown on the post-match results
+ * screen (prefilled with the last reading so most sessions only need to
+ * bump/type the delta), optionally note the stage, and submit. Uses the
+ * normal `POST /api/matches` path (via `useCreateMatch`) with `matchType:
+ * 'quickplay'` — GSP is Nintendo's online-quickplay ranking, and
+ * 'quickplay' is the existing online match-type value for it (see
+ * `matchTypeValues` in packages/shared/src/match.ts) — there is no separate
+ * "GSP entry" record type. After a successful save, the form resets for the
+ * next match (keeping "your fighter" sticky) and shows the GSP delta.
+ */
+export function QuickLogger({ fighter, lastGsp }: { fighter: Fighter; lastGsp: number | null }) {
+  const createMatch = useCreateMatch();
+  const [opponentFighterId, setOpponentFighterId] = useState<number | undefined>(undefined);
+  const [result, setResult] = useState<'win' | 'loss' | undefined>(undefined);
+  const [gspInput, setGspInput] = useState<string>(lastGsp !== null ? String(lastGsp) : '');
+  const [stageId, setStageId] = useState<number>(NO_SELECTION_STAGE.id);
+  const [submitting, setSubmitting] = useState(false);
+
+  function resetForNextMatch(nextGsp: number) {
+    setOpponentFighterId(undefined);
+    setResult(undefined);
+    setGspInput(String(nextGsp));
+    setStageId(NO_SELECTION_STAGE.id);
+  }
+
+  async function handleSubmit() {
+    if (!opponentFighterId) {
+      toast.error("Choose the opponent's character.");
+      return;
+    }
+    if (!result) {
+      toast.error('Mark this match as a win or loss.');
+      return;
+    }
+    const gsp = Number(gspInput);
+    if (!Number.isInteger(gsp) || gsp < 0) {
+      toast.error('Enter the GSP shown after the match (whole number, 0 or more).');
+      return;
+    }
+
+    const stage = stageOptions.find((s) => s.id === stageId) ?? NO_SELECTION_STAGE;
+    const delta = lastGsp !== null ? gsp - lastGsp : null;
+
+    setSubmitting(true);
+    try {
+      await createMatch.mutateAsync({
+        fighter_id: fighter.id,
+        opponent_id: opponentFighterId,
+        map: { id: stage.id, name: stage.name },
+        opponent: '',
+        notes: '',
+        matchType: 'quickplay',
+        win: result === 'win',
+        gsp,
+      });
+      const deltaLabel =
+        delta === null ? '' : ` (${delta >= 0 ? '+' : ''}${delta.toLocaleString()})`;
+      toast.success(`Match logged! GSP ${gsp.toLocaleString()}${deltaLabel}`);
+      resetForNextMatch(gsp);
+    } catch {
+      toast.error('Failed to log the match. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Quick Logger
+          <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground">
+            <img src={fighter.url} alt="" className="size-5 object-contain" />
+            {fighter.name}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="gsp-logger-opponent">
+              Opponent Character
+            </label>
+            <Select
+              value={opponentFighterId !== undefined ? String(opponentFighterId) : undefined}
+              onValueChange={(v) => setOpponentFighterId(Number(v))}
+            >
+              <SelectTrigger id="gsp-logger-opponent" className="w-full">
+                <SelectValue placeholder="Select a character" />
+              </SelectTrigger>
+              <SelectContent>
+                {alphaSpriteList.map((s) => (
+                  <SelectItem key={s.id} value={String(s.id)}>
+                    <img src={s.url} alt="" className="size-6 object-contain" />
+                    {s.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium">Result</span>
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              value={result ?? ''}
+              onValueChange={(value) => {
+                if (value === 'win' || value === 'loss') setResult(value);
+              }}
+            >
+              <ToggleGroupItem value="win" aria-label="Win">
+                Win
+              </ToggleGroupItem>
+              <ToggleGroupItem value="loss" aria-label="Loss">
+                Loss
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="gsp-logger-gsp">
+              GSP After Match
+            </label>
+            <Input
+              id="gsp-logger-gsp"
+              type="number"
+              min={0}
+              step={1}
+              value={gspInput}
+              onChange={(e) => setGspInput(e.target.value)}
+              placeholder="e.g. 9420000"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="gsp-logger-stage">
+              Stage (optional)
+            </label>
+            <Select value={String(stageId)} onValueChange={(v) => setStageId(Number(v))}>
+              <SelectTrigger id="gsp-logger-stage" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={String(NO_SELECTION_STAGE.id)}>
+                  {NO_SELECTION_STAGE.name}
+                </SelectItem>
+                <SelectGroup>
+                  <SelectLabel>All stages</SelectLabel>
+                  {alphaStageList.map((s) => (
+                    <SelectItem key={s.id} value={String(s.id)}>
+                      <StageOption stage={s} />
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
+          {submitting ? 'Logging...' : 'Log Match'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/components/RoadToElite.tsx
+++ b/apps/web/src/pages/Gsp/components/RoadToElite.tsx
@@ -1,0 +1,69 @@
+import { PartyPopper } from 'lucide-react';
+import type { GspPoint } from '@smash-tracker/shared';
+import { projectMatchesToElite } from '@smash-tracker/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getRecentGspWinRate } from './GspHero';
+
+/**
+ * The GSP page's projection card — "how many more matches at my current win
+ * rate until I hit Elite Smash". Built entirely on `projectMatchesToElite`
+ * (packages/shared/src/gsp.ts), which fits an exponential decay of per-win
+ * GSP gain from the player's own history (falling back to a cruder flat
+ * average with too little data). Always shown alongside the model's
+ * `assumptions` and a reminder that GSP's real formula isn't public — this is
+ * a simulation, not a guarantee.
+ */
+export function RoadToElite({
+  series,
+  eliteThreshold,
+}: {
+  series: GspPoint[];
+  eliteThreshold: number;
+}) {
+  const currentGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+  const winRate = getRecentGspWinRate(series) ?? 0;
+  const isElite = currentGsp !== null && currentGsp >= eliteThreshold;
+
+  const projection =
+    currentGsp === null || isElite ? null : projectMatchesToElite(series, eliteThreshold, winRate);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Road to Elite</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {currentGsp === null ? (
+          <p className="text-sm text-muted-foreground">
+            Log a match with a GSP reading for this fighter to see a projection.
+          </p>
+        ) : isElite ? (
+          <div className="flex items-center gap-2 text-emerald-500">
+            <PartyPopper className="size-6" />
+            <p className="text-lg font-semibold">You&apos;re already in Elite Smash!</p>
+          </div>
+        ) : projection ? (
+          <>
+            <p className="text-2xl font-bold">
+              ~{projection.matchesNeededLabel} more match
+              {projection.matchesNeededLabel === '1' ? '' : 'es'}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              at your current {Math.round(winRate * 100)}% win rate (estimate)
+            </p>
+            <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+              {projection.assumptions.map((assumption) => (
+                <li key={assumption}>{assumption}</li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Not enough win/loss history with GSP readings yet to project a path to Elite. Keep
+            logging matches — this needs a handful of wins to fit a trend.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/Gsp/lib/gspFighters.test.ts
+++ b/apps/web/src/pages/Gsp/lib/gspFighters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@smash-tracker/shared';
+import { getGspFighterOptions } from './gspFighters';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'>): Match {
+  return {
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'quickplay',
+    ...overrides,
+  };
+}
+
+describe('getGspFighterOptions', () => {
+  it('returns an empty list with no matches and no fighter selections', () => {
+    expect(getGspFighterOptions([])).toEqual([]);
+  });
+
+  it('includes a fighter with at least one gsp-bearing match', () => {
+    const matches = [makeMatch({ id: '1', time: 1, win: true, fighter_id: 1, gsp: 1000 })];
+    const options = getGspFighterOptions(matches);
+    expect(options.map((f) => f.id)).toContain(1);
+  });
+
+  it('excludes fighters with matches but no gsp reading', () => {
+    const matches = [makeMatch({ id: '1', time: 1, win: true, fighter_id: 1 })];
+    expect(getGspFighterOptions(matches)).toEqual([]);
+  });
+
+  it('includes primary/secondary fighters even with no gsp matches', () => {
+    const options = getGspFighterOptions([], [1], [2]);
+    expect(options.map((f) => f.id).sort()).toEqual([1, 2]);
+  });
+
+  it('de-duplicates fighters appearing in both matches and selections', () => {
+    const matches = [makeMatch({ id: '1', time: 1, win: true, fighter_id: 1, gsp: 1000 })];
+    const options = getGspFighterOptions(matches, [1]);
+    expect(options.filter((f) => f.id === 1)).toHaveLength(1);
+  });
+
+  it('sorts results alphabetically by name', () => {
+    // Fighter ids 1 (Mario) and 8 (Fox) per fighterData — Fox should sort before Mario.
+    const matches = [
+      makeMatch({ id: '1', time: 1, win: true, fighter_id: 1, gsp: 1000 }),
+      makeMatch({ id: '2', time: 2, win: true, fighter_id: 8, gsp: 1000 }),
+    ];
+    const options = getGspFighterOptions(matches);
+    const names = options.map((f) => f.name);
+    expect([...names].sort((a, b) => a.localeCompare(b))).toEqual(names);
+  });
+
+  it('ignores unknown fighter ids gracefully', () => {
+    const options = getGspFighterOptions([], [999999]);
+    expect(options).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Gsp/lib/gspFighters.ts
+++ b/apps/web/src/pages/Gsp/lib/gspFighters.ts
@@ -1,0 +1,31 @@
+import type { Fighter, Match } from '@smash-tracker/shared';
+import { getFighterById } from '@/data/sprites';
+
+/**
+ * Fighters offered by the GSP page's selector: every fighter with at least
+ * one gsp-bearing match, PLUS the user's primary/secondary picks as
+ * always-available suggestions (so a player who hasn't logged a GSP match
+ * yet for their main still sees it in the list rather than an empty
+ * selector). De-duplicated, sorted alphabetically like the rest of the app's
+ * fighter pickers (see `alphaSpriteList` in MatchForm.tsx).
+ */
+export function getGspFighterOptions(
+  matches: Match[],
+  primaryIds: number[] = [],
+  secondaryIds: number[] = [],
+): Fighter[] {
+  const ids = new Set<number>();
+  for (const match of matches) {
+    if (match.gsp !== undefined) {
+      ids.add(match.fighter_id);
+    }
+  }
+  for (const id of [...primaryIds, ...secondaryIds]) {
+    ids.add(id);
+  }
+
+  return [...ids]
+    .map((id) => getFighterById(id))
+    .filter((fighter): fighter is Fighter => fighter != null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/web/src/pages/Gsp/lib/gspVsGlicko.test.ts
+++ b/apps/web/src/pages/Gsp/lib/gspVsGlicko.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { GspPoint } from '@smash-tracker/shared';
+import type { RatingPeriodResult } from '@/lib/glicko';
+import { buildGspVsGlickoData, minMaxNormalize } from './gspVsGlicko';
+
+describe('minMaxNormalize', () => {
+  it('returns an empty array for empty input', () => {
+    expect(minMaxNormalize([])).toEqual([]);
+  });
+
+  it('maps min to 0 and max to 100', () => {
+    const result = minMaxNormalize([1000, 2000, 3000]);
+    expect(result[0]).toBeCloseTo(0);
+    expect(result[2]).toBeCloseTo(100);
+    expect(result[1]).toBeCloseTo(50);
+  });
+
+  it('returns a flat 50 line when every value is identical (zero range)', () => {
+    expect(minMaxNormalize([500, 500, 500])).toEqual([50, 50, 50]);
+  });
+
+  it('handles a single value as a flat 50', () => {
+    expect(minMaxNormalize([42])).toEqual([50]);
+  });
+});
+
+describe('buildGspVsGlickoData', () => {
+  function ratingPeriod(overrides: Partial<RatingPeriodResult>): RatingPeriodResult {
+    return { start: 0, end: 0, games: 1, rating: 1500, rd: 100, volatility: 0.06, ...overrides };
+  }
+
+  it('normalizes both series independently and pairs each with its own time value', () => {
+    const gspSeries: GspPoint[] = [
+      { time: 10, gsp: 1_000_000, win: true },
+      { time: 20, gsp: 2_000_000, win: true },
+    ];
+    const ratingPeriods: RatingPeriodResult[] = [
+      ratingPeriod({ end: 15, rating: 1400 }),
+      ratingPeriod({ end: 25, rating: 1600 }),
+    ];
+
+    const data = buildGspVsGlickoData(gspSeries, ratingPeriods);
+
+    expect(data.gsp).toEqual([
+      { time: 10, value: 0 },
+      { time: 20, value: 100 },
+    ]);
+    expect(data.glicko).toEqual([
+      { time: 15, value: 0 },
+      { time: 25, value: 100 },
+    ]);
+  });
+
+  it('returns empty arrays for empty input series', () => {
+    const data = buildGspVsGlickoData([], []);
+    expect(data.gsp).toEqual([]);
+    expect(data.glicko).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Gsp/lib/gspVsGlicko.ts
+++ b/apps/web/src/pages/Gsp/lib/gspVsGlicko.ts
@@ -1,0 +1,55 @@
+import type { GspPoint } from '@smash-tracker/shared';
+import type { RatingPeriodResult } from '@/lib/glicko';
+
+/** Minimum points required in EITHER series before the "GSP vs Glicko-2" card renders. */
+export const GSP_VS_GLICKO_MIN_POINTS = 3;
+
+/** One point in the normalized overlay series, keyed by time so both lines share an x-axis. */
+export interface NormalizedPoint {
+  time: number;
+  /** Min-max normalized to 0-100 within its own series. */
+  value: number;
+}
+
+/**
+ * Min-max normalizes `values` to the 0-100 range. When every value is
+ * identical (zero range), returns 50 for every point (a flat mid-line) rather
+ * than dividing by zero.
+ */
+export function minMaxNormalize(values: number[]): number[] {
+  if (values.length === 0) return [];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  if (range === 0) {
+    return values.map(() => 50);
+  }
+  return values.map((v) => ((v - min) / range) * 100);
+}
+
+export interface GspVsGlickoData {
+  gsp: NormalizedPoint[];
+  glicko: NormalizedPoint[];
+}
+
+/**
+ * Builds the two normalized series for the "GSP vs Glicko-2" overlay: the
+ * selected fighter's GSP readings vs. the player's overall Glicko-2 rating
+ * history (ALL fighters — see `computeRatingHistory`), each independently
+ * min-max normalized to 0-100 so they're comparable on one axis despite being
+ * on wildly different scales (GSP in the millions, Glicko ~1000-2000).
+ * `glicko` uses each rating period's END time (`RatingPeriodResult.end`) as
+ * its x-value, since a period covers a whole session rather than one instant.
+ */
+export function buildGspVsGlickoData(
+  gspSeries: GspPoint[],
+  ratingPeriods: RatingPeriodResult[],
+): GspVsGlickoData {
+  const gspValues = minMaxNormalize(gspSeries.map((p) => p.gsp));
+  const glickoValues = minMaxNormalize(ratingPeriods.map((p) => p.rating));
+
+  return {
+    gsp: gspSeries.map((p, i) => ({ time: p.time, value: gspValues[i]! })),
+    glicko: ratingPeriods.map((p, i) => ({ time: p.end, value: glickoValues[i]! })),
+  };
+}

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -9,6 +9,7 @@ import { ScoutPage } from '@/pages/Scout/ScoutPage';
 import { ReportsPage } from '@/pages/Reports/ReportsPage';
 import { MatchDataPage } from '@/pages/MatchData/MatchDataPage';
 import { TrendsPage } from '@/pages/Trends/TrendsPage';
+import { GspPage } from '@/pages/Gsp/GspPage';
 import { GroupsPage } from '@/pages/Groups/GroupsPage';
 import { TournamentDetailPage } from '@/pages/Tournaments/TournamentDetailPage';
 import { FighterAnalysisPage } from '@/pages/FighterAnalysis/FighterAnalysisPage';
@@ -106,6 +107,14 @@ export function AppRouter() {
           element={
             <ProtectedRoute>
               <TrendsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/gsp"
+          element={
+            <ProtectedRoute>
+              <GspPage />
             </ProtectedRoute>
           }
         />

--- a/packages/shared/src/gsp.test.ts
+++ b/packages/shared/src/gsp.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from './match.js';
+import {
+  DEFAULT_ELITE_THRESHOLD,
+  MAX_SIMULATED_MATCHES,
+  MIN_OBSERVATIONS_FOR_DECAY_FIT,
+  MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK,
+  fitGainDecay,
+  getGspGainStats,
+  getGspSeries,
+  gspSettingsSchema,
+  projectMatchesToElite,
+  upsertGspSettingsInputSchema,
+  type GspPoint,
+} from './gsp.js';
+
+function makeMatch(overrides: Partial<Match> & Pick<Match, 'time' | 'win'>): Match {
+  return {
+    id: 'x',
+    fighter_id: 1,
+    opponent_id: 2,
+    map: { id: 0, name: 'no selection' },
+    opponent: '',
+    notes: '',
+    matchType: 'quickplay',
+    ...overrides,
+  };
+}
+
+describe('gspSettingsSchema / upsertGspSettingsInputSchema', () => {
+  it('accepts a valid settings object', () => {
+    const parsed = gspSettingsSchema.parse({ eliteThreshold: 10_000_000, updatedAt: 123 });
+    expect(parsed.eliteThreshold).toBe(10_000_000);
+  });
+
+  it('rejects a non-positive threshold', () => {
+    expect(() => gspSettingsSchema.parse({ eliteThreshold: 0, updatedAt: 123 })).toThrow();
+    expect(() => gspSettingsSchema.parse({ eliteThreshold: -5, updatedAt: 123 })).toThrow();
+  });
+
+  it('the upsert input omits updatedAt (server-stamped)', () => {
+    const parsed = upsertGspSettingsInputSchema.parse({ eliteThreshold: 5_000_000 });
+    expect(parsed).toEqual({ eliteThreshold: 5_000_000 });
+  });
+
+  it('DEFAULT_ELITE_THRESHOLD is a plausible positive placeholder', () => {
+    expect(DEFAULT_ELITE_THRESHOLD).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_ELITE_THRESHOLD)).toBe(true);
+  });
+});
+
+describe('getGspSeries', () => {
+  it('returns an empty array when no matches carry gsp', () => {
+    const matches = [makeMatch({ time: 1, win: true, fighter_id: 1 })];
+    expect(getGspSeries(matches, 1)).toEqual([]);
+  });
+
+  it('filters to the requested fighter only', () => {
+    const matches = [
+      makeMatch({ time: 1, win: true, fighter_id: 1, gsp: 1000 }),
+      makeMatch({ time: 2, win: true, fighter_id: 2, gsp: 5000 }),
+    ];
+    const series = getGspSeries(matches, 1);
+    expect(series).toEqual([{ time: 1, gsp: 1000, win: true }]);
+  });
+
+  it('sorts chronologically regardless of input order', () => {
+    const matches = [
+      makeMatch({ time: 300, win: false, fighter_id: 1, gsp: 900 }),
+      makeMatch({ time: 100, win: true, fighter_id: 1, gsp: 1000 }),
+      makeMatch({ time: 200, win: true, fighter_id: 1, gsp: 1200 }),
+    ];
+    const series = getGspSeries(matches, 1);
+    expect(series.map((p) => p.time)).toEqual([100, 200, 300]);
+  });
+
+  it('skips matches for the fighter with no gsp reading', () => {
+    const matches = [
+      makeMatch({ time: 1, win: true, fighter_id: 1, gsp: 1000 }),
+      makeMatch({ time: 2, win: true, fighter_id: 1 }),
+    ];
+    expect(getGspSeries(matches, 1)).toEqual([{ time: 1, gsp: 1000, win: true }]);
+  });
+});
+
+describe('getGspGainStats', () => {
+  it('returns all-null/empty stats for a series with fewer than 2 points (no steps)', () => {
+    const series: GspPoint[] = [{ time: 1, gsp: 1000, win: true }];
+    const stats = getGspGainStats(series);
+    expect(stats.avgGainPerWinLifetime).toBeNull();
+    expect(stats.avgDropPerLossLifetime).toBeNull();
+    expect(stats.biggestGain).toBeNull();
+    expect(stats.biggestDrop).toBeNull();
+    expect(stats.perWinGains).toEqual([]);
+    expect(stats.gainTrend).toBe('flat');
+  });
+
+  it('computes lifetime avg gain/drop and biggest gain/drop', () => {
+    const series: GspPoint[] = [
+      { time: 1, gsp: 1000, win: true },
+      { time: 2, gsp: 1100, win: true }, // +100
+      { time: 3, gsp: 1050, win: false }, // -50
+      { time: 4, gsp: 1250, win: true }, // +200
+      { time: 5, gsp: 1150, win: false }, // -100
+    ];
+    const stats = getGspGainStats(series);
+    expect(stats.avgGainPerWinLifetime).toBeCloseTo(150); // (100+200)/2
+    expect(stats.avgDropPerLossLifetime).toBeCloseTo(75); // (50+100)/2
+    expect(stats.biggestGain).toBe(200);
+    expect(stats.biggestDrop).toBe(100);
+    expect(stats.perWinGains).toEqual([100, 200]);
+  });
+
+  it('restricts the "last 20" stats to the trailing 20 steps', () => {
+    const series: GspPoint[] = [{ time: 0, gsp: 0, win: true }];
+    // 25 win-steps of +10 each, then a final loss-step of -1000 far more
+    // recent than the older wins — last-20 should exclude the 5 oldest wins.
+    for (let i = 1; i <= 25; i += 1) {
+      series.push({ time: i, gsp: series[i - 1]!.gsp + 10, win: true });
+    }
+    series.push({ time: 26, gsp: series[25]!.gsp - 1000, win: false });
+
+    const stats = getGspGainStats(series);
+    // Lifetime: 25 win-steps all +10.
+    expect(stats.avgGainPerWinLifetime).toBeCloseTo(10);
+    // Last 20 steps = steps 7..26 (20 steps): 19 win-steps of +10 + 1 loss-step.
+    expect(stats.avgGainPerWinLast20).toBeCloseTo(10);
+    expect(stats.avgDropPerLossLast20).toBeCloseTo(1000);
+    // Lifetime loss stat should also just be the one loss-step.
+    expect(stats.avgDropPerLossLifetime).toBeCloseTo(1000);
+  });
+
+  it('flags a shrinking trend when per-win gains decrease over time', () => {
+    const series: GspPoint[] = [{ time: 0, gsp: 0, win: true }];
+    const gains = [500, 400, 300, 200, 100];
+    let gsp = 0;
+    gains.forEach((g, i) => {
+      gsp += g;
+      series.push({ time: i + 1, gsp, win: true });
+    });
+    expect(getGspGainStats(series).gainTrend).toBe('shrinking');
+  });
+
+  it('flags a growing trend when per-win gains increase over time', () => {
+    const series: GspPoint[] = [{ time: 0, gsp: 0, win: true }];
+    const gains = [100, 200, 300, 400, 500];
+    let gsp = 0;
+    gains.forEach((g, i) => {
+      gsp += g;
+      series.push({ time: i + 1, gsp, win: true });
+    });
+    expect(getGspGainStats(series).gainTrend).toBe('growing');
+  });
+
+  it('flags a flat trend when per-win gains stay roughly constant', () => {
+    const series: GspPoint[] = [{ time: 0, gsp: 0, win: true }];
+    let gsp = 0;
+    for (let i = 0; i < 5; i += 1) {
+      gsp += 100;
+      series.push({ time: i + 1, gsp, win: true });
+    }
+    expect(getGspGainStats(series).gainTrend).toBe('flat');
+  });
+});
+
+describe('fitGainDecay', () => {
+  function winStep(fromGsp: number, delta: number) {
+    return { fromGsp, delta, win: true as const };
+  }
+
+  it('returns null with fewer than MIN_OBSERVATIONS_FOR_DECAY_FIT win-steps', () => {
+    const steps = Array.from({ length: MIN_OBSERVATIONS_FOR_DECAY_FIT - 1 }, (_, i) =>
+      winStep(i * 1000, 100),
+    );
+    expect(fitGainDecay(steps)).toBeNull();
+  });
+
+  it('returns null when any gain is non-positive (cannot take a log)', () => {
+    const steps = [
+      winStep(1000, 100),
+      winStep(2000, 90),
+      winStep(3000, 0),
+      winStep(4000, 70),
+      winStep(5000, 60),
+    ];
+    expect(fitGainDecay(steps)).toBeNull();
+  });
+
+  it('returns null when all fromGsp values are identical (no x-variance)', () => {
+    const steps = Array.from({ length: 6 }, () => winStep(5000, 100));
+    expect(fitGainDecay(steps)).toBeNull();
+  });
+
+  it('returns null when the fitted decay rate is non-negative (gains not shrinking)', () => {
+    // Gains increasing with GSP — decay rate b should come back >= 0, so the
+    // model is rejected rather than projecting ever-increasing gains.
+    const steps = [
+      winStep(1000, 50),
+      winStep(2000, 60),
+      winStep(3000, 70),
+      winStep(4000, 80),
+      winStep(5000, 90),
+      winStep(6000, 100),
+    ];
+    expect(fitGainDecay(steps)).toBeNull();
+  });
+
+  it('fits a valid exponential decay from clean synthetic data', () => {
+    // gain(gsp) = 500 * exp(-0.0005 * gsp), sampled exactly (no noise).
+    const a = 500;
+    const b = -0.0005;
+    const steps = [0, 1000, 2000, 3000, 4000, 5000].map((gsp) =>
+      winStep(gsp, a * Math.exp(b * gsp)),
+    );
+    const fit = fitGainDecay(steps);
+    expect(fit).not.toBeNull();
+    expect(fit!.a).toBeCloseTo(a, 5);
+    expect(fit!.b).toBeCloseTo(b, 5);
+  });
+});
+
+describe('projectMatchesToElite', () => {
+  it('returns null for an empty series', () => {
+    expect(projectMatchesToElite([], DEFAULT_ELITE_THRESHOLD, 0.6)).toBeNull();
+  });
+
+  it('returns null (already Elite) when current gsp is at or above threshold', () => {
+    const series: GspPoint[] = [{ time: 1, gsp: 10_000_000, win: true }];
+    expect(projectMatchesToElite(series, 10_000_000, 0.6)).toBeNull();
+    expect(projectMatchesToElite(series, 9_000_000, 0.6)).toBeNull();
+  });
+
+  it('returns null when recent win rate is zero or negative', () => {
+    const series: GspPoint[] = [
+      { time: 1, gsp: 1_000_000, win: true },
+      { time: 2, gsp: 1_100_000, win: true },
+    ];
+    expect(projectMatchesToElite(series, 2_000_000, 0)).toBeNull();
+    expect(projectMatchesToElite(series, 2_000_000, -0.1)).toBeNull();
+  });
+
+  it('returns null (insufficient data) below MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK win-steps', () => {
+    // Only one win-step total.
+    const series: GspPoint[] = [
+      { time: 1, gsp: 1_000_000, win: false },
+      { time: 2, gsp: 1_100_000, win: true },
+    ];
+    expect(MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK).toBeGreaterThan(1);
+    expect(projectMatchesToElite(series, 2_000_000, 0.6)).toBeNull();
+  });
+
+  it('uses the linear-average fallback with a thin but non-degenerate sample', () => {
+    // Exactly at the linear-fallback floor, below the decay-fit floor.
+    const series: GspPoint[] = [{ time: 0, gsp: 1_000_000, win: true }];
+    let gsp = 1_000_000;
+    for (let i = 0; i < MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK; i += 1) {
+      gsp += 50_000;
+      series.push({ time: i + 1, gsp, win: true });
+    }
+    const result = projectMatchesToElite(series, gsp + 500_000, 0.6);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('linear-average');
+    expect(result!.matchesNeeded).toBeGreaterThan(0);
+    expect(result!.assumptions.length).toBeGreaterThan(0);
+  });
+
+  it('uses the exponential-decay model with a rich, cleanly-decaying sample', () => {
+    const series: GspPoint[] = [{ time: 0, gsp: 1_000_000, win: true }];
+    let gsp = 1_000_000;
+    // Alternate win (shrinking gain the higher gsp climbs) / loss (fixed drop).
+    for (let i = 0; i < 20; i += 1) {
+      const gain = 20_000 * Math.exp(-0.0000005 * gsp);
+      gsp += gain;
+      series.push({ time: series.length, gsp, win: true });
+      gsp -= 5_000;
+      series.push({ time: series.length, gsp, win: false });
+    }
+    const currentGsp = series[series.length - 1]!.gsp;
+    const result = projectMatchesToElite(series, currentGsp + 100_000, 0.6);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('exponential-decay');
+    expect(result!.matchesNeeded).toBeGreaterThan(0);
+  });
+
+  it('falls back to linear-average when the decay fit is degenerate despite enough observations', () => {
+    // >= MIN_OBSERVATIONS_FOR_DECAY_FIT win-steps but gains increasing with
+    // gsp (fitGainDecay rejects this), so it should fall back rather than
+    // returning null.
+    const series: GspPoint[] = [{ time: 0, gsp: 1_000_000, win: true }];
+    let gsp = 1_000_000;
+    const gains = [10_000, 12_000, 14_000, 16_000, 18_000, 20_000];
+    gains.forEach((g, i) => {
+      gsp += g;
+      series.push({ time: i + 1, gsp, win: true });
+    });
+    const result = projectMatchesToElite(series, gsp + 200_000, 0.6);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('linear-average');
+  });
+
+  it('caps simulation at MAX_SIMULATED_MATCHES and reports the capped label', () => {
+    // Tiny, slow gains vs. a far-away threshold — should hit the cap.
+    const series: GspPoint[] = [{ time: 0, gsp: 0, win: true }];
+    let gsp = 0;
+    for (let i = 0; i < 6; i += 1) {
+      gsp += 1; // flat, non-decaying-enough gain (constant, effectively b ~ 0 fails decay fit's b<0 requirement isn't guaranteed, but linear works regardless)
+      series.push({ time: i + 1, gsp, win: true });
+    }
+    const result = projectMatchesToElite(series, gsp + 10_000_000, 0.55);
+    expect(result).not.toBeNull();
+    if (result!.matchesNeeded === null) {
+      expect(result!.matchesNeededLabel).toBe(`more than ${MAX_SIMULATED_MATCHES}`);
+    } else {
+      // If somehow it didn't cap, at minimum it should be a huge number of matches.
+      expect(result!.matchesNeeded).toBeGreaterThan(1000);
+    }
+  });
+
+  it('returns null when expected progress per match is zero or negative under either model', () => {
+    // Losses on average bigger than gains at a low win rate — no forward progress.
+    const series: GspPoint[] = [{ time: 0, gsp: 1_000_000, win: true }];
+    let gsp = 1_000_000;
+    const deltas: Array<{ win: boolean; delta: number }> = [
+      { win: true, delta: 100 },
+      { win: false, delta: -100_000 },
+      { win: true, delta: 90 },
+      { win: false, delta: -90_000 },
+      { win: true, delta: 80 },
+      { win: false, delta: -80_000 },
+    ];
+    deltas.forEach(({ win, delta }, i) => {
+      gsp += delta;
+      series.push({ time: i + 1, gsp, win });
+    });
+    const result = projectMatchesToElite(series, gsp + 1_000_000, 0.1);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/shared/src/gsp.ts
+++ b/packages/shared/src/gsp.ts
@@ -1,0 +1,334 @@
+import { z } from 'zod';
+import type { Match } from './match.js';
+
+/**
+ * GSP (Global Smash Power) is Smash Ultimate's online quickplay ranking: the
+ * number of players you're estimated to outrank, derived from a hidden
+ * Elo-like rating over a roughly-normal skill distribution. Nintendo never
+ * published the formula (sources: ssbwiki.com/Global_Smash_Power,
+ * smashboards.com/threads/how-gsp-works.511478/). Two consequences we model
+ * in this file, both straight from that research:
+ *
+ *   1. Gains per win SHRINK as GSP grows — you're further into the bell
+ *      curve's tail, so each win outranks a smaller slice of the remaining
+ *      population. `projectMatchesToElite` fits this shrinkage from the
+ *      player's own history rather than assuming a fixed formula.
+ *   2. A fresh character's first few matches swing wildly (small sample
+ *      against a rating system that hasn't converged yet) — reflected here
+ *      by treating a handful of gain observations as too little to trust a
+ *      curve fit (see `MIN_OBSERVATIONS_FOR_DECAY_FIT` below).
+ *
+ * GSP is PER CHARACTER — every function here takes a specific `fighterId`
+ * and only looks at matches for that fighter.
+ *
+ * Everything derived here is an ESTIMATE. There is no public GSP API and
+ * projections are simulations built on a curve fit to a handful of data
+ * points — the UI must present them as such.
+ */
+
+/**
+ * `gspSettings/{uid}` — the user-maintained "what does Elite Smash require
+ * right now" threshold. There is no public Elite Smash API: entry cutoffs
+ * are estimated by the community (elitegsp.com aggregates crowd-sourced
+ * submissions) and drift upward roughly continuously as more players clear
+ * the bar. We link out to elitegsp.com with attribution rather than scrape
+ * it, and let the user type in (and periodically update) the number
+ * themselves.
+ */
+export const gspSettingsSchema = z.object({
+  /** The user's current best estimate of their fighter's Elite Smash entry threshold. */
+  eliteThreshold: z.number().int().positive(),
+  /** Epoch ms this was last saved — server-stamped, drives the "as of" date in the UI. */
+  updatedAt: z.number(),
+});
+export type GspSettings = z.infer<typeof gspSettingsSchema>;
+
+/** PUT /api/gsp-settings body — `updatedAt` is server-stamped, same convention as `opponentNoteSchema`. */
+export const upsertGspSettingsInputSchema = gspSettingsSchema.omit({ updatedAt: true });
+export type UpsertGspSettingsInput = z.infer<typeof upsertGspSettingsInputSchema>;
+
+/**
+ * Placeholder default Elite Smash threshold for a brand-new user who hasn't
+ * set their own yet. Elite cutoffs vary a lot by character popularity and
+ * climb ~200-300k/week (per elitegsp.com's tracked history around the time
+ * this was written, mid-2024) — this is a plausible mid-pack magnitude for a
+ * moderately popular character, NOT a real-time figure. It exists purely so
+ * the "distance to Elite" card has something to render before the user edits
+ * it; the UI always shows the "check elitegsp.com" link + last-updated date
+ * alongside it so the placeholder nature is obvious.
+ */
+export const DEFAULT_ELITE_THRESHOLD = 10_300_000;
+
+/** One chronological GSP reading for a specific fighter. */
+export interface GspPoint {
+  /** Epoch ms of the match this reading came from. */
+  time: number;
+  /** The post-match GSP reading. */
+  gsp: number;
+  /** Whether that match was a win. */
+  win: boolean;
+}
+
+/**
+ * Chronological GSP readings for `fighterId`, built from every match that
+ * carries a `gsp` value for that fighter. Matches without a `gsp` reading
+ * (offline sets, or online sets the player didn't log GSP for) are skipped
+ * entirely rather than interpolated — we only ever plot/analyze real
+ * readings.
+ */
+export function getGspSeries(matches: Match[], fighterId: number): GspPoint[] {
+  return matches
+    .filter((m) => m.fighter_id === fighterId && m.gsp !== undefined)
+    .map((m) => ({ time: m.time, gsp: m.gsp!, win: m.win }))
+    .sort((a, b) => a.time - b.time);
+}
+
+/** One step between two consecutive GSP readings. */
+interface GspStep {
+  /** GSP level the step started from (used as the x-value when fitting decay). */
+  fromGsp: number;
+  /** Signed change in GSP for this step (positive on a win-step, typically negative on a loss-step). */
+  delta: number;
+  win: boolean;
+}
+
+function toSteps(series: GspPoint[]): GspStep[] {
+  const steps: GspStep[] = [];
+  for (let i = 1; i < series.length; i += 1) {
+    steps.push({
+      fromGsp: series[i - 1]!.gsp,
+      delta: series[i]!.gsp - series[i - 1]!.gsp,
+      win: series[i]!.win,
+    });
+  }
+  return steps;
+}
+
+/** Average of a number array, or `null` for an empty array. */
+function average(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Simple trend label for the sequence of per-win gains over time: fits a
+ * least-squares line against step index and reports whether the slope is
+ * meaningfully negative (shrinking, the expected GSP pattern), meaningfully
+ * positive (growing), or flat. "Meaningful" is anchored to the sequence's own
+ * average gain so the threshold scales with the player's GSP bracket rather
+ * than a fixed magnitude.
+ */
+function gainTrend(gains: number[]): 'shrinking' | 'growing' | 'flat' {
+  if (gains.length < 2) return 'flat';
+  const n = gains.length;
+  const xMean = (n - 1) / 2;
+  const yMean = gains.reduce((sum, v) => sum + v, 0) / n;
+  let num = 0;
+  let den = 0;
+  gains.forEach((y, x) => {
+    num += (x - xMean) * (y - yMean);
+    den += (x - xMean) * (x - xMean);
+  });
+  const slope = den === 0 ? 0 : num / den;
+  const scale = Math.abs(yMean) || 1;
+  const relativeSlope = (slope * n) / scale;
+  if (relativeSlope < -0.15) return 'shrinking';
+  if (relativeSlope > 0.15) return 'growing';
+  return 'flat';
+}
+
+export interface GspGainStats {
+  /** Average GSP gained on a win-step, over the whole series. `null` when there are no win-steps. */
+  avgGainPerWinLifetime: number | null;
+  /** Average GSP lost on a loss-step, over the whole series (positive magnitude). `null` when there are no loss-steps. */
+  avgDropPerLossLifetime: number | null;
+  /** Same as `avgGainPerWinLifetime`, restricted to the last 20 steps. */
+  avgGainPerWinLast20: number | null;
+  /** Same as `avgDropPerLossLifetime`, restricted to the last 20 steps. */
+  avgDropPerLossLast20: number | null;
+  /** The single largest GSP gain observed on any win-step. `null` when there are no win-steps. */
+  biggestGain: number | null;
+  /** The single largest GSP drop (magnitude) observed on any loss-step. `null` when there are no loss-steps. */
+  biggestDrop: number | null;
+  /** Chronological per-win gains (for sparking/bar-charting the shrink over time). */
+  perWinGains: number[];
+  /** Whether per-win gains are trending down (expected as GSP climbs), up, or flat. */
+  gainTrend: 'shrinking' | 'growing' | 'flat';
+}
+
+const LAST_N = 20;
+
+/** Derives win/loss gain statistics from a chronological `GspPoint[]` (see `getGspSeries`). */
+export function getGspGainStats(series: GspPoint[]): GspGainStats {
+  const steps = toSteps(series);
+  const winSteps = steps.filter((s) => s.win);
+  const lossSteps = steps.filter((s) => !s.win);
+  const last20Steps = steps.slice(-LAST_N);
+  const last20WinSteps = last20Steps.filter((s) => s.win);
+  const last20LossSteps = last20Steps.filter((s) => !s.win);
+
+  const winGains = winSteps.map((s) => s.delta);
+  const lossDrops = lossSteps.map((s) => -s.delta);
+
+  return {
+    avgGainPerWinLifetime: average(winGains),
+    avgDropPerLossLifetime: average(lossDrops),
+    avgGainPerWinLast20: average(last20WinSteps.map((s) => s.delta)),
+    avgDropPerLossLast20: average(last20LossSteps.map((s) => -s.delta)),
+    biggestGain: winGains.length > 0 ? Math.max(...winGains) : null,
+    biggestDrop: lossDrops.length > 0 ? Math.max(...lossDrops) : null,
+    perWinGains: winGains,
+    gainTrend: gainTrend(winGains),
+  };
+}
+
+/** Minimum win-gain observations required to fit the exponential decay curve; below this the model would be overfit to noise. */
+export const MIN_OBSERVATIONS_FOR_DECAY_FIT = 5;
+/** Below this many win-gain observations, projection is impossible even with the cruder fallback — the "insufficient data" floor. */
+export const MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK = 2;
+/** Hard cap on simulated matches — beyond this we just say "more than N". */
+export const MAX_SIMULATED_MATCHES = 2000;
+
+export interface EliteProjection {
+  /** Simulated number of matches until GSP reaches the threshold, or `null` when the cap was hit (see `matchesNeededLabel`). */
+  matchesNeeded: number | null;
+  /** Human-facing label: the number, or `"more than 2000"` when the simulation cap was hit. */
+  matchesNeededLabel: string;
+  /** Whether the projection used the full exponential-decay fit, or the cruder linear-average fallback (few observations). */
+  model: 'exponential-decay' | 'linear-average';
+  assumptions: string[];
+}
+
+/**
+ * Least-squares fit of `ln(gain) = ln(a) + b * gsp` over win-steps, i.e. an
+ * exponential decay `gain(gsp) = a * exp(b * gsp)` of per-win GSP gain as a
+ * function of the GSP level the win happened at — modeling the "gains shrink
+ * as you climb" behavior described at the top of this file, fit from the
+ * player's OWN history rather than any assumed universal formula.
+ *
+ * Returns `null` when the fit is degenerate: fewer than
+ * `MIN_OBSERVATIONS_FOR_DECAY_FIT` win-steps, non-positive gains (can't take
+ * a log), all `fromGsp` values identical (no x-variance to regress against),
+ * or a fitted decay rate `b >= 0` (not actually decaying — the model doesn't
+ * apply, so we fall back rather than project using a curve that predicts
+ * gains INCREASING with GSP).
+ */
+export function fitGainDecay(winSteps: GspStep[]): { a: number; b: number } | null {
+  if (winSteps.length < MIN_OBSERVATIONS_FOR_DECAY_FIT) return null;
+  if (winSteps.some((s) => s.delta <= 0)) return null;
+
+  const xs = winSteps.map((s) => s.fromGsp);
+  const ys = winSteps.map((s) => Math.log(s.delta));
+  const n = xs.length;
+  const xMean = xs.reduce((sum, v) => sum + v, 0) / n;
+  const yMean = ys.reduce((sum, v) => sum + v, 0) / n;
+
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i += 1) {
+    num += (xs[i]! - xMean) * (ys[i]! - yMean);
+    den += (xs[i]! - xMean) * (xs[i]! - xMean);
+  }
+  if (den === 0) return null;
+
+  const b = num / den;
+  const lnA = yMean - b * xMean;
+  const a = Math.exp(lnA);
+
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b >= 0) return null;
+  return { a, b };
+}
+
+/**
+ * Projects how many more matches (at `recentWinRate`) it should take the
+ * player to reach `threshold` GSP for the fighter behind `series`.
+ *
+ * Model selection, from the player's own win-step history:
+ *   - >= `MIN_OBSERVATIONS_FOR_DECAY_FIT` win-gain observations that fit a
+ *     valid exponential decay (see `fitGainDecay`): simulate forward,
+ *     re-deriving the expected per-win gain at the CURRENT GSP level each
+ *     match from the fitted curve (so gains keep shrinking as GSP climbs
+ *     during the simulation itself, not just at the starting point). Loss
+ *     drops are held constant at the lifetime average loss drop — the
+ *     "shrinks with GSP" behavior is specifically documented for gains, not
+ *     losses, and we don't have enough evidence to fit a second curve.
+ *   - Between `MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK` and
+ *     `MIN_OBSERVATIONS_FOR_DECAY_FIT` observations (or a decay fit that
+ *     comes back degenerate): a cruder flat-average projection — average gain
+ *     per win and average drop per loss, held constant for every simulated
+ *     match. Labeled `'linear-average'` so the UI can call it out as cruder.
+ *   - Fewer than `MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK` observations, or a
+ *     zero/negative recent win rate (the player would never climb): returns
+ *     `null` (unprojectable).
+ *   - Already at/above the threshold: returns `null` (the UI shows an
+ *     already-Elite celebration state instead of a projection).
+ *
+ * Simulation is capped at `MAX_SIMULATED_MATCHES`; hitting the cap without
+ * reaching the threshold reports `matchesNeeded: null` /
+ * `matchesNeededLabel: "more than 2000"` rather than an unbounded loop.
+ */
+export function projectMatchesToElite(
+  series: GspPoint[],
+  threshold: number,
+  recentWinRate: number,
+): EliteProjection | null {
+  if (series.length === 0) return null;
+  const currentGsp = series[series.length - 1]!.gsp;
+  if (currentGsp >= threshold) return null; // already Elite — celebration state, not a projection
+  if (recentWinRate <= 0) return null; // can never climb at a 0% win rate
+
+  const steps = toSteps(series);
+  const winSteps = steps.filter((s) => s.win);
+  const lossSteps = steps.filter((s) => !s.win);
+  if (winSteps.length < MIN_OBSERVATIONS_FOR_LINEAR_FALLBACK) return null;
+
+  const avgLossDrop = average(lossSteps.map((s) => -s.delta)) ?? 0;
+  const decay = fitGainDecay(winSteps);
+
+  const assumptions = [
+    'GSP’s exact formula is not public — this is a simulation based on your own recent gains/losses, not Nintendo’s algorithm.',
+    `Assumes you keep winning ${Math.round(recentWinRate * 100)}% of matches (your recent rate) and threshold ${threshold.toLocaleString()} from your Elite Smash setting.`,
+  ];
+
+  let gsp = currentGsp;
+  let matches = 0;
+  let model: EliteProjection['model'];
+
+  if (decay) {
+    model = 'exponential-decay';
+    assumptions.push(
+      'Models your per-win GSP gain as shrinking exponentially the higher your GSP climbs (fit from your own match history), while loss drops are held at your average.',
+    );
+    while (gsp < threshold && matches < MAX_SIMULATED_MATCHES) {
+      const expectedGainAtGsp = decay.a * Math.exp(decay.b * gsp);
+      const expectedStep = recentWinRate * expectedGainAtGsp - (1 - recentWinRate) * avgLossDrop;
+      if (expectedStep <= 0) {
+        // Decay + loss rate would stall or reverse progress entirely — no
+        // finite projection is meaningful under this model.
+        return null;
+      }
+      gsp += expectedStep;
+      matches += 1;
+    }
+  } else {
+    model = 'linear-average';
+    assumptions.push(
+      'Too few wins to fit a shrinking-gains curve yet, so this uses a simpler flat average of your recent per-win gain instead — cruder, and more likely to be optimistic as your GSP grows.',
+    );
+    const avgGain = average(winSteps.map((s) => s.delta)) ?? 0;
+    const expectedStep = recentWinRate * avgGain - (1 - recentWinRate) * avgLossDrop;
+    if (expectedStep <= 0) return null;
+    while (gsp < threshold && matches < MAX_SIMULATED_MATCHES) {
+      gsp += expectedStep;
+      matches += 1;
+    }
+  }
+
+  const capped = matches >= MAX_SIMULATED_MATCHES && gsp < threshold;
+  return {
+    matchesNeeded: capped ? null : matches,
+    matchesNeededLabel: capped ? `more than ${MAX_SIMULATED_MATCHES}` : String(matches),
+    model,
+    assumptions,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,3 +36,4 @@ export * from './groups.js';
 export * from './billing.js';
 export * from './meta.js';
 export * from './matchupAdvisor.js';
+export * from './gsp.js';

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -149,6 +149,15 @@ export const matchRecordSchema = z.object({
    * single game's notes stay skimmable.
    */
   vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
+  /**
+   * Post-match GSP (Global Smash Power) reading, as shown on the in-game
+   * results screen (V10). Only meaningful for online matches — GSP is
+   * per-fighter, so a series of these across matches sharing `fighter_id`
+   * traces that fighter's GSP over time (see `gsp.ts`'s `getGspSeries`).
+   * User-editable, same optional/conditional-spread convention as
+   * `stocksLeft`.
+   */
+  gsp: z.number().int().min(0).optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 
@@ -223,6 +232,8 @@ const optionalNameInputSchema = z
  * either field (rather than sending it) is how a caller clears it, following
  * the same full-overwrite + conditional-spread convention as
  * `stocksLeft`/`eventName`/`tournamentName` (see `RtdbService.updateMatch`).
+ *
+ * `gsp` (V10) follows the same convention — omit to leave/clear it.
  */
 export const createMatchInputSchema = z.object({
   fighter_id: z.number().int().positive(),
@@ -237,6 +248,7 @@ export const createMatchInputSchema = z.object({
   tournamentName: optionalNameInputSchema,
   vodUrl: z.string().url().optional(),
   vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
+  gsp: z.number().int().min(0).optional(),
 });
 export type CreateMatchInput = z.infer<typeof createMatchInputSchema>;
 


### PR DESCRIPTION
## Summary

- Adds an optional per-character `gsp` reading to match records (logged through the existing `quickplay` online matchType — no new record type), plus a small user-maintained `gspSettings/{uid}` resource for the Elite Smash entry threshold (there's no public Elite Smash API, so this links out to elitegsp.com for reference rather than scraping it).
- New `/gsp` page (nav item "GSP", gauge icon), fighter-scoped like GSP itself: hero row (current GSP, editable Elite threshold, distance-to-Elite/ELITE badge, recent win rate), a GSP-over-time curve with a threshold line, a quick session logger (opponent character + Win/Loss + GSP-after, prefilled with the last reading), a gains analysis card (avg gain/win vs avg drop/loss, lifetime + last 20, a per-win gains bar showing the shrink), a "Road to Elite" projection, and a GSP-vs-Glicko-2 overlay (both series min-max normalized, skipped when either has under 3 points).
- The Elite projection (`packages/shared/src/gsp.ts`'s `projectMatchesToElite`) fits an exponential decay of per-win GSP gain vs. GSP level from the player's own match history (least squares on `ln(gain)` vs `gsp`), falling back to a cruder flat-average projection with thin data (2-4 win observations), and returning `null` (insufficient data / already Elite / no forward progress) below that. Simulation is capped at 2000 matches.

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing-style fast-refresh warnings only, matching existing Trends/RatingCurve precedent)
- [x] `pnpm typecheck` — passes across all packages
- [x] `pnpm test` — passes: `packages/shared` 127 tests, `apps/api` 407 tests, `apps/web` 850 tests (all green, no regressions)
- [x] `pnpm build` — passes
- [x] `pnpm format:check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)