### PR TITLE
Match edit/delete: GSP field, sync guards, and full-overwrite fixes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,7 +24,7 @@ import reportsRoutes from './routes/reports.js';
 import billingRoutes, { type StripeLikeClient } from './routes/billing.js';
 import tournamentsRoutes from './routes/tournaments.js';
 import groupsRoutes from './routes/groups.js';
-import { NotFoundError } from './services/rtdb.js';
+import { ConflictError, NotFoundError } from './services/rtdb.js';
 import type { FirebaseServices } from './firebase/admin.js';
 import type { ParryggConfig, ReportsConfig, StartggConfig, StripeConfig } from './config/env.js';
 import type { AnthropicLikeClient } from './reports/generate.js';
@@ -96,6 +96,15 @@ export function buildApp(options: BuildAppOptions) {
         error: 'Not Found',
         message: error.message,
         statusCode: 404,
+      });
+      return;
+    }
+
+    if (error instanceof ConflictError) {
+      reply.code(409).send({
+        error: 'Conflict',
+        message: error.message,
+        statusCode: 409,
       });
       return;
     }

--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -11,6 +11,34 @@ const validCreateInput = {
   win: true,
 };
 
+/** A stored start.gg-synced match (id `sgg-123-g1` in the tests). */
+const syncedRecord = {
+  fighter_id: 1,
+  opponent_id: 8,
+  time: 1700000000000,
+  map: { id: 1, name: 'Battlefield' },
+  opponent: 'someplayer',
+  notes: '',
+  matchType: 'online-tourney',
+  win: true,
+  source: 'startgg',
+  externalId: 'sgg:123:g1',
+} as const;
+
+/**
+ * The PATCH payload a well-behaved annotation editor (VodNotesDialog) sends
+ * for `syncedRecord`: every sync-owned game fact carried through unchanged.
+ */
+const syncedCarryThroughPayload = {
+  fighter_id: syncedRecord.fighter_id,
+  opponent_id: syncedRecord.opponent_id,
+  map: syncedRecord.map,
+  opponent: syncedRecord.opponent,
+  notes: syncedRecord.notes,
+  matchType: syncedRecord.matchType,
+  win: syncedRecord.win,
+};
+
 describe('GET /api/matches', () => {
   it('returns an empty array when the user has no matches', async () => {
     const { app } = buildTestApp();
@@ -742,6 +770,75 @@ describe('PATCH /api/matches/:id', () => {
 
     expect(response.statusCode).toBe(400);
   });
+
+  it('preserves the original time — editing corrects a match, it does not re-date it', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, win: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ time: 1700000000000, win: true });
+  });
+
+  it('returns 409 when changing game data on a synced match', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/sgg-123-g1`, {
+      ...syncedRecord,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/sgg-123-g1',
+      headers: authHeader(),
+      // Flipping the result is exactly the edit sync would undo.
+      payload: { ...syncedCarryThroughPayload, win: !syncedRecord.win },
+    });
+
+    expect(response.statusCode).toBe(409);
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    expect(matches[TEST_UID]!['sgg-123-g1']).toMatchObject({ win: syncedRecord.win });
+  });
+
+  it('allows annotation-only updates (notes/vod/gsp) on a synced match, preserving provenance', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/sgg-123-g1`, {
+      ...syncedRecord,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/sgg-123-g1',
+      headers: authHeader(),
+      payload: {
+        ...syncedCarryThroughPayload,
+        notes: 'their ledge habits are exploitable',
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps: [{ seconds: 161, note: 'missed punish on shield' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // source/externalId/time survive the full-overwrite rebuild.
+    expect(response.json()).toMatchObject({
+      notes: 'their ledge habits are exploitable',
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      source: 'startgg',
+      externalId: 'sgg:123:g1',
+      time: syncedRecord.time,
+    });
+  });
 });
 
 describe('DELETE /api/matches/:id', () => {
@@ -780,5 +877,21 @@ describe('DELETE /api/matches/:id', () => {
     });
 
     expect(response.statusCode).toBe(404);
+  });
+
+  it('returns 409 for a synced match and leaves it in place', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/sgg-123-g1`, { ...syncedRecord });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/matches/sgg-123-g1',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(409);
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    expect(matches[TEST_UID]!['sgg-123-g1']).toMatchObject({ source: 'startgg' });
   });
 });

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -37,6 +37,40 @@ export class ValidationError extends Error {
   }
 }
 
+/** Thrown for a 409-worthy write: the record exists but its state forbids this operation (e.g. editing/deleting a synced match). */
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}
+
+/**
+ * True when `input` would change a field that start.gg/parry.gg sync owns on
+ * a synced match record. Sync re-writes game facts idempotently (keyed
+ * `sgg-...`/`pgg-...`), so user edits to them would either drift from the
+ * source of truth or be silently overwritten by the next sync. User-owned
+ * annotations — `notes`, `vodUrl`, `vodTimestamps`, `gsp` — are NOT compared
+ * here: those never come from sync and stay editable on any match.
+ * Comparisons normalize the same way the web's payload builders do
+ * (`?? ''` strings, `?? 'none'` matchType, map sentinel) so a carry-through
+ * payload built from the record itself never reads as a change.
+ */
+function changesSyncOwnedFields(existing: MatchRecord, input: UpdateMatchInput): boolean {
+  return (
+    existing.fighter_id !== input.fighter_id ||
+    existing.opponent_id !== input.opponent_id ||
+    (existing.map?.id ?? 0) !== input.map.id ||
+    (existing.map?.name ?? 'no selection') !== input.map.name ||
+    (existing.opponent ?? '') !== (input.opponent ?? '') ||
+    (existing.matchType ?? 'none') !== input.matchType ||
+    existing.win !== input.win ||
+    existing.stocksLeft !== input.stocksLeft ||
+    (existing.eventName ?? '') !== (input.eventName ?? '') ||
+    (existing.tournamentName ?? '') !== (input.tournamentName ?? '')
+  );
+}
+
 /**
  * Thin data-access layer over the RTDB paths derived from legacy (see
  * packages/shared/README.md for provenance). Keeps route handlers free of
@@ -138,11 +172,26 @@ export class RtdbService {
     if (!existing.exists()) {
       throw new NotFoundError(`Match ${id} not found`);
     }
+    const current = matchRecordSchema.parse(existing.val());
+
+    // Synced matches: sync owns the game facts (idempotent re-writes would
+    // clobber user edits anyway) — only the user-annotation fields may
+    // change. 409 mirrors the UI, which hides Edit for synced rows but keeps
+    // VOD notes (which PATCH here with every game fact carried through).
+    if (current.source && changesSyncOwnedFields(current, input)) {
+      throw new ConflictError(
+        `Match ${id} is synced from ${current.source}; its game data is managed by sync`,
+      );
+    }
 
     const record: MatchRecord = {
       fighter_id: input.fighter_id,
       opponent_id: input.opponent_id,
-      time: Date.now(),
+      // Editing corrects a record, it doesn't re-date it: `time` keeps the
+      // original value (stamping Date.now() here re-ordered edited matches
+      // to "now", corrupting the GSP series / form curve / trends, all of
+      // which key on time).
+      time: current.time,
       map: input.map,
       notes: input.notes,
       matchType: input.matchType,
@@ -159,6 +208,10 @@ export class RtdbService {
       ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
       ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
+      // Server-set provenance survives the overwrite — the full-overwrite
+      // rebuild used to strip these, breaking source badges after a VOD edit.
+      ...(current.source !== undefined ? { source: current.source } : {}),
+      ...(current.externalId !== undefined ? { externalId: current.externalId } : {}),
     };
 
     await ref.set(record);
@@ -174,6 +227,14 @@ export class RtdbService {
     const existing = await ref.get();
     if (!existing.exists()) {
       throw new NotFoundError(`Match ${id} not found`);
+    }
+    const current = matchRecordSchema.parse(existing.val());
+    // Deleting a synced match is futile (the next sync re-creates it under
+    // the same idempotent key) — refuse instead of pretending it worked.
+    if (current.source) {
+      throw new ConflictError(
+        `Match ${id} is synced from ${current.source}; unlink or re-sync to manage it`,
+      );
     }
     await ref.remove();
   }

--- a/apps/web/src/components/match-form/MatchForm.test.ts
+++ b/apps/web/src/components/match-form/MatchForm.test.ts
@@ -10,6 +10,7 @@ function baseValues(overrides: Partial<MatchFormValues> = {}): MatchFormValues {
     matchType: 'offline-tourney',
     opponentName: 'Rival',
     notes: '',
+    gsp: '',
     ...overrides,
   };
 }
@@ -66,5 +67,15 @@ describe('matchFormValuesToInput', () => {
     const input = matchFormValuesToInput(baseValues({ eventName: '', tournamentName: '   ' }));
     expect('eventName' in input).toBe(false);
     expect('tournamentName' in input).toBe(false);
+  });
+
+  it('parses gsp text (commas/spaces tolerated) into the numeric gsp field', () => {
+    expect(matchFormValuesToInput(baseValues({ gsp: '12,400,000' })).gsp).toBe(12_400_000);
+    expect(matchFormValuesToInput(baseValues({ gsp: '12 400 000' })).gsp).toBe(12_400_000);
+  });
+
+  it('omits gsp when blank', () => {
+    const input = matchFormValuesToInput(baseValues({ gsp: '  ' }));
+    expect('gsp' in input).toBe(false);
   });
 });

--- a/apps/web/src/components/match-form/MatchForm.tsx
+++ b/apps/web/src/components/match-form/MatchForm.tsx
@@ -43,6 +43,7 @@ import { StageOption } from '@/components/StageOption';
 import { useOpponents } from '@/hooks/useOpponents';
 import { useMatches } from '@/hooks/useMatches';
 import { getGroupedStageOptions, stageOptions } from '@/lib/stageOptions';
+import { parseGspNumber } from '@/pages/Gsp/lib/parseGspNumber';
 
 export const alphaSpriteList = [...SpriteList].sort((a, b) => a.name.localeCompare(b.name));
 
@@ -97,6 +98,10 @@ export const matchFormSchema = z.object({
   stocksLeft: z.number().int().min(0).max(3).optional(),
   eventName: z.string().max(80, 'Limit 80 characters').optional(),
   tournamentName: z.string().max(80, 'Limit 80 characters').optional(),
+  /** GSP shown on the results screen, held as the user's raw text (commas/spaces tolerated — see parseGspNumber); '' = not tracked. */
+  gsp: z.string().refine((value) => value.trim() === '' || parseGspNumber(value) !== null, {
+    message: 'Enter a number like 12,400,000 (or leave blank)',
+  }),
 });
 
 export type MatchFormValues = z.infer<typeof matchFormSchema>;
@@ -109,6 +114,7 @@ export function matchFormValuesToInput(values: MatchFormValues): CreateMatchInpu
   const stage = stageOptions.find((s) => s.id === values.stageId) ?? NO_SELECTION_STAGE;
   const eventName = values.eventName?.trim();
   const tournamentName = values.tournamentName?.trim();
+  const gsp = values.gsp.trim() === '' ? null : parseGspNumber(values.gsp);
   return {
     fighter_id: values.fighterId,
     opponent_id: values.opponentFighterId,
@@ -120,6 +126,7 @@ export function matchFormValuesToInput(values: MatchFormValues): CreateMatchInpu
     ...(values.stocksLeft !== undefined ? { stocksLeft: values.stocksLeft } : {}),
     ...(eventName ? { eventName } : {}),
     ...(tournamentName ? { tournamentName } : {}),
+    ...(gsp !== null ? { gsp } : {}),
   };
 }
 
@@ -423,6 +430,26 @@ export function MatchFormFields({
         />
 
         <StocksSelectField control={form.control} />
+
+        <FormField
+          control={form.control}
+          name="gsp"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>GSP after match (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="e.g. 12,400,000"
+                  className="max-w-xs"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/apps/web/src/components/vod/VodNotesDialog.tsx
+++ b/apps/web/src/components/vod/VodNotesDialog.tsx
@@ -38,6 +38,9 @@ function buildUpdateInput(
     ...(match.stocksLeft !== undefined ? { stocksLeft: match.stocksLeft } : {}),
     ...(match.eventName !== undefined ? { eventName: match.eventName } : {}),
     ...(match.tournamentName !== undefined ? { tournamentName: match.tournamentName } : {}),
+    // gsp is carried through too — omitting it here used to wipe a
+    // QuickLogger match's GSP the moment VOD notes were added.
+    ...(match.gsp !== undefined ? { gsp: match.gsp } : {}),
     ...(overrides.vodUrl !== undefined ? { vodUrl: overrides.vodUrl } : {}),
     ...(overrides.vodTimestamps !== undefined ? { vodTimestamps: overrides.vodTimestamps } : {}),
   };

--- a/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
+++ b/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
@@ -51,6 +51,7 @@ function buildDefaultValues(fighterId: number): MatchFormValues {
     stocksLeft: undefined,
     eventName: '',
     tournamentName: '',
+    gsp: '',
   };
 }
 

--- a/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
+++ b/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
@@ -104,14 +104,19 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
                       {match.win ? 'Win' : 'Loss'}
                     </span>
                   </div>
-                  <Button
-                    variant="outline"
-                    size="icon-sm"
-                    aria-label="Delete match"
-                    onClick={() => setPendingDelete(match)}
-                  >
-                    <Trash2 />
-                  </Button>
+                  {/* Synced matches can't be deleted (the next sync would
+                      just re-create them; the API 409s it) — manage them on
+                      the Match Data page instead. */}
+                  {!match.source && (
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      aria-label="Delete match"
+                      onClick={() => setPendingDelete(match)}
+                    >
+                      <Trash2 />
+                    </Button>
+                  )}
                 </li>
               );
             })}

--- a/apps/web/src/pages/MatchData/components/EditMatchForm.tsx
+++ b/apps/web/src/pages/MatchData/components/EditMatchForm.tsx
@@ -30,6 +30,9 @@ function matchToFormValues(match: Match): MatchFormValues {
     stocksLeft: match.stocksLeft,
     eventName: match.eventName ?? '',
     tournamentName: match.tournamentName ?? '',
+    // Prefilled with locale separators, matching what parseGspNumber accepts
+    // back — a flubbed digit gets fixed in place instead of retyped.
+    gsp: match.gsp !== undefined ? match.gsp.toLocaleString('en-US') : '',
   };
 }
 
@@ -66,7 +69,14 @@ export function EditMatchForm({
   }
 
   async function onSubmit(values: MatchFormValues) {
-    const input: UpdateMatchInput = matchFormValuesToInput(values);
+    // PATCH is a full overwrite (omitted = cleared), so fields this form
+    // doesn't own must be carried through from the record or editing a match
+    // silently wipes its VOD link/notes (it used to).
+    const input: UpdateMatchInput = {
+      ...matchFormValuesToInput(values),
+      ...(match.vodUrl !== undefined ? { vodUrl: match.vodUrl } : {}),
+      ...(match.vodTimestamps !== undefined ? { vodTimestamps: match.vodTimestamps } : {}),
+    };
     try {
       await updateMatch.mutateAsync({ id: match.id, input });
       toast.success('Match edited!');

--- a/apps/web/src/pages/MatchData/components/MatchTable.tsx
+++ b/apps/web/src/pages/MatchData/components/MatchTable.tsx
@@ -250,8 +250,9 @@ export function MatchTable({
         enableHiding: false,
         cell: ({ row }) => {
           const hasVod = row.original.match.vodUrl != null;
+          const source = row.original.match.source;
           return (
-            <div className="flex justify-end gap-2">
+            <div className="flex items-center justify-end gap-2">
               <Button
                 variant="outline"
                 size="icon-sm"
@@ -261,22 +262,36 @@ export function MatchTable({
               >
                 <Video />
               </Button>
-              <Button
-                variant="outline"
-                size="icon-sm"
-                aria-label="Edit match"
-                onClick={() => setEditingMatch(row.original.match)}
-              >
-                <Pencil />
-              </Button>
-              <Button
-                variant="outline"
-                size="icon-sm"
-                aria-label="Delete match"
-                onClick={() => setPendingDelete(row.original.match)}
-              >
-                <Trash2 />
-              </Button>
+              {source ? (
+                // Synced matches: game data is managed by start.gg/parry.gg
+                // sync (the API 409s edits/deletes too) — VOD notes above
+                // stay editable.
+                <Badge
+                  variant="outline"
+                  title={`Synced from ${source === 'startgg' ? 'start.gg' : 'parry.gg'} — game data is managed by sync`}
+                >
+                  Synced
+                </Badge>
+              ) : (
+                <>
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Edit match"
+                    onClick={() => setEditingMatch(row.original.match)}
+                  >
+                    <Pencil />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Delete match"
+                    onClick={() => setPendingDelete(row.original.match)}
+                  >
+                    <Trash2 />
+                  </Button>
+                </>
+              )}
             </div>
           );
         },


### PR DESCRIPTION
## Feature
Fix a flubbed GSP digit or match result in place, and delete mistaken entries — with synced matches excluded.

- **GSP editable**: the shared match form (add + edit) gains a "GSP after match" text input (comma/space tolerant via `parseGspNumber`, prefilled with locale separators on edit).
- **Synced matches excluded** (start.gg/parry.gg own their game data, and deletes would be undone by the next idempotent sync):
  - API: `DELETE` on a synced match → **409**; `PATCH` that changes sync-owned game facts (fighters/map/opponent/result/type/stocks/tournament) → **409**. User annotations — `notes`, `vodUrl`, `vodTimestamps`, `gsp` — remain editable on any match.
  - UI: MatchTable shows a "Synced" badge instead of Edit/Delete (VOD button stays); Dashboard Previous Matches hides delete for synced rows.

## Latent bugs found and fixed (all full-overwrite PATCH fallout)
1. **Editing a match wiped its GSP and VOD data** — the edit form never carried `gsp`/`vodUrl`/`vodTimestamps`, and omission means "clear". EditMatchForm now owns `gsp` and carries VOD through; VodNotesDialog now carries `gsp` through.
2. **Editing re-dated the match to now** (`time: Date.now()` in `updateMatch`) — silently re-ordering GSP series, form curve, and trends. `time` is now preserved; editing corrects a record, it doesn't re-date it.
3. **Any PATCH stripped `source`/`externalId`** from synced records (the rebuild omitted them), breaking source badges after a VOD edit. Now preserved.

## Verification
- API: 413/413 (new: time preservation, 409 synced-edit, annotation-only-allowed with provenance preserved, 409 synced-delete)
- Web: 913/913 (new: gsp text→number mapping, blank-omission), lint/typecheck clean both packages

## Production-gap checklist
1 buildApp options — N/A (no new options). 2 Dockerfile — untouched. 3 RTDB nulls — conditional spreads throughout, no nulls written. 4 timeouts, 5 GA, 6 auth domains, 7 DNS — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)