### PR TITLE
V10.1: reverse-engineered MMR engine under the GSP tracker

### DIFF
--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -3,10 +3,21 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GSP_MODEL } from '@smash-tracker/shared';
 import { AuthProvider } from '@/context/AuthContext';
 import { GspPage } from './GspPage';
 import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
 import { SpriteList } from '@/data/sprites';
+import { computedEliteThreshold } from './lib/gspMmrModel';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
 
 vi.mock('firebase/auth', async () => {
   const mock = await import('@/test/mockAuth');
@@ -52,6 +63,19 @@ vi.mock('@/lib/api', () => ({
 
 const mario = SpriteList.find((s) => s.id === 1)!;
 const luigi = SpriteList.find((s) => s.id === 10)!;
+
+/**
+ * Matcher for the computed Elite threshold: the value drifts with wall-clock
+ * time (t advances ~0.98/hour, ~88 GSP/hour on the threshold), so instead of
+ * an exact string we accept any localized number within a small tolerance of
+ * the value computed at assertion time.
+ */
+function nearNumberMatcher(expected: number, tolerance = 500) {
+  return (content: string) => {
+    const n = Number(content.replace(/,/g, ''));
+    return Number.isFinite(n) && Math.abs(n - expected) <= tolerance;
+  };
+}
 
 function makeMatch(
   overrides: Partial<Record<string, unknown>> & { id: string; time: number; win: boolean },
@@ -138,13 +162,47 @@ describe('GspPage', () => {
 
     expect(await screen.findByText('9,050,000')).toBeInTheDocument(); // current GSP
     expect(screen.getByText('GSP Curve')).toBeInTheDocument();
-    expect(screen.getByText('10,000,000')).toBeInTheDocument(); // elite threshold
+    // Elite threshold is now COMPUTED from the model (settings updatedAt 0 =
+    // never saved, so no calibration) rather than showing the stored value.
+    expect(
+      screen.getByText(nearNumberMatcher(computedEliteThreshold(Date.now()))),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('10,000,000')).not.toBeInTheDocument();
   });
 
-  it('shows the ELITE badge once current GSP reaches the threshold', async () => {
+  it('shows the estimated MMR and reframes distance to Elite on the MMR scale', async () => {
     getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
-    getGspSettings.mockResolvedValue({ eliteThreshold: 9_000_000, updatedAt: 0 });
-    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_500_000 })]);
+    // Fixture times are epoch-ms ~0 (t floors to the model minimum), which
+    // makes the conversion deterministic: gsp 9,050,000 -> MMR 1,000.
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_050_000 })]);
+
+    renderGspPage();
+
+    expect(await screen.findByText('Est. MMR')).toBeInTheDocument();
+    expect(screen.getByText('1,000')).toBeInTheDocument();
+    // Distance card: 1142 - 1000 = 142, with the MMR framing caption.
+    expect(screen.getByText('142')).toBeInTheDocument();
+    expect(screen.getByText(/MMR 1,000 · below Elite \(1142\)/)).toBeInTheDocument();
+    // The honest-labeling caption links the community doc.
+    expect(
+      screen.getByRole('link', { name: 'community-reverse-engineered model' }),
+    ).toBeInTheDocument();
+  });
+
+  it('flags tail readings as approximate on the Est. MMR card', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    // 16,500,000 is beyond gsp(MMR 1400) at the floored t -> top tail.
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 16_500_000 })]);
+
+    renderGspPage();
+
+    expect(await screen.findByText(/top-tail reading — approximate/)).toBeInTheDocument();
+  });
+
+  it('shows the ELITE badge once the estimated MMR reaches Elite (1142)', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    // gsp 15,000,000 at the floored t -> MMR ~1158 >= 1142.
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 15_000_000 })]);
 
     renderGspPage();
 
@@ -152,7 +210,48 @@ describe('GspPage', () => {
     expect(screen.getByText(/already in Elite Smash/)).toBeInTheDocument();
   });
 
