### PR TITLE
Move canonical domain to grandfinals.gg

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,7 +7,7 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#18181b" />
-    <link rel="canonical" href="https://smash-tracker-f97b7.web.app/" />
+    <link rel="canonical" href="https://grandfinals.gg/" />
 
     <title>Smash Tracker — Free Super Smash Bros. Ultimate Analytics & GSP Tracker</title>
     <meta
@@ -17,7 +17,7 @@
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Smash Tracker" />
-    <meta property="og:url" content="https://smash-tracker-f97b7.web.app/" />
+    <meta property="og:url" content="https://grandfinals.gg/" />
     <meta
       property="og:title"
       content="Smash Tracker — Free Super Smash Bros. Ultimate Analytics & GSP Tracker"
@@ -26,7 +26,7 @@
       property="og:description"
       content="Free Super Smash Bros. Ultimate analytics: GSP & Elite Smash tracking, start.gg/parry.gg sync, matchup stats, stage mastery, and AI scouting reports."
     />
-    <meta property="og:image" content="https://smash-tracker-f97b7.web.app/og-image.png" />
+    <meta property="og:image" content="https://grandfinals.gg/og-image.png" />
 
     <meta name="twitter:card" content="summary" />
     <meta
@@ -37,7 +37,7 @@
       name="twitter:description"
       content="Free Super Smash Bros. Ultimate analytics: GSP & Elite Smash tracking, start.gg/parry.gg sync, matchup stats, stage mastery, and AI scouting reports."
     />
-    <meta name="twitter:image" content="https://smash-tracker-f97b7.web.app/og-image.png" />
+    <meta name="twitter:image" content="https://grandfinals.gg/og-image.png" />
 
     <script type="application/ld+json">
       {
@@ -46,7 +46,7 @@
         "name": "Smash Tracker",
         "applicationCategory": "GameApplication",
         "operatingSystem": "Web",
-        "url": "https://smash-tracker-f97b7.web.app/",
+        "url": "https://grandfinals.gg/",
         "description": "Free analytics for competitive Super Smash Bros. Ultimate players: GSP and Elite Smash tracking, start.gg and parry.gg sync, matchup analytics, opponent scouting, AI scouting reports, and Glicko-2 friend-group leaderboards.",
         "offers": {
           "@type": "Offer",

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://smash-tracker-f97b7.web.app/sitemap.xml
+Sitemap: https://grandfinals.gg/sitemap.xml

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://smash-tracker-f97b7.web.app/</loc>
+    <loc>https://grandfinals.gg/</loc>
   </url>
 </urlset>

--- a/apps/web/src/test/seo.test.ts
+++ b/apps/web/src/test/seo.test.ts
@@ -38,13 +38,13 @@ describe('SEO static files (apps/web/public/)', () => {
     const contents = readPublicFile('/public/robots.txt');
     expect(contents).toMatch(/User-agent:\s*\*/);
     expect(contents).toMatch(/Allow:\s*\//);
-    expect(contents).toContain('Sitemap: https://smash-tracker-f97b7.web.app/sitemap.xml');
+    expect(contents).toContain('Sitemap: https://grandfinals.gg/sitemap.xml');
   });
 
   it('sitemap.xml lists only the crawlable root route', () => {
     const contents = readPublicFile('/public/sitemap.xml');
     expect(contents).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
-    expect(contents).toContain('<loc>https://smash-tracker-f97b7.web.app/</loc>');
+    expect(contents).toContain('<loc>https://grandfinals.gg/</loc>');
     // Every other route requires auth and can't be indexed, so exactly one
     // <url> entry is expected.
     expect(contents.match(/<url>/g)).toHaveLength(1);


### PR DESCRIPTION
Custom domain cutover: canonical, OG/JSON-LD URLs, robots.txt, and sitemap.xml now point at **https://grandfinals.gg**. The old `web.app` domain keeps serving (both connected to the same Hosting site); canonical tags de-duplicate for search. Env-side (deploy time, not in this diff): `VITE_FIREBASE_AUTH_DOMAIN=grandfinals.gg` (domain already added to Firebase Auth authorized domains), `CORS_ORIGIN` gains the new origin, `WEB_BASE_URL` moves so Stripe/OAuth redirects land on the brand domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)