### PR TITLE
Offer deletion inside the Edit Match dialog

### DIFF
--- a/apps/web/src/components/match-form/EditMatchForm.tsx
+++ b/apps/web/src/components/match-form/EditMatchForm.tsx
@@ -51,12 +51,20 @@ export function EditMatchForm({
   fighterSprites,
   open,
   onOpenChange,
+  onDelete,
 }: {
   match: Match;
   /** The fighters offered for "Your Fighter" — the signed-in user's primary+secondary selections. */
   fighterSprites: Fighter[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * V14.1: renders a destructive Delete button in the footer when provided.
+   * The caller owns the confirmation + mutation (every page already has a
+   * delete AlertDialog) — this matters for entry points like the GSP curve's
+   * click-to-edit, where the dialog is the only affordance for that match.
+   */
+  onDelete?: (match: Match) => void;
 }) {
   const updateMatch = useUpdateMatch();
   const form = useMatchForm(matchToFormValues(match));
@@ -96,6 +104,16 @@ export function EditMatchForm({
         <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
           <MatchFormFields form={form} fighterSprites={fighterSprites} />
           <DialogFooter className="mt-4">
+            {onDelete && (
+              <Button
+                type="button"
+                variant="destructive"
+                className="sm:mr-auto"
+                onClick={() => onDelete(match)}
+              >
+                Delete Match
+              </Button>
+            )}
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -359,6 +359,28 @@ describe('GspPage', () => {
     expect(screen.getByText(/logged post-match GSP reading/)).toBeInTheDocument();
   });
 
+  it('opens the edit dialog from the GSP Log and offers deletion from inside it', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([
+      makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 }),
+      makeMatch({ id: 'm2', time: 2, win: true, gsp: 9_100_000 }),
+    ]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('GSP Log');
+
+    // Newest entry's edit button opens the shared EditMatchForm dialog.
+    await user.click(screen.getAllByRole('button', { name: /^Edit GSP entry/ })[0]!);
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('Edit Match');
+
+    // V14.1: chart clicks land in this dialog directly, so it must offer the
+    // delete path too — it hands off to the page's confirmation dialog.
+    await user.click(screen.getByRole('button', { name: 'Delete Match' }));
+    expect(await screen.findByText('Delete this GSP entry?')).toBeInTheDocument();
+  });
+
   describe('Road to Elite states', () => {
     it('projects net wins on the MMR scale at a >50% win rate', async () => {
       getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });

--- a/apps/web/src/pages/Gsp/GspPage.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.tsx
@@ -166,6 +166,12 @@ export function GspPage() {
           fighterSprites={editFighterSprites}
           open={editingMatch != null}
           onOpenChange={(open) => !open && setEditingMatch(null)}
+          // Curve clicks land here directly, so the dialog must offer the
+          // delete path too — hand off to the shared confirmation below.
+          onDelete={(match) => {
+            setEditingMatch(null);
+            setPendingDelete(match);
+          }}
         />
       )}
 

--- a/apps/web/src/pages/MatchData/components/MatchTable.tsx
+++ b/apps/web/src/pages/MatchData/components/MatchTable.tsx
@@ -525,6 +525,10 @@ export function MatchTable({
           fighterSprites={fighterSprites}
           open={editingMatch != null}
           onOpenChange={(open) => !open && setEditingMatch(null)}
+          onDelete={(match) => {
+            setEditingMatch(null);
+            setPendingDelete(match);
+          }}
         />
       )}
 


### PR DESCRIPTION
## Problem
The GSP curve's click-to-edit (#139) opens `EditMatchForm` directly — but the dialog only offered Cancel/Save, so a reading you wanted to *remove* (not correct) had no path from there.

## Change
`EditMatchForm` takes an optional `onDelete(match)` and renders a destructive **Delete Match** button (left-aligned in the footer) when provided. The caller owns the confirmation and mutation — both the GSP page and the Match Data table close the edit dialog and open their existing delete AlertDialog. Synced matches never reach this dialog (edit is hidden and the API 409s), so no extra guard needed.

## Verification
921/921 web tests — new flow test: GSP Log → edit dialog → "Delete Match" → confirmation dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)