### PR TITLE
Fix start.gg login callback 500 masking the real error

### DIFF
--- a/apps/api/src/routes/startgg.test.ts
+++ b/apps/api/src/routes/startgg.test.ts
@@ -205,4 +205,25 @@ describe('start.gg routes (configured)', () => {
 
     expect(response.headers.location).toContain('custom-token-for-existing-uid');
   });
+
+  it('login callback degrades to an error redirect when completion throws', async () => {
+    const { app, auth } = buildTestApp({ startgg: CONFIG, startggFetch: oauthFetchMock() });
+    // Mirrors the live incident: createCustomToken throwing (the runtime
+    // service account lacked iam.serviceAccounts.signBlob) must not surface
+    // as a 500 — Hosting's proxy retries 5xx and burns the single-use code.
+    auth.createCustomToken = async () => {
+      throw new Error('Permission iam.serviceAccounts.signBlob denied');
+    };
+    const state = signState(CONFIG.stateSecret, 'login');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/integrations/startgg/callback?code=auth-code&state=${encodeURIComponent(state)}`,
+    });
+
+    expect(response.statusCode).toBe(302);
+    const location = response.headers.location as string;
+    expect(location).toContain('startgg=error');
+    expect(location).toContain('reason=login_failed');
+  });
 });

--- a/apps/api/src/routes/startgg.ts
+++ b/apps/api/src/routes/startgg.ts
@@ -200,27 +200,37 @@ const startggRoutes: FastifyPluginAsyncZod<StartggRoutesOptions> = async (app, o
       if (!email) {
         return failure('email_unavailable');
       }
-      let firebaseUser;
+      // Everything past the code exchange must degrade to the same
+      // redirect-with-reason as the other failure paths: a raw 500 here makes
+      // Firebase Hosting's proxy retry the callback, and the retry burns the
+      // single-use OAuth code on an attempt the user never sees (observed
+      // live when createCustomToken lacked iam.serviceAccounts.signBlob).
       try {
-        firebaseUser = await app.firebase.auth.getUserByEmail(email);
-      } catch {
-        firebaseUser = await app.firebase.auth.createUser({ email });
+        let firebaseUser;
+        try {
+          firebaseUser = await app.firebase.auth.getUserByEmail(email);
+        } catch {
+          firebaseUser = await app.firebase.auth.createUser({ email });
+        }
+        const customToken = await app.firebase.auth.createCustomToken(firebaseUser.uid);
+        // Also persist the link for the newly signed-in account so sync works
+        // immediately after a "login with start.gg".
+        const record: StartggLinkRecord = {
+          userId: identity.id,
+          playerId: identity.player.id,
+          gamerTag: identity.player.gamerTag,
+          slug: identity.slug,
+          linkedAt: Date.now(),
+        };
+        await linksRef(firebaseUser.uid).update(record);
+        // Token travels in the URL fragment: fragments never reach servers/logs.
+        return reply.redirect(
+          `${config.webBaseUrl}/auth/startgg#token=${encodeURIComponent(customToken)}`,
+        );
+      } catch (err) {
+        request.log.error({ err }, 'start.gg login completion failed');
+        return failure('login_failed');
       }
-      const customToken = await app.firebase.auth.createCustomToken(firebaseUser.uid);
-      // Also persist the link for the newly signed-in account so sync works
-      // immediately after a "login with start.gg".
-      const record: StartggLinkRecord = {
-        userId: identity.id,
-        playerId: identity.player.id,
-        gamerTag: identity.player.gamerTag,
-        slug: identity.slug,
-        linkedAt: Date.now(),
-      };
-      await linksRef(firebaseUser.uid).update(record);
-      // Token travels in the URL fragment: fragments never reach servers/logs.
-      return reply.redirect(
-        `${config.webBaseUrl}/auth/startgg#token=${encodeURIComponent(customToken)}`,
-      );
     },
   );
 };


### PR DESCRIPTION
## Incident
A user reported "login with start.gg" bouncing them back to the home page signed out. Cloud Run logs showed every login attempt: callback → **500** (uncaught `auth/insufficient-permission`: the runtime service account lacks `iam.serviceAccounts.signBlob` for `createCustomToken`) → Hosting proxy retries the callback → retry fails `exchange_failed` because the single-use OAuth code was already consumed → user redirected home with no useful signal.

## Fix (this PR)
Wrap the login-completion branch (`getUserByEmail`/`createUser`/`createCustomToken`/link persistence) in try/catch so any throw degrades to the established `/?startgg=error&reason=login_failed` redirect and logs the underlying error, instead of 500ing and burning the code on a proxy retry. Regression test mirrors the incident (createCustomToken throwing → 302 with `reason=login_failed`).

## Root-cause remediation (separate, IAM — not in this PR)
The actual permission fix is granting the Cloud Run runtime SA **Service Account Token Creator** on itself:
```
gcloud iam service-accounts add-iam-policy-binding 781901075636-compute@developer.gserviceaccount.com \
  --member="serviceAccount:781901075636-compute@developer.gserviceaccount.com" \
  --role="roles/iam.serviceAccountTokenCreator" --project=smash-tracker-f97b7
```

## Verification
- 12/12 startgg route tests (11 existing + 1 new), API typecheck clean
- Production-gap checklist: no new buildApp options, no Dockerfile/RTDB-write/timeout/GA/auth-domain/DNS changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)