-  it('logs a match through the Quick Logger and shows the delta toast', async () => {
+  it('recalibrates the model when the Elite threshold is edited (stored via the settings API)', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('Elite Threshold');
+    expect(screen.getByText(/editing recalibrates the model/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit Elite threshold' }));
+    const input = screen.getByLabelText('Elite Smash threshold');
+    await user.clear(input);
+    await user.type(input, '14,800,000');
+    await user.click(screen.getByRole('button', { name: 'Save threshold' }));
+
+    await waitFor(() =>
+      expect(updateGspSettings).toHaveBeenCalledWith({ eliteThreshold: 14_800_000 }),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/recalibrated/i));
+  });
+
+  it('displays a saved threshold as a calibration: computed value + recalibrated date', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const savedAt = GSP_MODEL.T_ANCHOR.atMs;
+    getGspSettings.mockResolvedValue({ eliteThreshold: 14_720_247, updatedAt: savedAt });
+
+    renderGspPage();
+
+    await screen.findByText('Elite Threshold');
+    // The card shows the value computed from the calibration at NOW — which
+    // has drifted upward from the saved reading — not the raw saved value.
+    const expected = computedEliteThreshold(Date.now(), {
+      eliteThresholdGsp: 14_720_247,
+      atMs: savedAt,
+    });
+    expect(expected).toBeGreaterThan(14_720_247);
+    expect(screen.getByText(nearNumberMatcher(expected))).toBeInTheDocument();
+    expect(screen.getByText(/recalibrated/)).toBeInTheDocument();
+  });
+
+  it('logs a match through the Quick Logger and shows the GSP + MMR delta toast', async () => {
     getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
     listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
     const user = userEvent.setup();
@@ -182,6 +281,10 @@ describe('GspPage', () => {
         gsp: 9_500_000,
       }),
     );
+    // The toast carries both deltas: raw GSP and the estimated MMR change
+    // (both readings land on the main curve, so the conversion is "clean").
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('+500,000 GSP'));
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/≈ \+\d+ MMR/));
   });
 
   it('requires an opponent character and result before submitting from the Quick Logger', async () => {
@@ -230,5 +333,80 @@ describe('GspPage', () => {
         gsp: 9_300_000,
       }),
     );
+  });
+
+  it('toggles the curve between GSP and MMR views', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([
+      makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+      makeMatch({ id: 'm2', time: 2, win: true, gsp: 9_100_000 }),
+    ]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('GSP Curve');
+
+    // Default GSP view explains the computed threshold line.
+    expect(screen.getByText(/logged post-match GSP reading/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'MMR view' }));
+    expect(screen.getByText(/doesn't inflate over time/)).toBeInTheDocument();
+    expect(screen.queryByText(/logged post-match GSP reading/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'GSP view' }));
+    expect(screen.getByText(/logged post-match GSP reading/)).toBeInTheDocument();
+  });
+
+  describe('Road to Elite states', () => {
+    it('projects net wins on the MMR scale at a >50% win rate', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+        makeMatch({ id: 'm2', time: 2, win: true, gsp: 9_100_000 }),
+        makeMatch({ id: 'm3', time: 3, win: false, gsp: 9_050_000 }),
+      ]);
+
+      renderGspPage();
+
+      expect(await screen.findByText(/~\d+ more match/)).toBeInTheDocument();
+      expect(screen.getByText(/MMR\/match/)).toBeInTheDocument();
+      expect(screen.getByText(/to Elite \(MMR 1142\)/)).toBeInTheDocument();
+    });
+
+    it('presents equilibrium kindly at a <=50% win rate', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+        makeMatch({ id: 'm2', time: 2, win: false, gsp: 8_900_000 }),
+      ]);
+
+      renderGspPage();
+
+      expect(await screen.findByText('Holding steady at your level')).toBeInTheDocument();
+      expect(
+        screen.getByText(/matchmaking thinks this is your level right now/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/>50% win rate is what moves you up/)).toBeInTheDocument();
+    });
+
+    it('keeps the V10 own-history estimate as a secondary line when it can compute', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      // A longer winning series: enough win-steps for the V10 projection's
+      // linear fallback (>= 2 win-steps) and a >50% win rate for the primary.
+      listMatches.mockResolvedValue([
+        makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+        makeMatch({ id: 'm2', time: 2, win: true, gsp: 9_100_000 }),
+        makeMatch({ id: 'm3', time: 3, win: true, gsp: 9_200_000 }),
+        makeMatch({ id: 'm4', time: 4, win: true, gsp: 9_300_000 }),
+      ]);
+
+      renderGspPage();
+
+      // Both the primary MMR projection and the secondary own-history line
+      // contain "~N more matches", hence findAll.
+      const projections = await screen.findAllByText(/~\d+ more match/);
+      expect(projections.length).toBe(2);
+      expect(screen.getByText(/From your own GSP history instead/)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/Gsp/GspPage.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.tsx
@@ -74,7 +74,7 @@ export function GspPage() {
 
   const series = getGspSeries(matches, fighter.id);
   const gainStats = getGspGainStats(series);
-  const lastGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+  const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
 
   return (
     <div className="flex flex-col gap-6">
@@ -82,7 +82,8 @@ export function GspPage() {
         <h1 className="text-2xl font-semibold tracking-tight">GSP Tracker</h1>
         <p className="max-w-lg text-sm text-muted-foreground">
           Global Smash Power is per-character and its exact formula is never published by Nintendo —
-          everything below is an estimate built from your own logged matches.
+          everything below is an estimate built from your own logged matches and a
+          community-reverse-engineered model of the hidden MMR behind GSP.
         </p>
         <GspFighterSelect
           fighter={fighter}
@@ -93,16 +94,16 @@ export function GspPage() {
 
       <GspHero series={series} settings={gspSettings} />
 
-      <GspCurve series={series} eliteThreshold={gspSettings.eliteThreshold} />
+      <GspCurve series={series} settings={gspSettings} />
 
-      <QuickLogger fighter={fighter} lastGsp={lastGsp} />
+      <QuickLogger fighter={fighter} lastPoint={lastPoint} settings={gspSettings} />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <GainsAnalysis stats={gainStats} />
-        <RoadToElite series={series} eliteThreshold={gspSettings.eliteThreshold} />
+        <RoadToElite series={series} settings={gspSettings} />
       </div>
 
-      <GspVsGlicko gspSeries={series} allMatches={matches} />
+      <GspVsGlicko gspSeries={series} allMatches={matches} settings={gspSettings} />
     </div>
   );
 }

--- a/apps/web/src/pages/Gsp/components/GspCurve.test.ts
+++ b/apps/web/src/pages/Gsp/components/GspCurve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { GspPoint } from '@smash-tracker/shared';
-import { buildGspCurveData } from './GspCurve';
+import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import { GSP_MODEL, estimateT, mmrToGsp } from '@smash-tracker/shared';
+import { buildGspCurveData, buildMmrCurveData } from './GspCurve';
 
 describe('buildGspCurveData', () => {
   it('builds a GSP dataset and a flat threshold line of the same length', () => {
@@ -19,6 +20,49 @@ describe('buildGspCurveData', () => {
 
   it('handles an empty series', () => {
     const data = buildGspCurveData([], 10_000_000);
+    expect(data.labels).toEqual([]);
+    expect(data.datasets[0]!.data).toEqual([]);
+    expect(data.datasets[1]!.data).toEqual([]);
+  });
+});
+
+describe('buildMmrCurveData', () => {
+  const neverSaved: GspSettings = { eliteThreshold: 10_000_000, updatedAt: 0 };
+
+  it('converts readings to rounded MMR and draws the Elite line at the fixed Elite MMR', () => {
+    // Construct GSP readings that decode to exactly MMR 1000 and 1100 at
+    // their own log-time t, so the converted series is fully deterministic.
+    const t0Ms = GSP_MODEL.T_ANCHOR.atMs;
+    const t1Ms = t0Ms + 60 * 60 * 1000;
+    const series: GspPoint[] = [
+      { time: t0Ms, gsp: Math.round(mmrToGsp(1000, estimateT(t0Ms))), win: true },
+      { time: t1Ms, gsp: Math.round(mmrToGsp(1100, estimateT(t1Ms))), win: true },
+    ];
+
+    const data = buildMmrCurveData(series, neverSaved);
+
+    expect(data.labels).toHaveLength(2);
+    expect(data.datasets[0]!.label).toBe('Est. MMR');
+    expect(data.datasets[0]!.data).toEqual([1000, 1100]);
+    expect(data.datasets[1]!.label).toBe(`Elite (MMR ${GSP_MODEL.ELITE_MMR})`);
+    expect(data.datasets[1]!.data).toEqual([GSP_MODEL.ELITE_MMR, GSP_MODEL.ELITE_MMR]);
+  });
+
+  it('a flat-skill series renders flat in MMR even though its GSP inflated', () => {
+    const t0Ms = GSP_MODEL.T_ANCHOR.atMs;
+    const t1Ms = t0Ms + 14 * 24 * 60 * 60 * 1000; // two weeks of ceiling drift
+    const series: GspPoint[] = [
+      { time: t0Ms, gsp: Math.round(mmrToGsp(1050, estimateT(t0Ms))), win: true },
+      { time: t1Ms, gsp: Math.round(mmrToGsp(1050, estimateT(t1Ms))), win: true },
+    ];
+    expect(series[1]!.gsp).toBeGreaterThan(series[0]!.gsp);
+
+    const data = buildMmrCurveData(series, neverSaved);
+    expect(data.datasets[0]!.data).toEqual([1050, 1050]);
+  });
+
+  it('handles an empty series', () => {
+    const data = buildMmrCurveData([], neverSaved);
     expect(data.labels).toEqual([]);
     expect(data.datasets[0]!.data).toEqual([]);
     expect(data.datasets[1]!.data).toEqual([]);

--- a/apps/web/src/pages/Gsp/components/GspCurve.tsx
+++ b/apps/web/src/pages/Gsp/components/GspCurve.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -9,14 +10,21 @@ import {
   type ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import type { GspPoint } from '@smash-tracker/shared';
+import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import { GSP_MODEL } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
+import { calibrationFromSettings, computedEliteThreshold, toMmrSeries } from '../lib/gspMmrModel';
+import { useNowMs } from '../lib/useNowMs';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
 /** Minimum GSP readings before the curve renders instead of the locked/empty state. */
 export const GSP_CURVE_UNLOCK_THRESHOLD = 2;
+
+/** The two y-axis scales the curve can plot (V10.1 adds the converted-MMR view). */
+export type GspCurveView = 'gsp' | 'mmr';
 
 function formatPointLabel(time: number): string {
   return new Date(time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -41,6 +49,39 @@ export function buildGspCurveData(series: GspPoint[], eliteThreshold: number) {
       {
         label: 'Elite threshold',
         data: series.map(() => eliteThreshold),
+        borderColor: chartColors.grid,
+        backgroundColor: chartColors.grid,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        borderWidth: 1.5,
+        fill: false,
+        tension: 0,
+      },
+    ],
+  };
+}
+
+/**
+ * V10.1: the MMR view — every GSP reading converted through the community
+ * reverse-engineered model at its own log-time t (see
+ * ../lib/gspMmrModel.ts), with a flat Elite line at the fixed Elite entry
+ * MMR (1142). Same pure-builder convention as `buildGspCurveData`.
+ */
+export function buildMmrCurveData(series: GspPoint[], settings: GspSettings) {
+  const calibration = calibrationFromSettings(settings);
+  const mmrSeries = toMmrSeries(series, calibration);
+  return {
+    labels: mmrSeries.map((p) => formatPointLabel(p.time)),
+    datasets: [
+      {
+        label: 'Est. MMR',
+        ...redLineDataset(),
+        data: mmrSeries.map((p) => Math.round(p.mmr)),
+      },
+      {
+        label: `Elite (MMR ${GSP_MODEL.ELITE_MMR})`,
+        data: mmrSeries.map(() => GSP_MODEL.ELITE_MMR),
         borderColor: chartColors.grid,
         backgroundColor: chartColors.grid,
         borderDash: [6, 4],
@@ -88,38 +129,70 @@ function buildGspCurveOptions(series: GspPoint[]): ChartOptions<'line'> {
 }
 
 /**
- * GSP-over-time line chart for the selected fighter, with a dashed horizontal
- * line at the user's Elite Smash threshold setting (V10). Responsive per
+ * GSP-over-time line chart for the selected fighter (V10.1: with a GSP | MMR
+ * view toggle). The GSP view keeps V10's dashed line at the (now computed)
+ * Elite threshold; the MMR view plots the same readings converted to the
+ * hidden-MMR scale, where flat skill shows as a flat line instead of the
+ * steady inflation GSP's rising ceiling bakes in. Responsive per
  * `chartTheme`'s `maintainAspectRatio: false` convention (V9-C) — needs a
  * fixed-height wrapper div to actually fill.
  */
-export function GspCurve({
-  series,
-  eliteThreshold,
-}: {
-  series: GspPoint[];
-  eliteThreshold: number;
-}) {
+export function GspCurve({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
+  const nowMs = useNowMs();
+  const [view, setView] = useState<GspCurveView>('gsp');
   const hasEnoughReadings = series.length >= GSP_CURVE_UNLOCK_THRESHOLD;
+
+  const eliteThreshold = computedEliteThreshold(nowMs, calibrationFromSettings(settings));
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>GSP Curve</CardTitle>
+        <CardTitle className="flex items-center justify-between gap-2">
+          GSP Curve
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            value={view}
+            onValueChange={(value) => {
+              if (value === 'gsp' || value === 'mmr') setView(value);
+            }}
+          >
+            <ToggleGroupItem value="gsp" aria-label="GSP view">
+              GSP
+            </ToggleGroupItem>
+            <ToggleGroupItem value="mmr" aria-label="MMR view">
+              MMR
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {hasEnoughReadings ? (
           <>
             <div className="h-64">
               <Line
-                data={buildGspCurveData(series, eliteThreshold)}
+                data={
+                  view === 'mmr'
+                    ? buildMmrCurveData(series, settings)
+                    : buildGspCurveData(series, eliteThreshold)
+                }
                 options={buildGspCurveOptions(series)}
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              Every point is a logged post-match GSP reading for this fighter. The dashed line is
-              your Elite Smash threshold setting — an estimate, not a Nintendo-published value.
-            </p>
+            {view === 'mmr' ? (
+              <p className="text-xs text-muted-foreground">
+                Estimated hidden MMR behind each reading (community-reverse-engineered model) —
+                unlike GSP, it doesn&apos;t inflate over time, so a flat line means flat skill.
+                Dashed line: Elite entry at MMR {GSP_MODEL.ELITE_MMR}.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Every point is a logged post-match GSP reading for this fighter. The dashed line is
+                the computed Elite Smash threshold — a community-model estimate, not a
+                Nintendo-published value.
+              </p>
+            )}
           </>
         ) : (
           <p className="text-sm text-muted-foreground">

--- a/apps/web/src/pages/Gsp/components/GspHero.tsx
+++ b/apps/web/src/pages/Gsp/components/GspHero.tsx
@@ -2,12 +2,20 @@ import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { Pencil, Check, X } from 'lucide-react';
 import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import { GSP_MODEL } from '@smash-tracker/shared';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useUpdateGspSettings } from '@/hooks/useGspSettings';
 import { parseGspNumber } from '../lib/parseGspNumber';
+import {
+  GSP_MMR_DOC_URL,
+  calibrationFromSettings,
+  computedEliteThreshold,
+  estimateMmrAt,
+} from '../lib/gspMmrModel';
+import { useNowMs } from '../lib/useNowMs';
 
 const ELITEGSP_URL = 'https://elitegsp.com';
 
@@ -31,23 +39,57 @@ export function getRecentGspWinRate(series: GspPoint[], windowSize = 20): number
 }
 
 /**
- * GSP page hero row: current GSP reading, the user-editable Elite Smash
- * threshold (V10 — no public API for this, so the user maintains it, linking
- * out to elitegsp.com's crowd-sourced estimate for reference), distance to
- * Elite (or a celebration badge once at/above it), and recent GSP win rate.
+ * GSP page hero row (V10.1): current GSP reading, the estimated hidden MMR
+ * behind it (community reverse-engineered model — see
+ * packages/shared/src/gspMmr.ts), the COMPUTED Elite Smash threshold (still
+ * editable — an edit now recalibrates the model's time-drift parameter
+ * rather than pinning the displayed value), distance to Elite reframed on
+ * the MMR scale (Elite entry is a fixed MMR, 1142, unlike the ever-drifting
+ * GSP threshold), and recent GSP win rate.
  */
 export function GspHero({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
-  const currentGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+  const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const winRate = getRecentGspWinRate(series);
-  const isElite = currentGsp !== null && currentGsp >= settings.eliteThreshold;
+
+  const calibration = calibrationFromSettings(settings);
+  const estimate =
+    lastPoint !== null ? estimateMmrAt(lastPoint.gsp, lastPoint.time, calibration) : null;
+  const roundedMmr = estimate !== null ? Math.round(estimate.mmr) : null;
+  const isElite = roundedMmr !== null && roundedMmr >= GSP_MODEL.ELITE_MMR;
 
   return (
-    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
       <HeroCard label="Current GSP">
-        {currentGsp !== null ? (
+        {lastPoint !== null ? (
           <>
-            <span className="text-3xl font-bold">{currentGsp.toLocaleString()}</span>
+            <span className="text-3xl font-bold">{lastPoint.gsp.toLocaleString()}</span>
             <p className="text-sm text-muted-foreground">latest reading</p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+        )}
+      </HeroCard>
+
+      <HeroCard label="Est. MMR">
+        {estimate !== null && roundedMmr !== null ? (
+          <>
+            <span className="text-3xl font-bold">{roundedMmr.toLocaleString()}</span>
+            {estimate.zone !== 'main' && (
+              <p className="text-xs font-medium text-amber-500">
+                {estimate.zone}-tail reading &mdash; approximate
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              <a
+                href={GSP_MMR_DOC_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                community-reverse-engineered model
+              </a>{' '}
+              (&plusmn;1 GSP in the main curve; tails approximate)
+            </p>
           </>
         ) : (
           <p className="text-sm text-muted-foreground">No GSP logged yet</p>
@@ -57,7 +99,7 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
       <EliteThresholdCard settings={settings} />
 
       <HeroCard label="Distance to Elite">
-        {currentGsp === null ? (
+        {roundedMmr === null ? (
           <p className="text-sm text-muted-foreground">No GSP logged yet</p>
         ) : isElite ? (
           <span className="w-fit rounded-full bg-emerald-500/15 px-2 py-0.5 text-sm font-semibold text-emerald-500">
@@ -66,9 +108,11 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
         ) : (
           <>
             <span className="text-3xl font-bold">
-              {(settings.eliteThreshold - currentGsp).toLocaleString()}
+              {(GSP_MODEL.ELITE_MMR - roundedMmr).toLocaleString()}
             </span>
-            <p className="text-sm text-muted-foreground">GSP to go (estimate)</p>
+            <p className="text-sm text-muted-foreground">
+              MMR {roundedMmr.toLocaleString()} &middot; below Elite ({GSP_MODEL.ELITE_MMR})
+            </p>
           </>
         )}
       </HeroCard>
@@ -89,13 +133,28 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
   );
 }
 
+/**
+ * V10.1: shows the COMPUTED current Elite entry GSP — Elite is a fixed MMR
+ * (1142), so the GSP threshold is derived from the model's time-drift
+ * parameter t, recalibrated by the user's most recent edit (stored via the
+ * same settings API as V10; `eliteThreshold` + `updatedAt` double as the
+ * calibration point, no schema change). Editing no longer pins the displayed
+ * number — it feeds the model a fresh (value, timestamp) observation and the
+ * display keeps drifting forward from there, same as the real threshold does.
+ */
 function EliteThresholdCard({ settings }: { settings: GspSettings }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(settings.eliteThreshold));
   const updateSettings = useUpdateGspSettings();
 
-  const lastUpdatedLabel =
-    settings.updatedAt > 0 ? new Date(settings.updatedAt).toLocaleDateString() : 'never set';
+  const nowMs = useNowMs();
+  const calibration = calibrationFromSettings(settings);
+  const computed = computedEliteThreshold(nowMs, calibration);
+
+  const calibrationLabel =
+    settings.updatedAt > 0
+      ? `recalibrated ${new Date(settings.updatedAt).toLocaleDateString()}`
+      : 'from the model anchor';
 
   async function save() {
     const parsed = parseGspNumber(draft);
@@ -105,7 +164,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
     }
     try {
       await updateSettings.mutateAsync({ eliteThreshold: parsed });
-      toast.success('Elite threshold updated!');
+      toast.success('Model recalibrated from your threshold reading!');
       setEditing(false);
     } catch {
       toast.error('Failed to save the Elite threshold. Please try again.');
@@ -156,7 +215,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
           </div>
         ) : (
           <div className="flex items-center gap-1.5">
-            <span className="text-3xl font-bold">{settings.eliteThreshold.toLocaleString()}</span>
+            <span className="text-3xl font-bold">{computed.toLocaleString()}</span>
             <Button
               type="button"
               size="icon-xs"
@@ -169,14 +228,15 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
           </div>
         )}
         <p className="text-xs text-muted-foreground">
-          As of {lastUpdatedLabel} &middot;{' '}
+          computed &middot; {calibrationLabel} &middot; editing recalibrates the model &mdash; grab
+          the current number from{' '}
           <a
             href={ELITEGSP_URL}
             target="_blank"
             rel="noreferrer"
             className="underline underline-offset-2 hover:text-foreground"
           >
-            check elitegsp.com
+            elitegsp.com
           </a>
         </p>
       </CardContent>

--- a/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
+++ b/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
@@ -9,36 +9,37 @@ import {
   type ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import type { GspPoint, Match } from '@smash-tracker/shared';
+import type { GspPoint, GspSettings, Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
 import { computeRatingHistory } from '@/lib/glicko';
 import { GSP_VS_GLICKO_MIN_POINTS, buildGspVsGlickoData } from '../lib/gspVsGlicko';
+import { calibrationFromSettings } from '../lib/gspMmrModel';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
 function buildChartData(
-  gsp: { time: number; value: number }[],
+  mmr: { time: number; value: number }[],
   glicko: { time: number; value: number }[],
 ) {
-  const allTimes = [...new Set([...gsp.map((p) => p.time), ...glicko.map((p) => p.time)])].sort(
+  const allTimes = [...new Set([...mmr.map((p) => p.time), ...glicko.map((p) => p.time)])].sort(
     (a, b) => a - b,
   );
   const labels = allTimes.map((t) =>
     new Date(t).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
   );
 
-  const gspByTime = new Map(gsp.map((p) => [p.time, p.value]));
+  const mmrByTime = new Map(mmr.map((p) => [p.time, p.value]));
   const glickoByTime = new Map(glicko.map((p) => [p.time, p.value]));
 
   return {
     labels,
     datasets: [
       {
-        label: 'GSP (normalized)',
+        label: 'Est. MMR (normalized)',
         ...redLineDataset(),
         spanGaps: true,
-        data: allTimes.map((t) => gspByTime.get(t) ?? null),
+        data: allTimes.map((t) => mmrByTime.get(t) ?? null),
       },
       {
         label: 'Glicko-2 (normalized)',
@@ -74,20 +75,25 @@ function buildChartOptions(): ChartOptions<'line'> {
 }
 
 /**
- * Dual-line overlay of the selected fighter's GSP curve against the player's
- * OVERALL Glicko-2 rating history (all fighters — `computeRatingHistory`),
- * both independently min-max normalized to 0-100 (see `buildGspVsGlickoData`)
- * so they're visually comparable despite being on completely different
- * scales. Skipped entirely when either series has fewer than
- * `GSP_VS_GLICKO_MIN_POINTS` points — there's nothing meaningful to compare
- * yet.
+ * Dual-line overlay of the selected fighter's ESTIMATED MMR curve (V10.1 —
+ * GSP readings converted through the community reverse-engineered model,
+ * rating vs. rating) against the player's OVERALL Glicko-2 rating history
+ * (all fighters — `computeRatingHistory`). Both series remain independently
+ * min-max normalized to 0-100 — their raw scales are still unrelated — but
+ * comparing two drift-free ratings makes the SHAPES honestly comparable,
+ * where V10's raw GSP baked ceiling-inflation into its line (see
+ * `buildGspVsGlickoData` for the full rationale). Skipped entirely when
+ * either series has fewer than `GSP_VS_GLICKO_MIN_POINTS` points — there's
+ * nothing meaningful to compare yet.
  */
 export function GspVsGlicko({
   gspSeries,
   allMatches,
+  settings,
 }: {
   gspSeries: GspPoint[];
   allMatches: Match[];
+  settings: GspSettings;
 }) {
   const { periods } = computeRatingHistory(allMatches);
 
@@ -95,21 +101,27 @@ export function GspVsGlicko({
     return null;
   }
 
-  const { gsp, glicko } = buildGspVsGlickoData(gspSeries, periods);
+  const { mmr, glicko } = buildGspVsGlickoData(
+    gspSeries,
+    periods,
+    calibrationFromSettings(settings),
+  );
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>GSP vs Glicko-2</CardTitle>
+        <CardTitle>Est. MMR vs Glicko-2</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <div className="h-64">
-          <Line data={buildChartData(gsp, glicko)} options={buildChartOptions()} />
+          <Line data={buildChartData(mmr, glicko)} options={buildChartOptions()} />
         </div>
         <p className="text-xs text-muted-foreground">
-          Both lines are normalized to 0-100 over this window so their shapes are comparable despite
-          very different scales. Divergence usually means your quickplay form (GSP, this fighter
-          only) differs from your overall form (Glicko-2, across every fighter/session).
+          Your quickplay rating (estimated MMR for this fighter, community-reverse-engineered model)
+          vs. your overall Glicko-2 rating (every fighter/session) — both normalized to 0-100 over
+          this window since their raw scales are unrelated. Rating-vs-rating makes the shapes
+          honestly comparable; divergence usually means your quickplay form differs from your
+          overall form.
         </p>
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import type { Fighter } from '@smash-tracker/shared';
+import type { Fighter, GspPoint, GspSettings } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -20,6 +20,7 @@ import { alphaStageList, stageOptions } from '@/lib/stageOptions';
 import { StageOption } from '@/components/StageOption';
 import { useCreateMatch } from '@/hooks/useCreateMatch';
 import { parseGspNumber } from '../lib/parseGspNumber';
+import { calibrationFromSettings, estimateMmrAt } from '../lib/gspMmrModel';
 
 /**
  * Quick-log the core online-quickplay session loop: pick the opponent's
@@ -31,9 +32,21 @@ import { parseGspNumber } from '../lib/parseGspNumber';
  * 'quickplay' is the existing online match-type value for it (see
  * `matchTypeValues` in packages/shared/src/match.ts) — there is no separate
  * "GSP entry" record type. After a successful save, the form resets for the
- * next match (keeping "your fighter" sticky) and shows the GSP delta.
+ * next match (keeping "your fighter" sticky) and shows the GSP delta, plus
+ * the estimated hidden-MMR delta when both readings convert cleanly through
+ * the reverse-engineered model (V10.1 — see ../lib/gspMmrModel.ts).
  */
-export function QuickLogger({ fighter, lastGsp }: { fighter: Fighter; lastGsp: number | null }) {
+export function QuickLogger({
+  fighter,
+  lastPoint,
+  settings,
+}: {
+  fighter: Fighter;
+  /** The most recent GSP reading for this fighter (with its log time), or null with no history. */
+  lastPoint: GspPoint | null;
+  settings: GspSettings;
+}) {
+  const lastGsp = lastPoint?.gsp ?? null;
   const createMatch = useCreateMatch();
   const [opponentFighterId, setOpponentFighterId] = useState<number | undefined>(undefined);
   const [result, setResult] = useState<'win' | 'loss' | undefined>(undefined);
@@ -70,6 +83,22 @@ export function QuickLogger({ fighter, lastGsp }: { fighter: Fighter; lastGsp: n
     const stage = stageOptions.find((s) => s.id === stageId) ?? NO_SELECTION_STAGE;
     const delta = lastGsp !== null ? gsp - lastGsp : null;
 
+    // V10.1: alongside the raw GSP delta, estimate the hidden-MMR delta by
+    // converting both readings through the reverse-engineered model — each at
+    // its own log time (t drifts). Only shown when BOTH convert "cleanly"
+    // (land on the ±1-GSP-accurate main curve); tail readings are too
+    // approximate for a single-match delta to mean anything.
+    const calibration = calibrationFromSettings(settings);
+    let mmrDeltaLabel = '';
+    if (lastPoint !== null) {
+      const prev = estimateMmrAt(lastPoint.gsp, lastPoint.time, calibration);
+      const next = estimateMmrAt(gsp, Date.now(), calibration);
+      if (prev.zone === 'main' && next.zone === 'main') {
+        const mmrDelta = Math.round(next.mmr) - Math.round(prev.mmr);
+        mmrDeltaLabel = ` · ≈ ${mmrDelta >= 0 ? '+' : ''}${mmrDelta} MMR`;
+      }
+    }
+
     setSubmitting(true);
     try {
       await createMatch.mutateAsync({
@@ -83,8 +112,8 @@ export function QuickLogger({ fighter, lastGsp }: { fighter: Fighter; lastGsp: n
         gsp,
       });
       const deltaLabel =
-        delta === null ? '' : ` (${delta >= 0 ? '+' : ''}${delta.toLocaleString()})`;
-      toast.success(`Match logged! GSP ${gsp.toLocaleString()}${deltaLabel}`);
+        delta === null ? '' : ` (${delta >= 0 ? '+' : ''}${delta.toLocaleString()} GSP)`;
+      toast.success(`Match logged! GSP ${gsp.toLocaleString()}${deltaLabel}${mmrDeltaLabel}`);
       resetForNextMatch(gsp);
     } catch {
       toast.error('Failed to log the match. Please try again.');

--- a/apps/web/src/pages/Gsp/components/RoadToElite.tsx
+++ b/apps/web/src/pages/Gsp/components/RoadToElite.tsx
@@ -1,31 +1,51 @@
 import { PartyPopper } from 'lucide-react';
-import type { GspPoint } from '@smash-tracker/shared';
-import { projectMatchesToElite } from '@smash-tracker/shared';
+import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import {
+  ASSUMED_MMR_POINTS_PER_MATCH,
+  GSP_MODEL,
+  MAX_PROJECTED_MATCHES,
+  projectMatchesToElite,
+  projectMatchesToEliteMmr,
+} from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getRecentGspWinRate } from './GspHero';
+import { calibrationFromSettings, computedEliteThreshold, estimateMmrAt } from '../lib/gspMmrModel';
+import { useNowMs } from '../lib/useNowMs';
 
 /**
- * The GSP page's projection card — "how many more matches at my current win
- * rate until I hit Elite Smash". Built entirely on `projectMatchesToElite`
- * (packages/shared/src/gsp.ts), which fits an exponential decay of per-win
- * GSP gain from the player's own history (falling back to a cruder flat
- * average with too little data). Always shown alongside the model's
- * `assumptions` and a reminder that GSP's real formula isn't public — this is
- * a simulation, not a guarantee.
+ * The GSP page's projection card (V10.1) — "how far to Elite Smash".
+ *
+ * PRIMARY: the MMR projection (`projectMatchesToEliteMmr`,
+ * packages/shared/src/gspMmr.ts) — Elite entry is a fixed MMR (1142) and,
+ * per the community reverse-engineered zero-sum delta system (Elo K=20),
+ * even matchmaking trades ~10 MMR per match, so "net wins needed" is a
+ * clean, GSP-inflation-free number. Its 'equilibrium' outcome (win rate
+ * <= 50%) is an honest result presented kindly — matchmaking has found the
+ * player's level, and a >50% win rate (not more grinding) is what moves it.
+ *
+ * SECONDARY: V10's own-history GSP decay simulation
+ * (`projectMatchesToElite`, packages/shared/src/gsp.ts) as a
+ * "from your own GSP history" cross-check line, when it can compute.
  */
-export function RoadToElite({
-  series,
-  eliteThreshold,
-}: {
-  series: GspPoint[];
-  eliteThreshold: number;
-}) {
-  const currentGsp = series.length > 0 ? series[series.length - 1]!.gsp : null;
+export function RoadToElite({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
+  const nowMs = useNowMs();
+  const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const winRate = getRecentGspWinRate(series) ?? 0;
-  const isElite = currentGsp !== null && currentGsp >= eliteThreshold;
 
-  const projection =
-    currentGsp === null || isElite ? null : projectMatchesToElite(series, eliteThreshold, winRate);
+  const calibration = calibrationFromSettings(settings);
+  const estimate =
+    lastPoint !== null ? estimateMmrAt(lastPoint.gsp, lastPoint.time, calibration) : null;
+  const mmrProjection =
+    estimate !== null ? projectMatchesToEliteMmr(Math.round(estimate.mmr), winRate) : null;
+
+  // Secondary, own-history line (V10): simulate against the COMPUTED
+  // GSP threshold. Only meaningful when the primary isn't a
+  // celebration/equilibrium state.
+  const gspThreshold = computedEliteThreshold(nowMs, calibration);
+  const decayProjection =
+    lastPoint !== null && mmrProjection !== null && mmrProjection.status === 'projected'
+      ? projectMatchesToElite(series, gspThreshold, winRate)
+      : null;
 
   return (
     <Card>
@@ -33,35 +53,65 @@ export function RoadToElite({
         <CardTitle>Road to Elite</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
-        {currentGsp === null ? (
+        {mmrProjection === null ? (
           <p className="text-sm text-muted-foreground">
             Log a match with a GSP reading for this fighter to see a projection.
           </p>
-        ) : isElite ? (
+        ) : mmrProjection.status === 'already-elite' ? (
           <div className="flex items-center gap-2 text-emerald-500">
             <PartyPopper className="size-6" />
             <p className="text-lg font-semibold">You&apos;re already in Elite Smash!</p>
           </div>
-        ) : projection ? (
+        ) : mmrProjection.status === 'equilibrium' ? (
           <>
-            <p className="text-2xl font-bold">
-              ~{projection.matchesNeededLabel} more match
-              {projection.matchesNeededLabel === '1' ? '' : 'es'}
-            </p>
+            <p className="text-lg font-semibold">Holding steady at your level</p>
             <p className="text-sm text-muted-foreground">
-              at your current {Math.round(winRate * 100)}% win rate (estimate)
+              At your current {Math.round(winRate * 100)}% win rate, matchmaking thinks this is your
+              level right now — every match trades ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR both ways, so
+              a &gt;50% win rate is what moves you up, not more matches. Keep working the matchups
+              on this page and the number will follow.
             </p>
-            <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
-              {projection.assumptions.map((assumption) => (
-                <li key={assumption}>{assumption}</li>
-              ))}
-            </ul>
+          </>
+        ) : mmrProjection.status === 'capped' ? (
+          <>
+            <p className="text-2xl font-bold">more than {MAX_PROJECTED_MATCHES} net wins</p>
+            <p className="text-sm text-muted-foreground">
+              Your win rate is barely above 50%, so expected progress per match is tiny — a small
+              bump in win rate shortens this dramatically.
+            </p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">
-            Not enough win/loss history with GSP readings yet to project a path to Elite. Keep
-            logging matches — this needs a handful of wins to fit a trend.
-          </p>
+          <>
+            <p className="text-2xl font-bold">
+              ~{mmrProjection.matchesNeeded} more match
+              {mmrProjection.matchesNeeded === 1 ? '' : 'es'}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              to Elite (MMR {GSP_MODEL.ELITE_MMR}) at your ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR/match
+              and {Math.round(winRate * 100)}% win rate (community model estimate)
+            </p>
+            {decayProjection && (
+              <p className="text-xs text-muted-foreground">
+                From your own GSP history instead: ~{decayProjection.matchesNeededLabel} more match
+                {decayProjection.matchesNeededLabel === '1' ? '' : 'es'} (V10&apos;s{' '}
+                {decayProjection.model === 'exponential-decay'
+                  ? 'shrinking-gains fit'
+                  : 'flat-average fallback'}
+                ).
+              </p>
+            )}
+            <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+              <li>
+                Assumes matchmaking keeps pairing you against similar-MMR opponents (each match
+                trades ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR, the community table&apos;s value for an
+                even match) and that your recent win rate holds.
+              </li>
+              <li>
+                Built on the community-reverse-engineered MMR model, not Nintendo&apos;s algorithm —
+                a simulation, not a guarantee.
+              </li>
+            </ul>
+          </>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Gsp/lib/gspMmrModel.test.ts
+++ b/apps/web/src/pages/Gsp/lib/gspMmrModel.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import { GSP_MODEL, eliteThresholdGsp, estimateT, gspToMmr, mmrToGsp } from '@smash-tracker/shared';
+import {
+  calibrationFromSettings,
+  computedEliteThreshold,
+  estimateMmrAt,
+  toMmrSeries,
+} from './gspMmrModel';
+
+describe('calibrationFromSettings', () => {
+  it('returns undefined for the never-saved sentinel (updatedAt 0)', () => {
+    const settings: GspSettings = { eliteThreshold: 10_300_000, updatedAt: 0 };
+    expect(calibrationFromSettings(settings)).toBeUndefined();
+  });
+
+  it('maps a saved setting to a TCalibration (value + timestamp)', () => {
+    const settings: GspSettings = { eliteThreshold: 14_720_247, updatedAt: 1_780_000_000_000 };
+    expect(calibrationFromSettings(settings)).toEqual({
+      eliteThresholdGsp: 14_720_247,
+      atMs: 1_780_000_000_000,
+    });
+  });
+});
+
+describe('computedEliteThreshold', () => {
+  it('without a calibration, equals the model threshold at estimateT(now), rounded', () => {
+    const nowMs = GSP_MODEL.T_ANCHOR.atMs + 5 * 60 * 60 * 1000;
+    expect(computedEliteThreshold(nowMs)).toBe(Math.round(eliteThresholdGsp(estimateT(nowMs))));
+  });
+
+  it('reproduces (approximately) a calibration reading at the calibration instant', () => {
+    // Save "the threshold is X right now" and immediately recompute: the
+    // computed value must come back to X (within rounding of the t-solve).
+    const atMs = GSP_MODEL.T_ANCHOR.atMs + 10 * 24 * 60 * 60 * 1000;
+    const observed = 14_800_000;
+    const computed = computedEliteThreshold(atMs, { eliteThresholdGsp: observed, atMs });
+    expect(Math.abs(computed - observed)).toBeLessThanOrEqual(1);
+  });
+
+  it('drifts upward as time passes the calibration', () => {
+    const atMs = GSP_MODEL.T_ANCHOR.atMs;
+    const calibration = { eliteThresholdGsp: 14_720_247, atMs };
+    const aWeekLater = atMs + 7 * 24 * 60 * 60 * 1000;
+    expect(computedEliteThreshold(aWeekLater, calibration)).toBeGreaterThan(
+      computedEliteThreshold(atMs, calibration),
+    );
+  });
+});
+
+describe('estimateMmrAt', () => {
+  it('converts a GSP reading at the t of the given time', () => {
+    const atMs = GSP_MODEL.T_ANCHOR.atMs;
+    const t = estimateT(atMs);
+    const gsp = mmrToGsp(1100, t);
+    const result = estimateMmrAt(gsp, atMs);
+    expect(result.zone).toBe('main');
+    expect(result.mmr).toBeCloseTo(1100, 3);
+  });
+
+  it('flags tail readings via zone', () => {
+    const atMs = GSP_MODEL.T_ANCHOR.atMs;
+    const t = estimateT(atMs);
+    expect(estimateMmrAt(mmrToGsp(1500, t), atMs).zone).toBe('top');
+    expect(estimateMmrAt(mmrToGsp(500, t), atMs).zone).toBe('bottom');
+  });
+});
+
+describe('toMmrSeries', () => {
+  it('converts each reading at its OWN log time — flat skill stays flat despite GSP inflation', () => {
+    // Two readings a week apart, both at exactly MMR 1100 "in reality":
+    // the GSP for the same MMR is HIGHER a week later (the ceiling rose),
+    // yet the MMR series comes back flat.
+    const t0Ms = GSP_MODEL.T_ANCHOR.atMs;
+    const t1Ms = t0Ms + 7 * 24 * 60 * 60 * 1000;
+    const series: GspPoint[] = [
+      { time: t0Ms, gsp: Math.round(mmrToGsp(1100, estimateT(t0Ms))), win: true },
+      { time: t1Ms, gsp: Math.round(mmrToGsp(1100, estimateT(t1Ms))), win: true },
+    ];
+    expect(series[1]!.gsp).toBeGreaterThan(series[0]!.gsp); // GSP inflated...
+    const mmrSeries = toMmrSeries(series);
+    expect(Math.round(mmrSeries[0]!.mmr)).toBe(1100); // ...but MMR is flat.
+    expect(Math.round(mmrSeries[1]!.mmr)).toBe(1100);
+  });
+
+  it('preserves time/win and carries the zone through', () => {
+    const atMs = GSP_MODEL.T_ANCHOR.atMs;
+    const t = estimateT(atMs);
+    const series: GspPoint[] = [
+      { time: atMs, gsp: Math.round(mmrToGsp(1000, t)), win: true },
+      { time: atMs + 1000, gsp: Math.round(mmrToGsp(1600, estimateT(atMs + 1000))), win: false },
+    ];
+    const mmrSeries = toMmrSeries(series);
+    expect(mmrSeries[0]).toMatchObject({ time: atMs, win: true, zone: 'main' });
+    expect(mmrSeries[1]).toMatchObject({ time: atMs + 1000, win: false, zone: 'top' });
+  });
+
+  it('uses the calibration when provided (matches a direct gspToMmr at the calibrated t)', () => {
+    const atMs = GSP_MODEL.T_ANCHOR.atMs + 30 * 24 * 60 * 60 * 1000;
+    const calibration = { eliteThresholdGsp: 15_000_000, atMs };
+    const gsp = 12_000_000;
+    const expected = gspToMmr(gsp, estimateT(atMs, calibration));
+    const [point] = toMmrSeries([{ time: atMs, gsp, win: true }], calibration);
+    expect(point!.mmr).toBeCloseTo(expected.mmr, 8);
+    expect(point!.zone).toBe(expected.zone);
+  });
+
+  it('returns an empty array for an empty series', () => {
+    expect(toMmrSeries([])).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/Gsp/lib/gspMmrModel.ts
+++ b/apps/web/src/pages/Gsp/lib/gspMmrModel.ts
@@ -1,0 +1,72 @@
+import type { GspPoint, GspSettings, GspZone, TCalibration } from '@smash-tracker/shared';
+import { eliteThresholdGsp, estimateT, gspToMmr } from '@smash-tracker/shared';
+
+/**
+ * V10.1 page-level glue for the reverse-engineered GSP->MMR model
+ * (packages/shared/src/gspMmr.ts). The shared module is pure math over
+ * `(gsp, t)`; this file owns the two page-specific decisions:
+ *
+ *   1. WHERE the t-calibration comes from: the user's existing Elite
+ *      Threshold setting. `gspSettings` already stores exactly what a
+ *      `TCalibration` needs — `eliteThreshold` (the GSP value) and
+ *      `updatedAt` (when it was saved) — so V10.1 required NO schema change
+ *      (verified against `gspSettingsSchema`). An `updatedAt` of 0 is the
+ *      API's "never actually saved" sentinel (see `RtdbService.getGspSettings`),
+ *      in which case we fall back to the model's built-in 2026-06-11 anchor.
+ *   2. WHICH t each conversion uses: historical GSP readings are converted
+ *      at the t of THEIR OWN log time (t drifts ~0.98/hour, so a
+ *      reading from last month must not be interpreted against today's
+ *      inflated ceiling). This is what makes the MMR view flat over time
+ *      when skill is flat, unlike the ever-inflating GSP number.
+ */
+
+/** The community reverse-engineering doc every constant in the model traces to (captured 2026-07-07). */
+export const GSP_MMR_DOC_URL =
+  'https://docs.google.com/document/d/e/2PACX-1vTJ_OknOfmnoZ-jKu0lHukq6lTZJOLn6zEPUZMHOzRWZ68AOIPuejUQI1JqDDepP324fThnmShXeudb/pub';
+
+/**
+ * Derives a t-calibration from the user's Elite Threshold setting, or
+ * `undefined` when they've never actually saved one (`updatedAt: 0` is the
+ * API's synthesized-default sentinel — calibrating on the placeholder value
+ * would poison the model, so we use the doc's anchor instead).
+ */
+export function calibrationFromSettings(settings: GspSettings): TCalibration | undefined {
+  if (settings.updatedAt <= 0) return undefined;
+  return { eliteThresholdGsp: settings.eliteThreshold, atMs: settings.updatedAt };
+}
+
+/**
+ * The COMPUTED current Elite Smash entry GSP (rounded to a whole GSP): the
+ * model's Elite MMR (1142) pushed through the forward curve at t(now),
+ * recalibrated by the user's latest threshold edit when present.
+ */
+export function computedEliteThreshold(nowMs: number, calibration?: TCalibration): number {
+  return Math.round(eliteThresholdGsp(estimateT(nowMs, calibration)));
+}
+
+/** One GSP reading converted to the hidden-MMR scale. */
+export interface MmrPoint {
+  time: number;
+  /** Estimated hidden MMR (fractional — display code rounds). */
+  mmr: number;
+  /** 'main' readings are ±1-GSP-accurate; 'top'/'bottom' fall in the approximate linear tails. */
+  zone: GspZone;
+  win: boolean;
+}
+
+/** Estimated MMR for a single GSP reading taken at `atMs` (t evaluated at the reading's own time — see module doc). */
+export function estimateMmrAt(
+  gsp: number,
+  atMs: number,
+  calibration?: TCalibration,
+): { mmr: number; zone: GspZone } {
+  return gspToMmr(gsp, estimateT(atMs, calibration));
+}
+
+/** Converts a chronological GSP series to the MMR scale, each reading at its own log-time t (see module doc). */
+export function toMmrSeries(series: GspPoint[], calibration?: TCalibration): MmrPoint[] {
+  return series.map((p) => {
+    const { mmr, zone } = estimateMmrAt(p.gsp, p.time, calibration);
+    return { time: p.time, mmr, zone, win: p.win };
+  });
+}

--- a/apps/web/src/pages/Gsp/lib/gspVsGlicko.test.ts
+++ b/apps/web/src/pages/Gsp/lib/gspVsGlicko.test.ts
@@ -41,7 +41,9 @@ describe('buildGspVsGlickoData', () => {
 
     const data = buildGspVsGlickoData(gspSeries, ratingPeriods);
 
-    expect(data.gsp).toEqual([
+    // GSP -> MMR conversion is monotonic, so the lower GSP reading is still
+    // the series min (0) and the higher the max (100) after normalization.
+    expect(data.mmr).toEqual([
       { time: 10, value: 0 },
       { time: 20, value: 100 },
     ]);
@@ -51,9 +53,31 @@ describe('buildGspVsGlickoData', () => {
     ]);
   });
 
+  it('converts the GSP series to MMR before normalizing (not a raw-GSP overlay)', () => {
+    // Three GSP readings spaced EQUALLY in GSP, up in the curve's compressed
+    // upper half. On the MMR scale the spacing is NOT equal (the normal-CDF
+    // curve is nonlinear), so the middle point's normalized value must differ
+    // from the raw-GSP midpoint of 50.
+    const gspSeries: GspPoint[] = [
+      { time: 10, gsp: 9_000_000, win: true },
+      { time: 20, gsp: 12_000_000, win: true },
+      { time: 30, gsp: 15_000_000, win: true },
+    ];
+    const ratingPeriods: RatingPeriodResult[] = [
+      ratingPeriod({ end: 15, rating: 1400 }),
+      ratingPeriod({ end: 25, rating: 1500 }),
+      ratingPeriod({ end: 35, rating: 1600 }),
+    ];
+
+    const data = buildGspVsGlickoData(gspSeries, ratingPeriods);
+    expect(data.mmr[0]!.value).toBeCloseTo(0);
+    expect(data.mmr[2]!.value).toBeCloseTo(100);
+    expect(data.mmr[1]!.value).not.toBeCloseTo(50, 0);
+  });
+
   it('returns empty arrays for empty input series', () => {
     const data = buildGspVsGlickoData([], []);
-    expect(data.gsp).toEqual([]);
+    expect(data.mmr).toEqual([]);
     expect(data.glicko).toEqual([]);
   });
 });

--- a/apps/web/src/pages/Gsp/lib/gspVsGlicko.ts
+++ b/apps/web/src/pages/Gsp/lib/gspVsGlicko.ts
@@ -1,7 +1,8 @@
-import type { GspPoint } from '@smash-tracker/shared';
+import type { GspPoint, TCalibration } from '@smash-tracker/shared';
 import type { RatingPeriodResult } from '@/lib/glicko';
+import { toMmrSeries } from './gspMmrModel';
 
-/** Minimum points required in EITHER series before the "GSP vs Glicko-2" card renders. */
+/** Minimum points required in EITHER series before the "MMR vs Glicko-2" card renders. */
 export const GSP_VS_GLICKO_MIN_POINTS = 3;
 
 /** One point in the normalized overlay series, keyed by time so both lines share an x-axis. */
@@ -28,28 +29,40 @@ export function minMaxNormalize(values: number[]): number[] {
 }
 
 export interface GspVsGlickoData {
-  gsp: NormalizedPoint[];
+  mmr: NormalizedPoint[];
   glicko: NormalizedPoint[];
 }
 
 /**
- * Builds the two normalized series for the "GSP vs Glicko-2" overlay: the
- * selected fighter's GSP readings vs. the player's overall Glicko-2 rating
- * history (ALL fighters — see `computeRatingHistory`), each independently
- * min-max normalized to 0-100 so they're comparable on one axis despite being
- * on wildly different scales (GSP in the millions, Glicko ~1000-2000).
+ * Builds the two normalized series for the "MMR vs Glicko-2" overlay: the
+ * selected fighter's GSP readings CONVERTED TO ESTIMATED MMR (V10.1 — see
+ * ../lib/gspMmrModel.ts) vs. the player's overall Glicko-2 rating history
+ * (ALL fighters — see `computeRatingHistory`).
+ *
+ * V10.1 note on normalization: both series are still independently min-max
+ * normalized to 0-100. The units remain unrelated (Nintendo's hidden MMR
+ * scale vs. Glicko-2's rating scale), so a shared raw axis would be
+ * arbitrary — but the comparison is far more honest than V10's raw-GSP
+ * version: MMR is a drift-free rating like Glicko, whereas raw GSP inflated
+ * over time (a rising series even at flat skill) and its normal-CDF shape
+ * compressed changes near the ceiling. Normalizing two RATINGS compares
+ * their shapes; normalizing a rating against an inflating percentile-ish
+ * count distorted them.
+ *
  * `glicko` uses each rating period's END time (`RatingPeriodResult.end`) as
  * its x-value, since a period covers a whole session rather than one instant.
  */
 export function buildGspVsGlickoData(
   gspSeries: GspPoint[],
   ratingPeriods: RatingPeriodResult[],
+  calibration?: TCalibration,
 ): GspVsGlickoData {
-  const gspValues = minMaxNormalize(gspSeries.map((p) => p.gsp));
+  const mmrSeries = toMmrSeries(gspSeries, calibration);
+  const mmrValues = minMaxNormalize(mmrSeries.map((p) => p.mmr));
   const glickoValues = minMaxNormalize(ratingPeriods.map((p) => p.rating));
 
   return {
-    gsp: gspSeries.map((p, i) => ({ time: p.time, value: gspValues[i]! })),
+    mmr: mmrSeries.map((p, i) => ({ time: p.time, value: mmrValues[i]! })),
     glicko: ratingPeriods.map((p, i) => ({ time: p.end, value: glickoValues[i]! })),
   };
 }

--- a/apps/web/src/pages/Gsp/lib/useNowMs.ts
+++ b/apps/web/src/pages/Gsp/lib/useNowMs.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+/**
+ * Mount-time "now" for the GSP page's computed-threshold/MMR conversions.
+ *
+ * `Date.now()` straight in render is impure (react-hooks/purity), so it's
+ * captured once in a lazy `useState` initializer. Mount-time is plenty: the
+ * computed Elite threshold drifts ~88 GSP/hour under the model, so it can't
+ * visibly change within a page visit — and NOT ticking avoids re-render
+ * churn for a number that moves by rounding error.
+ */
+export function useNowMs(): number {
+  const [nowMs] = useState(() => Date.now());
+  return nowMs;
+}

--- a/packages/shared/src/gspMmr.test.ts
+++ b/packages/shared/src/gspMmr.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GSP_MODEL,
+  MAX_PROJECTED_MATCHES,
+  MMR_POINTS_TABLE,
+  ASSUMED_MMR_POINTS_PER_MATCH,
+  eloExpectedPointsForWin,
+  estimateT,
+  eliteThresholdGsp,
+  gspToMmr,
+  mmrToGsp,
+  mmrPointsForWin,
+  mmrPointsForWinDetailed,
+  normCdf,
+  normInv,
+  projectMatchesToEliteMmr,
+} from './gspMmr.js';
+
+describe('normCdf', () => {
+  it('Φ(0) = 0.5', () => {
+    // The Numerical Recipes erfc approximation has a documented fractional
+    // error < 1.2e-7 (see module doc) — precision expectations throughout
+    // this file are set at 6-7 decimal places to match that floor, not
+    // machine epsilon.
+    expect(normCdf(0)).toBeCloseTo(0.5, 7);
+  });
+
+  it('Φ(1.2909...) ≈ 0.9016 (this model’s Elite z-score)', () => {
+    expect(normCdf((1142 - 1000) / 110)).toBeCloseTo(0.9016323928886333, 6);
+  });
+
+  it('is symmetric: Φ(-z) = 1 - Φ(z)', () => {
+    expect(normCdf(-1.5)).toBeCloseTo(1 - normCdf(1.5), 10);
+  });
+
+  it('matches known standard-normal reference values', () => {
+    expect(normCdf(1)).toBeCloseTo(0.8413447, 6);
+    expect(normCdf(1.96)).toBeCloseTo(0.9750021, 6);
+    expect(normCdf(-1)).toBeCloseTo(0.1586553, 6);
+  });
+});
+
+describe('normInv', () => {
+  it('Φ⁻¹(0.5) = 0', () => {
+    expect(normInv(0.5)).toBeCloseTo(0, 8);
+  });
+
+  it('is the inverse of normCdf across the main range', () => {
+    for (const z of [-2.5, -1.29, -0.5, 0.1, 0.9, 1.2909090909, 2.2]) {
+      expect(normInv(normCdf(z))).toBeCloseTo(z, 6);
+    }
+  });
+
+  it('matches a known reference value (97.5th percentile ≈ 1.95996)', () => {
+    expect(normInv(0.975)).toBeCloseTo(1.959963985, 6);
+  });
+
+  it('clamps to +/-Infinity outside (0, 1)', () => {
+    expect(normInv(0)).toBe(-Infinity);
+    expect(normInv(1)).toBe(Infinity);
+    expect(normInv(-0.1)).toBe(-Infinity);
+    expect(normInv(1.1)).toBe(Infinity);
+  });
+});
+
+describe('GSP_MODEL constants', () => {
+  it('matches the reverse-engineered doc verbatim', () => {
+    expect(GSP_MODEL.A).toBe(1_995_587);
+    expect(GSP_MODEL.K).toBe(16_058_300);
+    expect(GSP_MODEL.T_ANCHOR).toEqual({ t: 502, atMs: Date.UTC(2026, 5, 11, 19, 21) });
+    expect(GSP_MODEL.T_PER_HOUR).toBe(0.98);
+    expect(GSP_MODEL.CENTER).toBe(1000);
+    expect(GSP_MODEL.SIGMA).toBe(110);
+    expect(GSP_MODEL.ELITE_MMR).toBe(1142);
+    expect(GSP_MODEL.SLOPE_TOP).toBe(220.5);
+    expect(GSP_MODEL.SLOPE_BOTTOM).toBe(248.8);
+    expect(GSP_MODEL.MAIN_MIN).toBe(600);
+    expect(GSP_MODEL.MAIN_MAX).toBe(1400);
+  });
+
+  it('anchor timestamp is exactly 2026-06-11T19:21:00Z', () => {
+    expect(new Date(GSP_MODEL.T_ANCHOR.atMs).toISOString()).toBe('2026-06-11T19:21:00.000Z');
+  });
+});
+
+describe('estimateT', () => {
+  it('returns the anchor t at the anchor time with no calibration', () => {
+    expect(estimateT(GSP_MODEL.T_ANCHOR.atMs)).toBeCloseTo(502, 8);
+  });
+
+  it('advances at 0.98/hour from the anchor', () => {
+    const oneHourLater = GSP_MODEL.T_ANCHOR.atMs + 60 * 60 * 1000;
+    expect(estimateT(oneHourLater)).toBeCloseTo(502.98, 6);
+    const oneDayLater = GSP_MODEL.T_ANCHOR.atMs + 24 * 60 * 60 * 1000;
+    expect(estimateT(oneDayLater)).toBeCloseTo(502 + 24 * 0.98, 6);
+  });
+
+  it('goes backward in time correctly too', () => {
+    const oneHourBefore = GSP_MODEL.T_ANCHOR.atMs - 60 * 60 * 1000;
+    expect(estimateT(oneHourBefore)).toBeCloseTo(502 - 0.98, 6);
+  });
+
+  it('with a calibration exactly reproducing the anchor, recovers the anchor t going forward', () => {
+    const calibration = {
+      eliteThresholdGsp: eliteThresholdGsp(502),
+      atMs: GSP_MODEL.T_ANCHOR.atMs,
+    };
+    expect(estimateT(GSP_MODEL.T_ANCHOR.atMs, calibration)).toBeCloseTo(502, 4);
+    const oneHourLater = GSP_MODEL.T_ANCHOR.atMs + 60 * 60 * 1000;
+    expect(estimateT(oneHourLater, calibration)).toBeCloseTo(502.98, 4);
+  });
+
+  it('recalibrates from a DIFFERENT t: a later, higher threshold reading resets the drift basis', () => {
+    const laterMs = GSP_MODEL.T_ANCHOR.atMs + 10 * 24 * 60 * 60 * 1000; // 10 days later
+    const realTAtLater = estimateT(laterMs); // ~502 + 240*0.98
+    const calibration = { eliteThresholdGsp: eliteThresholdGsp(realTAtLater), atMs: laterMs };
+    expect(estimateT(laterMs, calibration)).toBeCloseTo(realTAtLater, 4);
+
+    // Project a further day forward from the calibration and confirm the
+    // drift keeps advancing from the recalibrated basis, not the original anchor.
+    const twoDaysAfterCalibration = laterMs + 24 * 60 * 60 * 1000;
+    expect(estimateT(twoDaysAfterCalibration, calibration)).toBeCloseTo(
+      realTAtLater + 0.98 * 24,
+      3,
+    );
+  });
+});
+
+describe('eliteThresholdGsp — the doc’s worked example', () => {
+  it('t=502 ⇒ Elite threshold ≈ 14,720,247 (within ±1 GSP, per the doc)', () => {
+    const gsp = eliteThresholdGsp(502);
+    expect(gsp).toBeCloseTo(14_720_246.6, 0);
+    expect(Math.round(gsp)).toBe(14_720_247);
+  });
+});
+
+describe('mmrToGsp / gspToMmr — main curve', () => {
+  const t = 502;
+
+  it('round-trips across the main curve (MMR 600-1400)', () => {
+    for (const mmr of [600, 650, 800, 950, 1000, 1050, 1142, 1200, 1350, 1400]) {
+      const gsp = mmrToGsp(mmr, t);
+      const back = gspToMmr(gsp, t);
+      expect(back.zone).toBe('main');
+      expect(back.mmr).toBeCloseTo(mmr, 4);
+    }
+  });
+
+  it('MMR 1000 (center) maps to the midpoint between A and the ceiling', () => {
+    const gsp = mmrToGsp(1000, t);
+    const ceiling = GSP_MODEL.K + 100 * t;
+    // Loosened to match the erfc approximation's precision floor (see
+    // normCdf's module doc) rather than exact machine precision.
+    expect(gsp).toBeCloseTo((GSP_MODEL.A + ceiling) / 2, 0);
+  });
+
+  it('Elite MMR (1142) maps to eliteThresholdGsp(t)', () => {
+    expect(mmrToGsp(1142, t)).toBeCloseTo(eliteThresholdGsp(t), 6);
+  });
+
+  it('is monotonically increasing across the main range', () => {
+    let prev = mmrToGsp(600, t);
+    for (let mmr = 610; mmr <= 1400; mmr += 10) {
+      const gsp = mmrToGsp(mmr, t);
+      expect(gsp).toBeGreaterThan(prev);
+      prev = gsp;
+    }
+  });
+});
+
+describe('mmrToGsp / gspToMmr — top tail (MMR > 1400)', () => {
+  const t = 502;
+
+  it('is linear beyond MMR 1400 with slope SLOPE_TOP', () => {
+    const base = mmrToGsp(1400, t);
+    const at1450 = mmrToGsp(1450, t);
+    expect(at1450 - base).toBeCloseTo(50 * GSP_MODEL.SLOPE_TOP, 6);
+  });
+
+  it('round-trips and labels the zone "top"', () => {
+    for (const mmr of [1401, 1500, 1800, 2500]) {
+      const gsp = mmrToGsp(mmr, t);
+      const back = gspToMmr(gsp, t);
+      expect(back.zone).toBe('top');
+      expect(back.mmr).toBeCloseTo(mmr, 4);
+    }
+  });
+
+  it('a GSP just above gsp(1400) is classified into the top tail', () => {
+    const boundaryGsp = mmrToGsp(1400, t);
+    const result = gspToMmr(boundaryGsp + 1000, t);
+    expect(result.zone).toBe('top');
+    expect(result.mmr).toBeGreaterThan(1400);
+  });
+});
+
+describe('mmrToGsp / gspToMmr — bottom tail (MMR < 600)', () => {
+  const t = 502;
+
+  it('is linear below MMR 600 with slope SLOPE_BOTTOM', () => {
+    const base = mmrToGsp(600, t);
+    const at550 = mmrToGsp(550, t);
+    expect(base - at550).toBeCloseTo(50 * GSP_MODEL.SLOPE_BOTTOM, 6);
+  });
+
+  it('round-trips and labels the zone "bottom"', () => {
+    for (const mmr of [599, 500, 200, 0]) {
+      const gsp = mmrToGsp(mmr, t);
+      const back = gspToMmr(gsp, t);
+      expect(back.zone).toBe('bottom');
+      expect(back.mmr).toBeCloseTo(mmr, 4);
+    }
+  });
+
+  it('a GSP just below gsp(600) is classified into the bottom tail', () => {
+    const boundaryGsp = mmrToGsp(600, t);
+    const result = gspToMmr(boundaryGsp - 1000, t);
+    expect(result.zone).toBe('bottom');
+    expect(result.mmr).toBeLessThan(600);
+  });
+
+  it('floors t at T_MIN so degenerate t values cannot flip the curve inside out', () => {
+    // A wildly-negative t (e.g. from converting an epoch-0-ish timestamp, or
+    // a garbage calibration) would make ceiling(t) < A without the floor.
+    const insaneT = -500_000;
+    const gspAtFloor = mmrToGsp(1000, GSP_MODEL.T_MIN);
+    expect(mmrToGsp(1000, insaneT)).toBeCloseTo(gspAtFloor, 6);
+    const back = gspToMmr(gspAtFloor, insaneT);
+    expect(back.zone).toBe('main');
+    expect(back.mmr).toBeCloseTo(1000, 4);
+    // Elite threshold stays sane (above A, below the t=T_MIN ceiling).
+    const threshold = eliteThresholdGsp(insaneT);
+    expect(threshold).toBeGreaterThan(GSP_MODEL.A);
+    expect(threshold).toBeLessThan(GSP_MODEL.K);
+  });
+
+  it('handles extreme/out-of-range GSP gracefully (no throw, finite result)', () => {
+    expect(() => gspToMmr(-1_000_000, t)).not.toThrow();
+    expect(() => gspToMmr(0, t)).not.toThrow();
+    expect(() => gspToMmr(1e12, t)).not.toThrow();
+    const veryLow = gspToMmr(-1_000_000, t);
+    expect(Number.isFinite(veryLow.mmr)).toBe(true);
+    expect(veryLow.zone).toBe('bottom');
+    const veryHigh = gspToMmr(1e12, t);
+    expect(Number.isFinite(veryHigh.mmr)).toBe(true);
+    expect(veryHigh.zone).toBe('top');
+  });
+});
+
+describe('mmrPointsForWin / mmrPointsForWinDetailed', () => {
+  it('matches every observed breakpoint from the doc verbatim', () => {
+    const cases: Array<[number, number]> = [
+      [600, 0], // > 533
+      [533, 0],
+      [500, 1], // 523..411
+      [411, 1],
+      [523, 1],
+      [370, 2], // 394..333
+      [333, 2],
+      [394, 2],
+      [280, 3], // 313..253
+      [253, 3],
+      [313, 3],
+      [220, 4], // 242..207
+      [207, 4],
+      [242, 4],
+      [175, 5], // 177..170
+      [170, 5],
+      [177, 5],
+      [140, 6], // ~140
+      [100, 7], // 108..87
+      [87, 7],
+      [108, 7],
+      [60, 8], // 85..44
+      [44, 8],
+      [85, 8],
+      [20, 9], // 40..7
+      [7, 9],
+      [40, 9],
+      [0, 10], // 5..-28
+      [5, 10],
+      [-28, 10],
+      [-45, 11], // -30..-60
+      [-30, 11],
+      [-60, 11],
+      [-80, 12], // -68..-97
+      [-68, 12],
+      [-97, 12],
+      [-115, 13], // ..-130
+      [-130, 13],
+      [-150, 14], // ..-165
+      [-165, 14],
+      [-200, 15], // ~-200
+      [-240, 16], // -233..-251
+      [-233, 16],
+      [-251, 16],
+      [-290, 17], // ~-290
+      [-350, 18], // ..-390
+    ];
+    for (const [diff, expected] of cases) {
+      expect(mmrPointsForWin(diff)).toBe(expected);
+    }
+  });
+
+  it('reports "observed" as the source for diffs covered by the verbatim table', () => {
+    expect(mmrPointsForWinDetailed(0).source).toBe('observed');
+    expect(mmrPointsForWinDetailed(533).source).toBe('observed');
+    expect(mmrPointsForWinDetailed(-390).source).toBe('observed');
+  });
+
+  it('the observed table takes precedence over the Elo fill where they disagree', () => {
+    // At diff 533 the continuous Elo K=20 expectation is ~0.91, which would
+    // round to 1 — but the doc observed 0, and observed wins.
+    expect(Math.round(eloExpectedPointsForWin(533))).toBe(1);
+    expect(mmrPointsForWin(533)).toBe(0);
+    expect(mmrPointsForWinDetailed(533).source).toBe('observed');
+  });
+
+  it('falls back to rounded Elo K=20 and reports "elo-fill" for gaps between bands', () => {
+    // -200 to -233 (exclusive) is a gap in the observed table (which only
+    // has a single-point sample at -200).
+    const gapDiff = -210;
+    const isInObservedRow = MMR_POINTS_TABLE.some(
+      (row) => gapDiff >= row.diffMin && gapDiff <= row.diffMax,
+    );
+    expect(isInObservedRow).toBe(false);
+    const result = mmrPointsForWinDetailed(gapDiff);
+    expect(result.source).toBe('elo-fill');
+    expect(result.points).toBe(Math.round(eloExpectedPointsForWin(gapDiff)));
+    expect(result.points).toBe(15);
+  });
+
+  it('produces 19 and 20 for huge upsets via the Elo fill (the doc gave no explicit bands)', () => {
+    // The doc's tail shorthand ("..−390→18, →19, →20") has no diff ranges
+    // for 19/20, so those come from the logistic fill: 19 from ~-437, 20
+    // from ~-637.
+    expect(mmrPointsForWin(-391)).toBe(18); // still ~18.09 on the Elo curve
+    expect(mmrPointsForWinDetailed(-391).source).toBe('elo-fill');
+    expect(mmrPointsForWin(-450)).toBe(19);
+    expect(mmrPointsForWin(-700)).toBe(20);
+  });
+
+  it('is naturally bounded to [0, 20] for extreme diffs (logistic asymptotes)', () => {
+    expect(mmrPointsForWin(100_000)).toBe(0);
+    expect(mmrPointsForWin(-100_000)).toBe(20);
+  });
+
+  it('ASSUMED_MMR_POINTS_PER_MATCH is mmrPointsForWin(0) = 10 (Elo K/2 at diff 0)', () => {
+    expect(ASSUMED_MMR_POINTS_PER_MATCH).toBe(mmrPointsForWin(0));
+    expect(ASSUMED_MMR_POINTS_PER_MATCH).toBe(10);
+    expect(eloExpectedPointsForWin(0)).toBeCloseTo(10, 10);
+  });
+});
+
+describe('eloExpectedPointsForWin', () => {
+  it('is exactly K/2 = 10 at diff 0', () => {
+    expect(eloExpectedPointsForWin(0)).toBeCloseTo(10, 12);
+  });
+
+  it('is monotonically decreasing in diff', () => {
+    let prev = eloExpectedPointsForWin(-800);
+    for (let diff = -750; diff <= 800; diff += 50) {
+      const val = eloExpectedPointsForWin(diff);
+      expect(val).toBeLessThan(prev);
+      prev = val;
+    }
+  });
+
+  it('is zero-sum symmetric: elo(diff) + elo(-diff) = K', () => {
+    for (const diff of [-400, -137, 0, 55, 233, 519]) {
+      expect(eloExpectedPointsForWin(diff) + eloExpectedPointsForWin(-diff)).toBeCloseTo(20, 10);
+    }
+  });
+
+  it('stays within 1 point of every observed table row midpoint (the validation claim)', () => {
+    // The coordinator-validated claim: every observed row is within 0.9
+    // points of the continuous Elo value. Check against each band midpoint
+    // (using the finite edge for the half-open 0-points band).
+    for (const row of MMR_POINTS_TABLE) {
+      const probe = Number.isFinite(row.diffMax) ? (row.diffMin + row.diffMax) / 2 : row.diffMin;
+      expect(Math.abs(eloExpectedPointsForWin(probe) - row.points)).toBeLessThan(1);
+    }
+  });
+});
+
+describe('projectMatchesToEliteMmr', () => {
+  it('returns already-elite when currentMmr >= ELITE_MMR', () => {
+    expect(projectMatchesToEliteMmr(1142, 0.6)).toEqual({ status: 'already-elite' });
+    expect(projectMatchesToEliteMmr(1200, 0.9)).toEqual({ status: 'already-elite' });
+  });
+
+  it('returns equilibrium for a <=50% win rate (honest, not an error)', () => {
+    expect(projectMatchesToEliteMmr(1000, 0.5)).toEqual({ status: 'equilibrium' });
+    expect(projectMatchesToEliteMmr(1000, 0.4)).toEqual({ status: 'equilibrium' });
+    expect(projectMatchesToEliteMmr(1000, 0)).toEqual({ status: 'equilibrium' });
+  });
+
+  it('projects a finite match count for a >50% win rate', () => {
+    const result = projectMatchesToEliteMmr(1100, 0.6);
+    expect(result.status).toBe('projected');
+    if (result.status === 'projected') {
+      // Expected net per match = (2*0.6-1)*10 ~= 2 (floating-point puts it
+      // fractionally under 2, so 42 MMR needed rounds up to 22 matches via
+      // Math.ceil rather than the mathematically-idealized 21).
+      expect(result.matchesNeeded).toBe(22);
+    }
+  });
+
+  it('caps at MAX_PROJECTED_MATCHES for a barely-above-50% win rate on a big gap', () => {
+    // Very close to 50%, so expected net per match is tiny.
+    const result = projectMatchesToEliteMmr(600, 0.501);
+    expect(result.status).toBe('capped');
+  });
+
+  it('MAX_PROJECTED_MATCHES matches the documented cap of 2000', () => {
+    expect(MAX_PROJECTED_MATCHES).toBe(2000);
+  });
+
+  it('a 100% win rate projects the fastest (fewest matches) for the same gap', () => {
+    const slower = projectMatchesToEliteMmr(1100, 0.55);
+    const faster = projectMatchesToEliteMmr(1100, 0.9);
+    expect(slower.status).toBe('projected');
+    expect(faster.status).toBe('projected');
+    if (slower.status === 'projected' && faster.status === 'projected') {
+      expect(faster.matchesNeeded).toBeLessThan(slower.matchesNeeded);
+    }
+  });
+});

--- a/packages/shared/src/gspMmr.ts
+++ b/packages/shared/src/gspMmr.ts
@@ -1,0 +1,466 @@
+/**
+ * V10.1: a REVERSE-ENGINEERED hidden-MMR model underneath Smash Ultimate's
+ * publicly-shown GSP number. Unlike `gsp.ts` (which fits curves to a player's
+ * OWN match history with no assumed universal formula), everything in this
+ * file encodes a specific community-reverse-engineered formula from a single
+ * source:
+ *
+ *   Source: https://docs.google.com/document/d/e/2PACX-1vTJ_OknOfmnoZ-jKu0lHukq6lTZJOLn6zEPUZMHOzRWZ68AOIPuejUQI1JqDDepP324fThnmShXeudb/pub
+ *   Captured: 2026-07-07
+ *
+ * The doc's claim, in short: Nintendo maintains a hidden WHOLE-NUMBER MMR per
+ * character (roughly Elo-like, matchmaking pairs similar MMR), and the GSP
+ * shown on the results screen is a deterministic transform of that MMR:
+ *
+ *   - Main curve (MMR 600-1400): GSP is the CDF of a normal distribution
+ *     centered at MMR 1000 (sigma 110) rescaled between a fixed floor `A` and
+ *     a slowly-rising "ceiling" that grows over time as the population's high
+ *     scores inflate. The doc reports this fits observed (MMR, GSP) pairs to
+ *     within +/-1 GSP.
+ *   - Top tail (MMR > 1400) and bottom tail (MMR < 600): the normal-CDF shape
+ *     is abandoned in favor of a straight line anchored at the curve's
+ *     endpoint. The doc labels the tail slopes approximate and slowly
+ *     drifting, unlike the main curve's +/-1 precision.
+ *
+ * Match MMR deltas (`mmrPointsForWin` below): the delta system matches Elo
+ * K=20 (logistic, 400 divisor) within +/-1 point across all observations
+ * (mean |error| 0.41; even matches predict exactly 10 = K/2); the exact
+ * integer quantization rule is UNRESOLVED (simple rounding only reproduces
+ * 16/28 observed rows, with systematic sub-rounding at band edges — observed
+ * values sit below the continuous Elo value at group high-diff edges, at
+ * inconsistent implied cutoffs) — treat single-point precision as
+ * approximate. Where the doc gives an explicit observed band we return the
+ * observed value verbatim; everywhere else we round the continuous Elo
+ * expectation.
+ *
+ * This is NOT Nintendo's published algorithm — nobody outside Nintendo has
+ * that. It is one community's regression against crowd-sourced data points,
+ * and every function in this file is a re-implementation of that regression.
+ * Treat every constant below as "authoritative from that doc", not as ground
+ * truth about the game.
+ */
+
+/**
+ * ---------------------------------------------------------------------------
+ * normCdf / normInv
+ * ---------------------------------------------------------------------------
+ *
+ * `normCdf(z)` uses the Numerical Recipes rational Chebyshev approximation of
+ * the complementary error function (Press et al., "Numerical Recipes in C",
+ * 2nd ed., section 6.2, "erfc" via a single rational-polynomial fit). It
+ * claims fractional error < 1.2e-7 everywhere, which is more than sufficient
+ * to reproduce the doc's +/-1 GSP precision at the ~16-million-GSP magnitudes
+ * this model operates at (verified below against the doc's worked example).
+ *
+ * `normInv(p)` uses Peter Acklam's rational approximation for the inverse
+ * standard normal CDF (algorithm published at
+ * https://web.archive.org/web/2015/http://home.online.no/~pjacklam/notes/invnorm/
+ * — no Newton refinement step is applied; Acklam's approximation alone is
+ * accurate to about 1.15e-9 relative error over the full range, which is far
+ * tighter than anything the tail/rounding behavior of this model needs).
+ */
+
+/** Standard normal CDF, Φ(z). See module doc for algorithm + precision notes. */
+export function normCdf(z: number): number {
+  return 0.5 * (1 + erf(z / Math.SQRT2));
+}
+
+/** Error function via the Numerical Recipes rational-Chebyshev erfc fit (see module doc). */
+function erf(x: number): number {
+  const z = Math.abs(x);
+  const t = 1 / (1 + 0.5 * z);
+  const poly =
+    -1.26551223 +
+    t *
+      (1.00002368 +
+        t *
+          (0.37409196 +
+            t *
+              (0.09678418 +
+                t *
+                  (-0.18628806 +
+                    t *
+                      (0.27886807 +
+                        t *
+                          (-1.13520398 +
+                            t * (1.48851587 + t * (-0.82215223 + t * 0.17087277))))))));
+  const ans = t * Math.exp(-z * z + poly);
+  return x >= 0 ? 1 - ans : ans - 1;
+}
+
+/** Inverse standard normal CDF, Φ⁻¹(p). See module doc for algorithm + precision notes. */
+export function normInv(p: number): number {
+  if (p <= 0) return -Infinity;
+  if (p >= 1) return Infinity;
+
+  // Acklam's rational-approximation coefficients.
+  const a = [
+    -3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2, 1.38357751867269e2,
+    -3.066479806614716e1, 2.506628277459239,
+  ];
+  const b = [
+    -5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2, 6.680131188771972e1,
+    -1.328068155288572e1,
+  ];
+  const c = [
+    -7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838, -2.549732539343734,
+    4.374664141464968, 2.938163982698783,
+  ];
+  const d = [7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996, 3.754408661907416];
+  const pLow = 0.02425;
+  const pHigh = 1 - pLow;
+
+  if (p < pLow) {
+    const q = Math.sqrt(-2 * Math.log(p));
+    return (
+      (((((c[0]! * q + c[1]!) * q + c[2]!) * q + c[3]!) * q + c[4]!) * q + c[5]!) /
+      ((((d[0]! * q + d[1]!) * q + d[2]!) * q + d[3]!) * q + 1)
+    );
+  }
+  if (p <= pHigh) {
+    const q = p - 0.5;
+    const r = q * q;
+    return (
+      ((((((a[0]! * r + a[1]!) * r + a[2]!) * r + a[3]!) * r + a[4]!) * r + a[5]!) * q) /
+      (((((b[0]! * r + b[1]!) * r + b[2]!) * r + b[3]!) * r + b[4]!) * r + 1)
+    );
+  }
+  const q = Math.sqrt(-2 * Math.log(1 - p));
+  return (
+    -(((((c[0]! * q + c[1]!) * q + c[2]!) * q + c[3]!) * q + c[4]!) * q + c[5]!) /
+    ((((d[0]! * q + d[1]!) * q + d[2]!) * q + d[3]!) * q + 1)
+  );
+}
+
+/**
+ * All constants from the reverse-engineered doc (see module header for URL +
+ * capture date). Each field's comment traces exactly which claim it encodes.
+ */
+export const GSP_MODEL = {
+  /** GSP floor of the main curve as MMR -> -infinity (2026-07-07 doc). */
+  A: 1_995_587,
+  /** Base of the slowly-rising GSP "ceiling", `ceiling(t) = K + 100*t` (2026-07-07 doc). */
+  K: 16_058_300,
+  /**
+   * Anchor point for the drifting `t` parameter: `t = 502` was observed at
+   * 2026-06-11 14:21 US Central (2026-06-11T19:21:00Z). `estimateT` projects
+   * forward/backward from this instant at `T_PER_HOUR`.
+   */
+  T_ANCHOR: { t: 502, atMs: Date.UTC(2026, 5, 11, 19, 21) },
+  /** Average drift rate of `t`, ~0.98/hour (observed range 14-36/day); frozen per offline session (2026-07-07 doc). */
+  T_PER_HOUR: 0.98,
+  /** Center of the main curve's normal distribution, MMR 1000 (2026-07-07 doc). */
+  CENTER: 1000,
+  /** Standard deviation of the main curve's normal distribution, 110 MMR (2026-07-07 doc). */
+  SIGMA: 110,
+  /** Elite Smash entry MMR, exactly 1142 (observed 1142 in / 1141 out; ~90th percentile of the main curve — 2026-07-07 doc). */
+  ELITE_MMR: 1142,
+  /** Top-tail (MMR > 1400) linear slope, GSP per MMR point; approximate, drifts slowly upward (2026-07-07 doc). */
+  SLOPE_TOP: 220.5,
+  /** Bottom-tail (MMR < 600) linear slope, GSP per MMR point; approximate, also drifts (2026-07-07 doc). */
+  SLOPE_BOTTOM: 248.8,
+  /** Lower bound of the main (normal-CDF) curve; below this MMR the model switches to the bottom-tail line (2026-07-07 doc). */
+  MAIN_MIN: 600,
+  /** Upper bound of the main (normal-CDF) curve; above this MMR the model switches to the top-tail line (2026-07-07 doc). */
+  MAIN_MAX: 1400,
+  /** Default MMR assumed for a character the player has never played, ~1095 (2026-07-07 doc). */
+  DEFAULT_UNPLAYED_MMR: 1095,
+  /**
+   * Floor applied to `t` inside the GSP<->MMR transforms (NOT from the doc —
+   * an implementation guard, 2026-07-07). The doc's linear drift model is
+   * anchored mid-2026; extrapolated far enough backward it eventually makes
+   * the curve degenerate (`ceiling(t) <= A` around t = -140,627, ~2010).
+   * t = 0 corresponds to ~3 weeks before the anchor (late May 2026);
+   * conversions for readings older than that clamp here and carry extra
+   * error — the drift rate before the doc's observation window is unknown
+   * anyway, so a linear backward extrapolation would be false precision.
+   */
+  T_MIN: 0,
+} as const;
+
+/** `zone` marks which piece of the piecewise model a reading falls into — 'main' is the +/-1-GSP-accurate normal-CDF curve; 'top'/'bottom' are the approximate, drifting linear tails. */
+export type GspZone = 'main' | 'top' | 'bottom';
+
+/**
+ * `ceiling(t) = K + 100t` — the main curve's slowly-rising GSP ceiling
+ * (2026-07-07 doc). `t` is floored at `GSP_MODEL.T_MIN` so a wildly-negative
+ * estimate (pre-2026 timestamps, or a garbage calibration input) can never
+ * push the ceiling below the floor `A` and flip the curve inside out — see
+ * the `T_MIN` comment for why the model can't honestly reach back that far.
+ */
+function ceilingAt(t: number): number {
+  return GSP_MODEL.K + 100 * Math.max(t, GSP_MODEL.T_MIN);
+}
+
+/** Forward transform for the main curve only: `A + (ceiling(t) - A) * Φ((mmr - CENTER)/SIGMA)`. */
+function mainCurveGsp(mmr: number, t: number): number {
+  const z = (mmr - GSP_MODEL.CENTER) / GSP_MODEL.SIGMA;
+  return GSP_MODEL.A + (ceilingAt(t) - GSP_MODEL.A) * normCdf(z);
+}
+
+/** GSP at the main curve's upper boundary (MMR 1400), the anchor for the top tail. */
+function gspAtMainMax(t: number): number {
+  return mainCurveGsp(GSP_MODEL.MAIN_MAX, t);
+}
+
+/** GSP at the main curve's lower boundary (MMR 600), the anchor for the bottom tail. */
+function gspAtMainMin(t: number): number {
+  return mainCurveGsp(GSP_MODEL.MAIN_MIN, t);
+}
+
+/**
+ * Calibration input for `estimateT`: a user-supplied "what's the Elite
+ * threshold right now" reading (from editing the Elite Threshold card),
+ * paired with when it was entered. Because Elite entry is a fixed MMR
+ * (1142), a fresh threshold reading lets us solve for `t` at that instant
+ * more precisely than extrapolating purely from the anchor — this becomes
+ * the new basis for projecting `t` forward.
+ */
+export interface TCalibration {
+  /** The Elite Smash entry GSP the user reported as current, at `atMs`. */
+  eliteThresholdGsp: number;
+  /** Epoch ms the calibration reading was taken/saved. */
+  atMs: number;
+}
+
+/**
+ * Estimates the drifting `t` parameter at `atMs`.
+ *
+ * Without a calibration: linear extrapolation from the doc's anchor
+ * (`t = 502` at 2026-06-11T19:21:00Z), advancing at `T_PER_HOUR` (0.98/hour).
+ *
+ * With a `calibration` (the user's most recent Elite-threshold edit): solves
+ * `eliteThresholdGsp = A + (K + 100*t - A) * Φ((ELITE_MMR - CENTER)/SIGMA)`
+ * for `t` at `calibration.atMs`, then extrapolates from THAT point instead —
+ * the user's threshold edit becomes a fresh t-recalibration, which is more
+ * accurate than the fixed 2026-06-11 anchor as real time passes it by.
+ */
+export function estimateT(atMs: number, calibration?: TCalibration): number {
+  if (calibration) {
+    const phiElite = normCdf((GSP_MODEL.ELITE_MMR - GSP_MODEL.CENTER) / GSP_MODEL.SIGMA);
+    // eliteThresholdGsp = A + (K + 100*tCal - A) * phiElite
+    // => tCal = ((eliteThresholdGsp - A) / phiElite - K + A) / 100
+    const tAtCalibration =
+      ((calibration.eliteThresholdGsp - GSP_MODEL.A) / phiElite - GSP_MODEL.K + GSP_MODEL.A) / 100;
+    const hoursSince = (atMs - calibration.atMs) / (1000 * 60 * 60);
+    return tAtCalibration + hoursSince * GSP_MODEL.T_PER_HOUR;
+  }
+
+  const hoursSince = (atMs - GSP_MODEL.T_ANCHOR.atMs) / (1000 * 60 * 60);
+  return GSP_MODEL.T_ANCHOR.t + hoursSince * GSP_MODEL.T_PER_HOUR;
+}
+
+/** The current computed Elite Smash entry GSP at drift parameter `t` (i.e. `mmrToGsp(ELITE_MMR, t)`). */
+export function eliteThresholdGsp(t: number): number {
+  return mainCurveGsp(GSP_MODEL.ELITE_MMR, t);
+}
+
+/**
+ * Forward transform: hidden MMR -> GSP, at drift parameter `t`. Applies
+ * whichever of the three zones `mmr` falls into.
+ */
+export function mmrToGsp(mmr: number, t: number): number {
+  if (mmr > GSP_MODEL.MAIN_MAX) {
+    return gspAtMainMax(t) + (mmr - GSP_MODEL.MAIN_MAX) * GSP_MODEL.SLOPE_TOP;
+  }
+  if (mmr < GSP_MODEL.MAIN_MIN) {
+    return gspAtMainMin(t) - (GSP_MODEL.MAIN_MIN - mmr) * GSP_MODEL.SLOPE_BOTTOM;
+  }
+  return mainCurveGsp(mmr, t);
+}
+
+export interface GspToMmrResult {
+  /** Estimated hidden MMR for this GSP reading, at drift parameter `t`. */
+  mmr: number;
+  /** Which zone of the piecewise model the reading fell into — 'main' is +/-1-GSP-accurate; 'top'/'bottom' are approximate linear tails. */
+  zone: GspZone;
+}
+
+/**
+ * Inverse transform: GSP -> estimated hidden MMR, at drift parameter `t`.
+ * Inverts the main curve via `normInv`; readings at/beyond the main curve's
+ * boundary GSP values (`gsp(1400)` / `gsp(600)`) are inverted via the linear
+ * tails instead, and clamp/zone accordingly so wildly out-of-range input
+ * (e.g. negative GSP, or GSP far beyond anything achievable) still returns a
+ * finite estimate rather than throwing.
+ */
+export function gspToMmr(gsp: number, t: number): GspToMmrResult {
+  const gspMax = gspAtMainMax(t);
+  const gspMin = gspAtMainMin(t);
+
+  if (gsp > gspMax) {
+    const mmr = GSP_MODEL.MAIN_MAX + (gsp - gspMax) / GSP_MODEL.SLOPE_TOP;
+    return { mmr, zone: 'top' };
+  }
+  if (gsp < gspMin) {
+    const mmr = GSP_MODEL.MAIN_MIN - (gspMin - gsp) / GSP_MODEL.SLOPE_BOTTOM;
+    return { mmr, zone: 'bottom' };
+  }
+
+  const ceiling = ceilingAt(t);
+  const p = (gsp - GSP_MODEL.A) / (ceiling - GSP_MODEL.A);
+  // Clamp to a valid CDF domain — floating point can push p just outside
+  // (0, 1) at the exact boundaries, where normInv would return +/-Infinity.
+  const clampedP = Math.min(Math.max(p, 1e-12), 1 - 1e-12);
+  const z = normInv(clampedP);
+  const mmr = GSP_MODEL.CENTER + z * GSP_MODEL.SIGMA;
+  return { mmr, zone: 'main' };
+}
+
+/**
+ * Observed (MMR difference -> zero-sum points) breakpoints from the
+ * reverse-engineered doc, verbatim where the doc gives an explicit range.
+ * `diffMin`/`diffMax` are the inclusive bounds of winner-minus-loser MMR the
+ * doc associates with each point value; gaps between breakpoints (and diffs
+ * beyond the table entirely) are filled by the Elo K=20 model in
+ * `mmrPointsForWin`, not by this table. Ordered from largest diff (blowout
+ * favorite win, 0 points) to most negative (huge upset).
+ *
+ * NOTE on the doc's tail shorthand: the source doc's last few entries were
+ * written as "..−390→18, →19, →20" — a compressed sequence with NO explicit
+ * diff ranges for 19 and 20. Rather than inventing bands for them, this
+ * table stops at the last explicitly-ranged observation (18, up to −390) and
+ * lets the Elo fill produce 19/20 for larger upsets — the fill's logistic
+ * curve reaches 19 around diff −437 and 20 around diff −637.
+ */
+export const MMR_POINTS_TABLE: ReadonlyArray<{
+  diffMin: number;
+  diffMax: number;
+  points: number;
+}> = [
+  { diffMin: 533, diffMax: Infinity, points: 0 },
+  { diffMin: 411, diffMax: 523, points: 1 },
+  { diffMin: 333, diffMax: 394, points: 2 },
+  { diffMin: 253, diffMax: 313, points: 3 },
+  { diffMin: 207, diffMax: 242, points: 4 },
+  { diffMin: 170, diffMax: 177, points: 5 },
+  { diffMin: 140, diffMax: 140, points: 6 },
+  { diffMin: 87, diffMax: 108, points: 7 },
+  { diffMin: 44, diffMax: 85, points: 8 },
+  { diffMin: 7, diffMax: 40, points: 9 },
+  { diffMin: -28, diffMax: 5, points: 10 },
+  { diffMin: -60, diffMax: -30, points: 11 },
+  { diffMin: -97, diffMax: -68, points: 12 },
+  { diffMin: -130, diffMax: -98, points: 13 },
+  { diffMin: -165, diffMax: -131, points: 14 },
+  { diffMin: -200, diffMax: -200, points: 15 },
+  { diffMin: -251, diffMax: -233, points: 16 },
+  { diffMin: -290, diffMax: -290, points: 17 },
+  { diffMin: -390, diffMax: -291, points: 18 },
+];
+
+/** The delta system's Elo K-factor: every observed row is within ~0.9 points of K=20 Elo (see module doc). */
+export const MMR_ELO_K = 20;
+
+/**
+ * Continuous Elo expectation for the winner's point gain at
+ * `diff = winnerMmr - loserMmr`: `K * (1 - 1/(1 + 10^(-diff/400)))` — the
+ * standard logistic Elo update with K=20 and the conventional 400 divisor.
+ * At diff 0 this is exactly K/2 = 10. Validated against the doc's observed
+ * table: every row within 0.9 points, mean |error| 0.41 (see module doc; the
+ * exact integer quantization the game applies on top of this is unresolved).
+ */
+export function eloExpectedPointsForWin(diff: number): number {
+  return MMR_ELO_K * (1 - 1 / (1 + Math.pow(10, -diff / 400)));
+}
+
+/**
+ * Zero-sum MMR points awarded to the WINNER of a match (the loser loses the
+ * same amount), as a function of `diff = winnerMmr - loserMmr`, for two
+ * already-stabilized characters (see module doc — fresh/unstabilized
+ * characters swing more and are out of scope here).
+ *
+ * Looks up the observed breakpoint table verbatim first
+ * (`MMR_POINTS_TABLE`); for any diff that falls in a gap between observed
+ * bands (the doc only sampled specific points), rounds the continuous Elo
+ * K=20 expectation (`eloExpectedPointsForWin`) instead. Both paths are
+ * exercised and documented so callers can tell which is which via
+ * `mmrPointsForWinDetailed`. Single-point precision is approximate either
+ * way — the game's exact integer quantization is unresolved (module doc).
+ */
+export function mmrPointsForWin(diff: number): number {
+  return mmrPointsForWinDetailed(diff).points;
+}
+
+export interface MmrPointsResult {
+  points: number;
+  /** Whether `points` came from the doc's verbatim observed table or from rounding the continuous Elo K=20 expectation. */
+  source: 'observed' | 'elo-fill';
+}
+
+/** Same as `mmrPointsForWin` but also reports whether the result came from the observed table or the Elo fill (see doc comment on `mmrPointsForWin`). */
+export function mmrPointsForWinDetailed(diff: number): MmrPointsResult {
+  const hit = MMR_POINTS_TABLE.find((row) => diff >= row.diffMin && diff <= row.diffMax);
+  if (hit) {
+    return { points: hit.points, source: 'observed' };
+  }
+  // Math.round of a value already bounded in (0, 20) by the logistic curve —
+  // no extra clamp needed.
+  return { points: Math.round(eloExpectedPointsForWin(diff)), source: 'elo-fill' };
+}
+
+/** Hard cap on projected matches, mirroring `MAX_SIMULATED_MATCHES` in gsp.ts. */
+export const MAX_PROJECTED_MATCHES = 2000;
+
+/**
+ * Assumed per-match zero-sum points when matchmaking pairs opponents of
+ * similar MMR (diff ~ 0, `mmrPointsForWin(0) = 10`) — the projection's
+ * flat-rate assumption, now Elo-justified: at diff 0 the continuous Elo K=20
+ * expectation is exactly K/2 = 10, and the observed table agrees.
+ */
+export const ASSUMED_MMR_POINTS_PER_MATCH = mmrPointsForWin(0);
+
+export type EliteMmrProjection =
+  | { status: 'already-elite' }
+  | { status: 'equilibrium' }
+  | { status: 'projected'; matchesNeeded: number }
+  | { status: 'capped' };
+
+/**
+ * Projects net matches needed to reach `GSP_MODEL.ELITE_MMR`, given the
+ * player's current estimated MMR and recent win rate, under a simplifying
+ * assumption: matchmaking pairs opponents of similar MMR, so every match
+ * (win or loss) trades close to `ASSUMED_MMR_POINTS_PER_MATCH` (~10) points —
+ * `mmrPointsForWin(0)`, the zero-sum value at diff=0. Expected net MMR per
+ * match is then `p * g - (1-p) * g = (2p - 1) * g` where `p` is the recent
+ * win rate and `g` is that flat per-match point value.
+ *
+ * This is a much simpler model than `gsp.ts`'s `projectMatchesToElite`
+ * (which fits an exponential decay from the player's own GSP history) —
+ * here we lean entirely on the reverse-engineered zero-sum system (observed
+ * table + Elo K=20, see `mmrPointsForWin`) rather than curve-fitting, since
+ * MMR deltas (unlike GSP deltas) are NOT expected to shrink as the player
+ * climbs (points fall out of a fixed Elo-style MMR-gap rule, not a
+ * population-relative curve).
+ *
+ * Discriminated result:
+ *   - `'already-elite'`: `currentMmr >= ELITE_MMR` already.
+ *   - `'equilibrium'`: `winRate <= 0.5` — expected net progress is <= 0.
+ *     This is NOT an error state: matchmaking pairing the player against
+ *     similar-MMR opponents at a <=50% win rate means the system has found
+ *     their current level. The UI must present this kindly (a >50% win rate,
+ *     not more grinding, is what moves the number).
+ *   - `'projected'`: a finite `matchesNeeded` under `MAX_PROJECTED_MATCHES`.
+ *   - `'capped'`: progress is positive but so slow the cap was hit before
+ *     reaching Elite.
+ */
+export function projectMatchesToEliteMmr(
+  currentMmr: number,
+  recentWinRate: number,
+): EliteMmrProjection {
+  if (currentMmr >= GSP_MODEL.ELITE_MMR) {
+    return { status: 'already-elite' };
+  }
+  if (recentWinRate <= 0.5) {
+    return { status: 'equilibrium' };
+  }
+
+  const expectedNetPerMatch = (2 * recentWinRate - 1) * ASSUMED_MMR_POINTS_PER_MATCH;
+  const mmrNeeded = GSP_MODEL.ELITE_MMR - currentMmr;
+  const matchesNeeded = Math.ceil(mmrNeeded / expectedNetPerMatch);
+
+  if (matchesNeeded > MAX_PROJECTED_MATCHES) {
+    return { status: 'capped' };
+  }
+  return { status: 'projected', matchesNeeded };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,3 +37,4 @@ export * from './billing.js';
 export * from './meta.js';
 export * from './matchupAdvisor.js';
 export * from './gsp.js';
+export * from './gspMmr.js';


### PR DESCRIPTION
## Summary

Upgrades the live GSP tracker (`/gsp`) with the community-reverse-engineered GSP formula: a hidden whole-number **MMR** drives matchmaking, and GSP is a deterministic transform of it. Source doc (URL + capture date 2026-07-07) is cited in the `gspMmr.ts` module doc and linked from the page.

### New shared module — `packages/shared/src/gspMmr.ts`

- **Main curve (MMR 600–1400):** `GSP = A + (ceiling(t) − A)·Φ((MMR−1000)/110)` with `A = 1,995,587`, `ceiling(t) = 16,058,300 + 100t`. Verified against the doc's worked example: **t=502 ⇒ Elite threshold 14,720,247** (unit test, exact after rounding; raw value 14,720,246.52 vs the doc's 14,720,246.6).
- **Tails:** linear above MMR 1400 (slope ≈220.5) and below 600 (slope ≈248.8), labeled approximate via a `zone` discriminator.
- **`normCdf`/`normInv`:** Numerical Recipes erfc fit (<1.2e-7) + Acklam's inverse-normal (~1.15e-9), algorithms + precision documented.
- **t drift:** ~0.98/hour from the anchor (t=502 @ 2026-06-11T19:21Z). `estimateT` accepts a **calibration** — the user's Elite-threshold edit becomes a t-recalibration (solves t from the Elite fixed point, MMR 1142). A `T_MIN` floor guards against degenerate backward extrapolation (documented as an implementation guard, not a doc constant).
- **Match deltas (amended spec):** observed zero-sum breakpoint table encoded verbatim + **Elo K=20 logistic fill** (`20·(1 − 1/(1+10^(−diff/400)))`) for gaps — every observed row is within ±1 of the Elo value; the exact integer quantization is unresolved and documented as approximate. `mmrPointsForWinDetailed` reports `'observed' | 'elo-fill'` per lookup. The doc's shorthand tail (no explicit bands for 19/20) is resolved by the Elo fill rather than invented bands — noted in the table doc.
- **`projectMatchesToEliteMmr`:** net/match = `(2p−1)·10` (even matchmaking ⇒ K/2 = 10 at diff 0, Elo-justified); discriminated result with an honest **`equilibrium`** outcome for ≤50% win rates, plus already-elite / projected / capped (2000).

### GSP page changes

- **Hero:** new *Est. MMR* card (tail-zone caveat when applicable; honest-labeling caption links the community doc), distance-to-Elite reframed in MMR ("MMR 1,000 · below Elite (1142)"), Elite badge now MMR-based. The **Elite Threshold card shows the computed value** by default and stays editable — "editing recalibrates the model — grab the current number from elitegsp.com". Existing `gspSettingsSchema` doubles as the calibration store (`eliteThreshold` + `updatedAt`) — **no schema change, verified**; `updatedAt: 0` (never saved) falls back to the doc anchor.
- **Road to Elite:** MMR projection is primary ("~N more matches at ~10 MMR/match"); V10's own-history decay simulation is kept as a secondary "from your own GSP history" line; equilibrium gets supportive copy ("matchmaking thinks this is your level right now — a >50% win rate is what moves you up").
- **Quick logger toast:** "+500,000 GSP · ≈ +9 MMR" — MMR delta shown only when both readings convert cleanly (both on the ±1-accurate main curve), each converted at its own log-time t.
- **Curve:** GSP | MMR toggle. MMR view converts each reading at its own log-time t, so flat skill plots flat (unlike inflating GSP); dashed line at MMR 1142.
- **Est. MMR vs Glicko-2** (was GSP vs Glicko-2): compares the converted MMR series against Glicko — rating vs rating. Min-max normalization **kept** (raw scales are still unrelated), but the shapes are now honestly comparable since neither series inflates; decision documented in `buildGspVsGlickoData`.

### Tests

- `packages/shared`: 173 passing (45 new in `gspMmr.test.ts` — worked example, round-trips across all three zones, T_MIN guard, full delta-table verbatim check, Elo-fill vs observed precedence, zero-sum symmetry, projection branches incl. equilibrium/capped).
- `apps/web`: 879 passing — new page-level tests for the Est. MMR stat, tail caveat, computed threshold + recalibration edit, GSP+MMR delta toast, curve view toggle, and all Road-to-Elite states; new unit tests for `gspMmrModel` (calibration mapping, flat-skill-stays-flat) and `buildMmrCurveData`.
- Full gate: `pnpm lint` ✅ (0 errors) · `typecheck` ✅ · `test` ✅ (173 + 408 + 879) · `build` ✅ · `format:check` ✅

### Notes / deviations

- No API changes were needed (no new routes, no `buildApp` options, no RTDB shape changes).
- New/unstabilized characters swing more than the delta table — noted as out of scope in the module doc, per the source.
- `Date.now()` in render tripped the `react-hooks/purity` lint rule — added a `useNowMs()` mount-time hook (the computed threshold drifts ~88 GSP/hour, so a static "now" per visit is exact enough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
