### PR TITLE
Track page views on every route, not just the authenticated shell

### DIFF
--- a/apps/web/src/layouts/MainLayout.tsx
+++ b/apps/web/src/layouts/MainLayout.tsx
@@ -1,7 +1,5 @@
-import { useEffect, type ReactNode } from 'react';
-import { useLocation } from 'react-router';
+import { type ReactNode } from 'react';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { logAnalyticsPageView } from '@/lib/firebase';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 import { Footer } from './Footer';
@@ -15,13 +13,8 @@ import { Footer } from './Footer';
  * page's stage-chip and Advisor Retrospective tooltips).
  */
 export function MainLayout({ children }: { children: ReactNode }) {
-  // GA4 only auto-collects the initial page load; SPA navigations are
-  // reported here. No-ops entirely when analytics isn't configured.
-  const location = useLocation();
-  useEffect(() => {
-    logAnalyticsPageView(location.pathname);
-  }, [location.pathname]);
-
+  // page_view reporting lives in routes/RouteAnalytics.tsx (app-wide, public
+  // pages included), not here.
   return (
     <TooltipProvider>
       <div className="flex min-h-svh flex-col">

--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -87,6 +87,12 @@ function initAnalytics(): Promise<AnalyticsContext | null> {
     if (!config.measurementId) {
       return null;
     }
+    // Automated browsers are excluded: scripts/prerender.mjs loads the public
+    // routes in headless Chrome on every deploy, and counting those (or other
+    // headless bots) would pollute acquisition data with phantom visits.
+    if (typeof navigator !== 'undefined' && navigator.webdriver) {
+      return null;
+    }
     const mod = await import('firebase/analytics');
     if (!(await mod.isSupported().catch(() => false))) {
       return null;
@@ -96,8 +102,8 @@ function initAnalytics(): Promise<AnalyticsContext | null> {
     // default 'auto' domain walk tries to set _ga cookies at the web.app
     // level — browsers reject those ("invalid domain" console errors on
     // every page in Firefox) before falling back. send_page_view is off
-    // because MainLayout logs page_view itself on mount + every route
-    // change (the signed-out landing page is deliberately uncounted).
+    // because routes/RouteAnalytics.tsx logs page_view on mount + every
+    // route change, for every route (public SEO pages included).
     const analytics = mod.initializeAnalytics(getFirebaseApp(), {
       config: {
         cookie_domain: window.location.hostname,

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import { HomePage } from '@/pages/Home/HomePage';
 import { ProtectedRoute } from './ProtectedRoute';
+import { RouteAnalytics } from './RouteAnalytics';
 
 /**
  * V12 SEO: every page except HomePage is lazy-loaded so the entry chunk stays
@@ -94,6 +95,7 @@ function RouteFallback() {
 export function AppRouter() {
   return (
     <BrowserRouter>
+      <RouteAnalytics />
       <Suspense fallback={<RouteFallback />}>
         <Routes>
           <Route path="/" element={<HomePage />} />

--- a/apps/web/src/routes/RouteAnalytics.test.tsx
+++ b/apps/web/src/routes/RouteAnalytics.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router';
+import { logAnalyticsPageView } from '@/lib/firebase';
+import { RouteAnalytics } from './RouteAnalytics';
+
+vi.mock('@/lib/firebase', () => ({
+  logAnalyticsPageView: vi.fn(),
+}));
+
+function renderWithRouter() {
+  return render(
+    <MemoryRouter initialEntries={['/faq']}>
+      <RouteAnalytics />
+      <Routes>
+        <Route path="/faq" element={<Link to="/gsp-calculator">go</Link>} />
+        <Route path="/gsp-calculator" element={<div>calculator</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RouteAnalytics', () => {
+  beforeEach(() => {
+    vi.mocked(logAnalyticsPageView).mockClear();
+  });
+
+  it('logs a page_view for the initial route, including public ones', () => {
+    renderWithRouter();
+    expect(logAnalyticsPageView).toHaveBeenCalledExactlyOnceWith('/faq');
+  });
+
+  it('logs a page_view on every navigation', async () => {
+    renderWithRouter();
+    await userEvent.click(screen.getByRole('link', { name: 'go' }));
+
+    expect(await screen.findByText('calculator')).toBeInTheDocument();
+    expect(logAnalyticsPageView).toHaveBeenCalledTimes(2);
+    expect(logAnalyticsPageView).toHaveBeenLastCalledWith('/gsp-calculator');
+  });
+});

--- a/apps/web/src/routes/RouteAnalytics.tsx
+++ b/apps/web/src/routes/RouteAnalytics.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import { logAnalyticsPageView } from '@/lib/firebase';
+
+/**
+ * App-wide GA4 page_view reporter, mounted once inside the router.
+ *
+ * GA4 auto-collection is disabled (`send_page_view: false` in lib/firebase.ts)
+ * and SPA navigations never auto-report, so this effect is the single source
+ * of page_view events: initial mount + every route change, for EVERY route.
+ * It used to live in MainLayout, which meant only authenticated pages were
+ * counted — anonymous visitors on `/`, `/faq`, and `/gsp-calculator` (the
+ * V12 SEO surface, i.e. all acquisition traffic) were invisible and GA
+ * Realtime showed 0 despite real visits.
+ */
+export function RouteAnalytics() {
+  const location = useLocation();
+  useEffect(() => {
+    logAnalyticsPageView(location.pathname);
+  }, [location.pathname]);
+  return null;
+}


### PR DESCRIPTION
## Problem
GA4 Realtime shows 0 active users while real visitors browse the site. `page_view` logging lived in `MainLayout` — the authenticated shell — so the signed-out landing page and the new V12 public pages (`/faq`, `/gsp-calculator`), i.e. **all acquisition traffic**, were never counted.

## Change
- New `RouteAnalytics` component mounted once inside `BrowserRouter`: logs `page_view` on initial mount + every SPA navigation, for every route (public + authed). MainLayout's logging removed (single source, no double-counting).
- `initAnalytics` now no-ops under `navigator.webdriver`, so the deploy-time puppeteer prerender of the public routes (and headless bots) don't log phantom visits.

## Verification
- 907/907 web tests (2 new: initial-route + navigation page_view assertions), lint/typecheck clean.
- After deploy: load grandfinals.gg in a normal browser and watch GA Realtime blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)