### PR TITLE
Fix stale comment: legacy createProfile Cloud Function is now actually deleted

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,8 +12,10 @@ const usersRoutes: FastifyPluginAsyncZod = async (app) => {
 
   app.addHook('preHandler', app.authenticate);
 
-  // PUT /api/users/me — idempotent upsert, replaces the deleted Cloud
-  // Function's onCreate auth trigger (`users/{uid} = { email }`).
+  // PUT /api/users/me — idempotent upsert. Replaces the legacy `createProfile`
+  // Cloud Function (auth onCreate trigger writing `users/{uid} = { email }`),
+  // deleted from the smash-tracker-f97b7 project on 2026-07-08. The user node
+  // is now created only when the client calls this endpoint.
   app.put(
     '/users/me',
     {


### PR DESCRIPTION
## Summary
- The comment on `PUT /api/users/me` claimed the legacy `createProfile` auth-onCreate Cloud Function was already deleted — it wasn't. It was still ACTIVE in `smash-tracker-f97b7` (1st-gen, nodejs14, us-central1), writing `users/{uid} = { email }` to RTDB on every Firebase Auth account creation, and it scaffolded the orphaned shell-account records during the 2026-07-08 start.gg-login incident.
- The deployed function has now been deleted (`gcloud functions delete createProfile --region=us-central1`); the project has **zero** Cloud Functions remaining. This PR updates the comment to match reality: the user node is created only when the client calls `PUT /api/users/me`.

## Verification
- `grep -rn createProfile` across the repo: no references (the legacy `functions/` source dir was already removed in 5f531c0; `firebase.json` has no `functions` block).
- `gcloud functions list --project=smash-tracker-f97b7` after deletion: `Listed 0 items.`

Note: dependabot PRs #59–71 target the legacy tree deleted in 5f531c0 and can all be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)