### PR TITLE
Persist opponent character in the GSP quick logger (rematch flow)

### DIFF
--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -196,4 +196,39 @@ describe('GspPage', () => {
 
     expect(createMatch).not.toHaveBeenCalled();
   });
+
+  it('persists the opponent character after logging so rematches only need result + GSP', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('Quick Logger');
+
+    // First match: full entry.
+    await user.click(screen.getByRole('combobox', { name: 'Opponent Character' }));
+    await user.click(await screen.findByRole('option', { name: luigi.name }));
+    await user.click(screen.getByRole('radio', { name: 'Win' }));
+    const gspInput = screen.getByLabelText('GSP After Match');
+    await user.clear(gspInput);
+    await user.type(gspInput, '9500000');
+    await user.click(screen.getByRole('button', { name: 'Log Match' }));
+    await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(1));
+
+    // Rematch: same opponent stays selected — only result + GSP needed.
+    await user.click(screen.getByRole('radio', { name: 'Loss' }));
+    const gspInput2 = screen.getByLabelText('GSP After Match');
+    await user.clear(gspInput2);
+    await user.type(gspInput2, '9300000');
+    await user.click(screen.getByRole('button', { name: 'Log Match' }));
+
+    await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(2));
+    expect(createMatch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        opponent_id: luigi.id,
+        win: false,
+        gsp: 9_300_000,
+      }),
+    );
+  });
 });

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -42,7 +42,11 @@ export function QuickLogger({ fighter, lastGsp }: { fighter: Fighter; lastGsp: n
   const [submitting, setSubmitting] = useState(false);
 
   function resetForNextMatch(nextGsp: number) {
-    setOpponentFighterId(undefined);
+    // The opponent's character is deliberately PERSISTED: quickplay rematches
+    // against the same player are common, so the next log usually needs only
+    // Win/Loss + the new GSP. Result resets (must be chosen every match),
+    // GSP prefills with the reading just entered, stage resets (it changes
+    // game to game and is optional anyway).
     setResult(undefined);
     setGspInput(String(nextGsp));
     setStageId(NO_SELECTION_STAGE.id);


### PR DESCRIPTION
Logging a rematch errored with "Choose the opponent's character" — the post-submit reset cleared the opponent state while the Select still displayed the old value. The opponent character now persists across submissions (rematches are the common case), so a rematch is just Win/Loss + new GSP. Result and stage still reset; GSP prefills with the last reading. Test added for the rematch flow.

856 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)