### PR TITLE
Fix GA cookie 'invalid domain' errors on *.web.app

### DIFF
--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -91,7 +91,20 @@ function initAnalytics(): Promise<AnalyticsContext | null> {
     if (!(await mod.isSupported().catch(() => false))) {
       return null;
     }
-    return { analytics: mod.getAnalytics(getFirebaseApp()), mod };
+    // cookie_domain must be pinned to the exact host: the app lives on
+    // *.web.app, and `web.app` is on the Public Suffix List, so gtag's
+    // default 'auto' domain walk tries to set _ga cookies at the web.app
+    // level — browsers reject those ("invalid domain" console errors on
+    // every page in Firefox) before falling back. send_page_view is off
+    // because MainLayout logs page_view itself on mount + every route
+    // change (the signed-out landing page is deliberately uncounted).
+    const analytics = mod.initializeAnalytics(getFirebaseApp(), {
+      config: {
+        cookie_domain: window.location.hostname,
+        send_page_view: false,
+      },
+    });
+    return { analytics, mod };
   })().catch(() => null);
   return analyticsInit;
 }


### PR DESCRIPTION
The `_ga_...` "rejected for invalid domain" console errors on every page were real (not just tracking protection, as first assumed): `web.app` is on the Public Suffix List, so gtag's default `cookie_domain: 'auto'` walk tries to set cookies at the `web.app` level and browsers reject them before falling back to the host.

Fix: `initializeAnalytics(app, { config: { cookie_domain: window.location.hostname, send_page_view: false } })` — pinned host-only cookies (no rejected writes), and the automatic page_view is off since MainLayout already logs page_view on mount + every route change (the default was double-counting initial loads).

855 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)