### PR TITLE
Default the opponent to 'unknown' when adding a match

### DIFF
--- a/apps/web/src/components/match-form/MatchForm.tsx
+++ b/apps/web/src/components/match-form/MatchForm.tsx
@@ -482,6 +482,10 @@ export function MatchFormFields({
                         placeholder="Type a name..."
                         value={field.value}
                         onValueChange={(value) => field.onChange(value)}
+                        // Select-all on focus: the field arrives pre-filled
+                        // ('unknown' on add, the saved name on edit), so
+                        // typing should replace it, not append to it.
+                        onFocus={(e) => e.currentTarget.select()}
                       />
                       <CommandList>
                         <CommandEmpty>Press enter to add a new opponent.</CommandEmpty>

--- a/apps/web/src/components/match-form/SetWizard.tsx
+++ b/apps/web/src/components/match-form/SetWizard.tsx
@@ -81,7 +81,10 @@ export function defaultSetSharedValues(fighterId: number): SetSharedFormValues {
   return {
     fighterId,
     opponentFighterId: alphaSpriteList[0]?.id ?? 0,
-    opponentName: '',
+    // Same default as the single-game form (see AddMatchForm's
+    // buildDefaultValues): untouched entries land on the shared "unknown"
+    // opponent instead of demanding a name for random quickplay sets.
+    opponentName: 'unknown',
     matchType: 'none',
     format: 'bo3',
     eventName: '',
@@ -314,6 +317,10 @@ export function SetWizard({
                         placeholder="Type a name..."
                         value={field.value}
                         onValueChange={(value) => field.onChange(value)}
+                        // Select-all on focus — same rationale as the
+                        // single-game form: 'unknown' arrives pre-filled and
+                        // typing should replace it.
+                        onFocus={(e) => e.currentTarget.select()}
                       />
                       <CommandList>
                         <CommandEmpty>Press enter to add a new opponent.</CommandEmpty>

--- a/apps/web/src/pages/Dashboard/components/AddMatchForm.test.tsx
+++ b/apps/web/src/pages/Dashboard/components/AddMatchForm.test.tsx
@@ -64,6 +64,10 @@ async function fillOpponentName(
 ) {
   await user.click(within(dialog).getByRole('combobox', { name: 'Opponent' }));
   const input = await screen.findByPlaceholderText('Type a name...');
+  // The field arrives pre-filled ('unknown' by default) — clear it first,
+  // like a user replacing the value (the real input also selects-all on
+  // focus so typing replaces).
+  await user.clear(input);
   await user.type(input, name);
 }
 
@@ -123,7 +127,7 @@ describe('AddMatchForm', () => {
     expect(createMatch).not.toHaveBeenCalled();
   });
 
-  it('requires an opponent name before submitting', async () => {
+  it("defaults the opponent to 'unknown' when the field is left untouched", async () => {
     const user = userEvent.setup();
     renderForm();
 
@@ -133,8 +137,8 @@ describe('AddMatchForm', () => {
     await user.click(within(dialog).getByRole('radio', { name: 'Win' }));
     await user.click(within(dialog).getByRole('button', { name: 'Save' }));
 
-    expect(await within(dialog).findByText('Opponent name is required')).toBeInTheDocument();
-    expect(createMatch).not.toHaveBeenCalled();
+    await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(1));
+    expect(createMatch).toHaveBeenCalledWith(expect.objectContaining({ opponent: 'unknown' }));
   });
 
   it('submits a correctly shaped CreateMatchInput with a lowercased opponent name and the map sentinel', async () => {
@@ -274,6 +278,7 @@ describe('AddMatchForm', () => {
 
       await user.click(within(dialog).getByRole('combobox', { name: 'Opponent' }));
       const opponentInput = await screen.findByPlaceholderText('Type a name...');
+      await user.clear(opponentInput); // pre-filled with 'unknown'
       await user.type(opponentInput, 'powpow');
 
       await user.click(within(dialog).getByRole('radio', { name: 'Game 1 Win' }));
@@ -314,6 +319,7 @@ describe('AddMatchForm', () => {
 
       await user.click(within(dialog).getByRole('combobox', { name: 'Opponent' }));
       const opponentInput = await screen.findByPlaceholderText('Type a name...');
+      await user.clear(opponentInput); // pre-filled with 'unknown'
       await user.type(opponentInput, 'powpow');
 
       await user.click(within(dialog).getByRole('radio', { name: 'Game 1 Win' }));

--- a/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
+++ b/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
@@ -42,7 +42,11 @@ function buildDefaultValues(fighterId: number): MatchFormValues {
     result: undefined as unknown as MatchFormValues['result'],
     stageId: NO_SELECTION_STAGE.id,
     matchType: 'none',
-    opponentName: '',
+    // 'unknown' by default: most quickplay opponents are randoms, and forcing
+    // a typed name for every match was the top friction in the add flow. All
+    // untouched entries aggregate under one "unknown" opponent (names are
+    // the RTDB key), and the combobox still lets you replace it.
+    opponentName: 'unknown',
     notes: '',
     stocksLeft: undefined,
     eventName: '',


### PR DESCRIPTION
## What
Adding a match no longer demands a typed opponent name. Both entry modes (single game + set wizard) pre-fill the opponent as **unknown** — save immediately and the match lands under one aggregated "unknown" opponent (names are the RTDB key, so they merge naturally). The opponent combobox still works exactly as before for naming real rivals.

## UX detail
The combobox filter input arrives pre-filled now, so it selects-all on focus — typing replaces "unknown" instead of appending to it. Side benefit: the edit form's combobox (pre-filled with the saved name) gets the same replace-on-type behavior.

## Verification
911/911 web tests: the old "requires an opponent name" test is replaced by "defaults to 'unknown' when untouched" (asserts the created payload), and set-mode tests updated for the pre-filled input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)