### PR TITLE
Per-route document titles so GA page reports are readable

### DIFF
--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -123,9 +123,14 @@ function initAnalytics(): Promise<AnalyticsContext | null> {
 export function logAnalyticsPageView(pagePath: string): void {
   void initAnalytics().then((ctx) => {
     if (ctx) {
+      // document.title is read here — after initAnalytics' promise resolves,
+      // i.e. after the commit's effect flush — so RouteTitles/useSeo have
+      // already set the per-route title and GA's "Views by Page title"
+      // gets real page names instead of one collapsed row.
       ctx.mod.logEvent(ctx.analytics, 'page_view', {
         page_path: pagePath,
         page_location: window.location.href,
+        page_title: document.title,
       });
     }
   });

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import { HomePage } from '@/pages/Home/HomePage';
 import { ProtectedRoute } from './ProtectedRoute';
 import { RouteAnalytics } from './RouteAnalytics';
+import { RouteTitles } from './RouteTitles';
 
 /**
  * V12 SEO: every page except HomePage is lazy-loaded so the entry chunk stays
@@ -95,6 +96,10 @@ function RouteFallback() {
 export function AppRouter() {
   return (
     <BrowserRouter>
+      {/* Order matters: RouteTitles' effect runs before RouteAnalytics reads
+          document.title (the async analytics init resolves after the whole
+          effect flush), and page-level useSeo effects run before both. */}
+      <RouteTitles />
       <RouteAnalytics />
       <Suspense fallback={<RouteFallback />}>
         <Routes>

--- a/apps/web/src/routes/RouteTitles.test.tsx
+++ b/apps/web/src/routes/RouteTitles.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { navItems } from '@/layouts/nav';
+import { RouteTitles, titleForPath } from './RouteTitles';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <RouteTitles />
+    </MemoryRouter>,
+  );
+}
+
+describe('RouteTitles', () => {
+  it('sets a per-route title for every nav destination', () => {
+    for (const item of navItems) {
+      expect(titleForPath(item.href)).toBe(`${item.title} | Smash Tracker`);
+    }
+  });
+
+  it('applies the title to the document', () => {
+    renderAt('/matchups');
+    expect(document.title).toBe('Matchups | Smash Tracker');
+  });
+
+  it('titles tournament detail pages', () => {
+    expect(titleForPath('/tournaments/tournament-123')).toBe('Tournament | Smash Tracker');
+  });
+
+  it('leaves unmapped (public/SEO) routes alone so useSeo owns them', () => {
+    document.title = 'set by useSeo';
+    renderAt('/gsp-calculator');
+    expect(document.title).toBe('set by useSeo');
+    expect(titleForPath('/')).toBeNull();
+    expect(titleForPath('/faq')).toBeNull();
+  });
+});

--- a/apps/web/src/routes/RouteTitles.tsx
+++ b/apps/web/src/routes/RouteTitles.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import { navItems } from '@/layouts/nav';
+
+/**
+ * Per-route document titles for the authenticated app, mounted once inside
+ * the router. Before this, every authed page shared index.html's static
+ * marketing title, so GA4's "Views by Page title" collapsed the whole app
+ * into one row. Titles derive from the same `navItems` the sidebar renders
+ * (they can't drift), plus explicit entries for routes that aren't in the
+ * nav. RouteAnalytics reads `document.title` after effects flush, so the
+ * page_view hit carries the per-route title.
+ *
+ * Public/SEO routes (`/`, `/faq`, `/gsp-calculator`, `/not-found`) are
+ * deliberately NOT mapped here: they own richer titles via `useSeo`, and
+ * this component leaves any path it doesn't recognize untouched. Plain
+ * `document.title` assignment (not `useSeo`) so the static OG/twitter tags —
+ * which only matter for the crawlable public pages — aren't rewritten with
+ * app-chrome titles.
+ */
+const ROUTE_TITLES: ReadonlyArray<{ prefix: string; title: string }> = [
+  ...navItems.map(({ href, title }) => ({ prefix: href, title })),
+  { prefix: '/profile', title: 'Profile' },
+  { prefix: '/tournaments/', title: 'Tournament' },
+  { prefix: '/auth/startgg', title: 'Signing in with start.gg' },
+];
+
+export function titleForPath(pathname: string): string | null {
+  const match = ROUTE_TITLES.find(
+    ({ prefix }) =>
+      pathname === prefix ||
+      pathname.startsWith(`${prefix}/`) ||
+      (prefix.endsWith('/') && pathname.startsWith(prefix)),
+  );
+  return match ? `${match.title} | Smash Tracker` : null;
+}
+
+export function RouteTitles() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    const title = titleForPath(pathname);
+    if (title !== null) {
+      document.title = title;
+    }
+  }, [pathname]);
+  return null;
+}


### PR DESCRIPTION
## Problem
GA4 "Views by Page title" shows one collapsed row — every authed page shares index.html's static marketing title, so per-page traffic is unreadable in the dashboard (page_path is collected but the Realtime cards key on title).

## Change
- `RouteTitles` mounted once inside the router: sets `document.title` per route ("Matchups | Smash Tracker"), derived from the sidebar's `navItems` so titles can't drift from nav labels, plus explicit entries for `/profile`, `/tournaments/:eventId`, `/auth/startgg`.
- Public/SEO routes (`/`, `/faq`, `/gsp-calculator`, `/not-found`) are deliberately unmapped — their richer `useSeo` titles win, and OG/twitter tags aren't rewritten with app-chrome titles.
- `page_view` events now send an explicit `page_title`, read after the effect flush so it's always the per-route title.

## Verification
911/911 web tests (4 new), lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)