### PR TITLE
Fix: GSP match logging fails on anonymous opponent

### DIFF
--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -279,6 +279,34 @@ describe('POST /api/matches', () => {
     expect(stored).toMatchObject({ gsp: 9_420_000 });
   });
 
+  it('accepts an anonymous (blank) opponent for online/GSP matches and omits it + the registry entry', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        opponent: '',
+        matchType: 'quickplay',
+        gsp: 12_345_678,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).not.toHaveProperty('opponent');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).not.toHaveProperty('opponent');
+    expect(stored).toMatchObject({ gsp: 12_345_678 });
+    // No blank key written into the opponents registry.
+    const opponents = (dump.opponents ?? {}) as Record<string, unknown>;
+    expect(opponents[TEST_UID] ?? {}).toEqual({});
+  });
+
   it('omits gsp from the stored record when not provided', async () => {
     const { app, database } = buildTestApp();
 

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -101,13 +101,15 @@ export class RtdbService {
       opponent_id: input.opponent_id,
       time: Date.now(),
       map: input.map,
-      opponent: input.opponent,
       notes: input.notes,
       matchType: input.matchType,
       win: input.win,
       // RTDB rejects `undefined` values outright, so optional fields must
       // only be present on the record when the input actually provided
       // them (conditional spread) rather than being set to `undefined`.
+      // `opponent` is optional too: online quickplay (GSP) matches have no
+      // named opponent.
+      ...(input.opponent !== undefined ? { opponent: input.opponent } : {}),
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
@@ -118,7 +120,9 @@ export class RtdbService {
 
     const ref = this.database.ref(`matches/${uid}`).push();
     await ref.set(record);
-    await this.addOpponent(uid, input.opponent);
+    if (input.opponent !== undefined) {
+      await this.addOpponent(uid, input.opponent);
+    }
 
     const id = ref.key;
     if (!id) {
@@ -140,14 +144,15 @@ export class RtdbService {
       opponent_id: input.opponent_id,
       time: Date.now(),
       map: input.map,
-      opponent: input.opponent,
       notes: input.notes,
       matchType: input.matchType,
       win: input.win,
       // See createMatch — RTDB rejects `undefined` values, so these are
       // only included when the input actually set them. Omitting
-      // vodUrl/vodTimestamps/gsp from the input is how a caller clears them,
-      // since this is a full overwrite (`.set()`, not a partial patch).
+      // opponent/vodUrl/vodTimestamps/gsp from the input is how a caller
+      // clears them, since this is a full overwrite (`.set()`, not a partial
+      // patch).
+      ...(input.opponent !== undefined ? { opponent: input.opponent } : {}),
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
@@ -157,7 +162,9 @@ export class RtdbService {
     };
 
     await ref.set(record);
-    await this.addOpponent(uid, input.opponent);
+    if (input.opponent !== undefined) {
+      await this.addOpponent(uid, input.opponent);
+    }
 
     return { id, ...record };
   }

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -252,13 +252,25 @@ describe('createMatchInputSchema', () => {
     expect(createMatchInputSchema.parse(input)).toEqual({ ...input, notes: '' });
   });
 
-  it('rejects a blank opponent name', () => {
+  it('treats a blank opponent name as absent (anonymous online/GSP matches)', () => {
+    const parsed = createMatchInputSchema.parse({
+      fighter_id: 1,
+      opponent_id: 8,
+      map: { id: 0, name: 'no selection' },
+      opponent: '   ',
+      matchType: 'quickplay',
+      win: true,
+    });
+    expect(parsed.opponent).toBeUndefined();
+  });
+
+  it('still rejects an opponent name with RTDB-illegal characters', () => {
     expect(() =>
       createMatchInputSchema.parse({
         fighter_id: 1,
         opponent_id: 8,
         map: { id: 0, name: 'no selection' },
-        opponent: '',
+        opponent: 'bad/name',
         matchType: 'none',
         win: true,
       }),

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -191,14 +191,23 @@ function containsRtdbIllegalChar(value: string): boolean {
   return RTDB_RESERVED_KEY_CHARS.some((char) => value.includes(char));
 }
 
-const opponentNameInputSchema = z
+/**
+ * Opponent name for match entry where the opponent may legitimately be
+ * anonymous — online quickplay (the GSP logger, V10) matches you against
+ * random players whose tag you never see. Trims + lowercases + rejects
+ * RTDB-illegal characters when a name IS given, but a blank/whitespace
+ * string transforms to `undefined` (→ omitted from the stored record, whose
+ * `opponent` is already optional) instead of failing validation. Manual
+ * entry keeps its own client-side name requirement (MatchForm/SetWizard).
+ */
+const optionalOpponentNameInputSchema = z
   .string()
   .trim()
-  .min(1, 'Opponent name is required')
   .transform((value) => value.toLowerCase())
   .refine((value) => !containsRtdbIllegalChar(value), {
     message: 'Opponent name cannot contain . # $ [ ] / or control characters',
-  });
+  })
+  .transform((value) => (value ? value : undefined));
 
 /**
  * A trimmed, 1-80 char optional free-text name field (`eventName` /
@@ -239,7 +248,7 @@ export const createMatchInputSchema = z.object({
   fighter_id: z.number().int().positive(),
   opponent_id: z.number().int().positive(),
   map: matchStageSchema,
-  opponent: opponentNameInputSchema,
+  opponent: optionalOpponentNameInputSchema,
   notes: z.string().default(''),
   matchType: matchTypeSchema,
   win: z.boolean(),


### PR DESCRIPTION
**Bug:** logging a GSP match failed with "Failed to log the match." The quick logger sends `opponent: ''` (online quickplay opponents are anonymous), but `createMatchInputSchema.opponent` required `.min(1)`, so every GSP log 400'd.

**Fix:** the create/update input now treats a blank opponent as absent (transforms to `undefined`), matching the stored record shape (`opponent` is already optional). Blank opponent → omitted from the write and skipped in the opponents registry; non-blank names keep trim/lowercase + RTDB-illegal-char validation. Manual entry is unchanged (MatchForm/SetWizard enforce their own name requirement client-side).

The `_ga_...` "invalid domain" cookie warnings in the console are unrelated — that's Firefox tracking protection rejecting Google Analytics cookies, harmless.

Full monorepo gate green (128 shared / 408 api / 855 web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)