### PR TITLE
Localization phase 2a: Dashboard page + shared analytics components

### DIFF
--- a/apps/web/src/components/AnalyticsFilterControls.tsx
+++ b/apps/web/src/components/AnalyticsFilterControls.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import {
   Select,
@@ -10,11 +11,11 @@ import { useAnalyticsFilter } from '@/hooks/useAnalyticsFilter';
 import type { AnalyticsRangeFilter, AnalyticsSourceFilter } from '@/context/AnalyticsFilterContext';
 import { cn } from '@/lib/utils';
 
-const RANGE_LABELS: Record<AnalyticsRangeFilter, string> = {
-  all: 'All time',
-  '3m': '3m',
-  '6m': '6m',
-  '12m': '12m',
+const RANGE_LABEL_KEYS: Record<AnalyticsRangeFilter, string> = {
+  all: 'filters.allTime',
+  '3m': 'filters.months3',
+  '6m': 'filters.months6',
+  '12m': 'filters.months12',
 };
 
 /**
@@ -23,6 +24,7 @@ const RANGE_LABELS: Record<AnalyticsRangeFilter, string> = {
  * in the desktop topbar and again (full-width) inside the mobile nav Sheet.
  */
 export function AnalyticsFilterControls({ className }: { className?: string }) {
+  const { t } = useTranslation();
   const { source, range, setSource, setRange } = useAnalyticsFilter();
 
   return (
@@ -37,21 +39,21 @@ export function AnalyticsFilterControls({ className }: { className?: string }) {
             setSource(next as AnalyticsSourceFilter);
           }
         }}
-        aria-label="Filter matches by source"
+        aria-label={t('filters.sourceAria')}
       >
-        <ToggleGroupItem value="all">All</ToggleGroupItem>
-        <ToggleGroupItem value="manual">Casual</ToggleGroupItem>
-        <ToggleGroupItem value="startgg">Competitive</ToggleGroupItem>
+        <ToggleGroupItem value="all">{t('filters.all')}</ToggleGroupItem>
+        <ToggleGroupItem value="manual">{t('common.casual')}</ToggleGroupItem>
+        <ToggleGroupItem value="startgg">{t('common.competitive')}</ToggleGroupItem>
       </ToggleGroup>
 
       <Select value={range} onValueChange={(next) => setRange(next as AnalyticsRangeFilter)}>
-        <SelectTrigger size="sm" aria-label="Filter matches by time range" className="w-[110px]">
+        <SelectTrigger size="sm" aria-label={t('filters.rangeAria')} className="w-[110px]">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {(Object.keys(RANGE_LABELS) as AnalyticsRangeFilter[]).map((value) => (
+          {(Object.keys(RANGE_LABEL_KEYS) as AnalyticsRangeFilter[]).map((value) => (
             <SelectItem key={value} value={value}>
-              {RANGE_LABELS[value]}
+              {t(RANGE_LABEL_KEYS[value])}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/src/components/FilteredEmptyNotice.tsx
+++ b/apps/web/src/components/FilteredEmptyNotice.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useAnalyticsFilter } from '@/hooks/useAnalyticsFilter';
 
@@ -8,13 +9,14 @@ import { useAnalyticsFilter } from '@/hooks/useAnalyticsFilter';
  * driven off `allMatches.length === 0`, not this.
  */
 export function FilteredEmptyNotice() {
+  const { t } = useTranslation();
   const { resetFilters } = useAnalyticsFilter();
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-dashed bg-muted/50 px-4 py-3 text-sm">
-      <span className="text-muted-foreground">No matches match the current filters.</span>
+      <span className="text-muted-foreground">{t('shared.filteredNotice.message')}</span>
       <Button variant="outline" size="sm" onClick={resetFilters}>
-        Clear filters
+        {t('shared.filteredNotice.clear')}
       </Button>
     </div>
   );

--- a/apps/web/src/components/GlickoExplainer.tsx
+++ b/apps/web/src/components/GlickoExplainer.tsx
@@ -1,3 +1,4 @@
+import { Trans, useTranslation } from 'react-i18next';
 import { Info } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,6 +17,8 @@ import {
  * precedent — this much copy reads poorly in a hover-only tooltip).
  */
 export function GlickoExplainer() {
+  const { t } = useTranslation();
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -23,7 +26,7 @@ export function GlickoExplainer() {
           type="button"
           variant="ghost"
           size="icon-xs"
-          aria-label="What is Glicko-2?"
+          aria-label={t('shared.glicko.whatIs')}
           className="shrink-0 text-muted-foreground hover:text-foreground"
         >
           <Info className="size-4" />
@@ -31,21 +34,15 @@ export function GlickoExplainer() {
       </PopoverTrigger>
       <PopoverContent className="w-80 text-sm">
         <PopoverHeader>
-          <PopoverTitle>What is Glicko-2?</PopoverTitle>
+          <PopoverTitle>{t('shared.glicko.whatIs')}</PopoverTitle>
           <p>
-            <strong>Glicko-2</strong> is the rating system used in chess and by many competitive
-            ladders. Unlike a raw win rate, it weighs <em>who</em> you beat and how surprising the
-            result was.
+            <Trans i18nKey="shared.glicko.p1" components={{ strong: <strong />, em: <em /> }} />
           </p>
           <p>
-            The <strong>±number (RD)</strong> is uncertainty: it shrinks as you play more and grows
-            when you&apos;re inactive — so a 1500 ±50 player is proven, a 1500 ±300 player is
-            unknown.
+            <Trans i18nKey="shared.glicko.p2" components={{ strong: <strong />, em: <em /> }} />
           </p>
           <p>
-            We use it because bracket play is bursty: Glicko-2 handles long gaps between tournaments
-            and small samples far better than Elo or win-rate alone. Ratings here are unofficial and
-            computed only from your synced/logged games.
+            <Trans i18nKey="shared.glicko.p3" components={{ strong: <strong />, em: <em /> }} />
           </p>
         </PopoverHeader>
       </PopoverContent>

--- a/apps/web/src/components/LanguageSelect.test.tsx
+++ b/apps/web/src/components/LanguageSelect.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import i18n, { SUPPORTED_LANGUAGES } from '@/i18n';
 import { LanguageSelect } from './LanguageSelect';
@@ -27,7 +27,10 @@ describe('LanguageSelect', () => {
     await user.click(screen.getByRole('combobox', { name: 'Language' }));
     await user.click(screen.getByRole('option', { name: 'Español' }));
 
-    expect(i18n.resolvedLanguage).toBe('es');
+    // The switch loads the es locale as an async chunk (see i18n/index.ts),
+    // so the language settles a tick after the click — poll instead of
+    // asserting synchronously.
+    await waitFor(() => expect(i18n.resolvedLanguage).toBe('es'));
     expect(i18n.t('nav.dashboard')).toBe('Panel');
     // i18next's detector cache — this is what makes the choice stick and
     // outrank browser-language detection on the next visit.

--- a/apps/web/src/components/WinLossPips.tsx
+++ b/apps/web/src/components/WinLossPips.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { getLastNMatches } from '@/lib/stats';
 
@@ -6,21 +7,22 @@ import { getLastNMatches } from '@/lib/stats';
  * red for a loss. Shared by the Fighter Analysis and Matchups pages.
  */
 export function WinLossPips({ matches, limit = 10 }: { matches: Match[]; limit?: number }) {
+  const { t } = useTranslation();
   const recent = getLastNMatches(matches, limit);
 
   if (recent.length === 0) {
-    return <p className="text-sm text-muted-foreground">No matches yet.</p>;
+    return <p className="text-sm text-muted-foreground">{t('shared.pips.empty')}</p>;
   }
 
   return (
     <div
       className="flex items-center gap-1.5"
-      aria-label={`Last ${recent.length} results, newest first`}
+      aria-label={t('shared.pips.recentResults', { count: recent.length })}
     >
       {recent.map((match) => (
         <span
           key={match.id}
-          title={`${match.win ? 'Win' : 'Loss'} — ${new Date(match.time).toLocaleDateString()}`}
+          title={`${match.win ? t('common.win') : t('common.loss')} — ${new Date(match.time).toLocaleDateString()}`}
           className={`size-3 rounded-full ${match.win ? 'bg-emerald-500' : 'bg-destructive'}`}
         />
       ))}

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -38,6 +38,127 @@
     "delete": "Löschen",
     "win": "Sieg",
     "loss": "Niederlage",
-    "cannotBeUndone": "Diese Aktion kann nicht rückgängig gemacht werden."
+    "cannotBeUndone": "Diese Aktion kann nicht rückgängig gemacht werden.",
+    "wins": "Siege",
+    "losses": "Niederlagen",
+    "casual": "Casual",
+    "competitive": "Kompetitiv",
+    "unknown": "Unbekannt",
+    "notAvailable": "k. A."
+  },
+  "filters": {
+    "sourceAria": "Matches nach Quelle filtern",
+    "rangeAria": "Matches nach Zeitraum filtern",
+    "all": "Alle",
+    "allTime": "Gesamter Zeitraum",
+    "months3": "3 M",
+    "months6": "6 M",
+    "months12": "12 M"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "Keine Matches entsprechen den aktuellen Filtern.",
+      "clear": "Filter zurücksetzen"
+    },
+    "pips": {
+      "empty": "Noch keine Matches.",
+      "recentResults": "Letzte {{count}} Ergebnisse, neueste zuerst"
+    },
+    "glicko": {
+      "whatIs": "Was ist Glicko-2?",
+      "p1": "<strong>Glicko-2</strong> ist das Wertungssystem aus dem Schach, das auch viele kompetitive Ladder nutzen. Anders als eine reine Winrate gewichtet es, <em>wen</em> du schlägst und wie überraschend das Ergebnis war.",
+      "p2": "Die <strong>±-Zahl (RD)</strong> ist die Unsicherheit: Sie schrumpft, je mehr du spielst, und wächst bei Inaktivität — ein Spieler mit 1500 ±50 ist etabliert, einer mit 1500 ±300 eine Unbekannte.",
+      "p3": "Wir nutzen es, weil Bracket-Play stoßweise passiert: Glicko-2 kommt mit langen Pausen zwischen Turnieren und kleinen Stichproben deutlich besser zurecht als Elo oder Winrate allein. Die Wertungen hier sind inoffiziell und werden nur aus deinen synchronisierten bzw. erfassten Matches berechnet."
+    }
+  },
+  "dashboard": {
+    "loading": "Dein Dashboard wird geladen...",
+    "empty": {
+      "title": "Du hast noch keine Kämpfer ausgewählt!",
+      "subtitle": "Wähle deine Main- und Secondary-Kämpfer, um Matches zu erfassen.",
+      "choosePrimary": "Main-Kämpfer wählen",
+      "chooseSecondary": "Secondary-Kämpfer wählen"
+    },
+    "hero": {
+      "overallRecord": "Gesamtbilanz",
+      "winRate": "{{rate}} % Winrate",
+      "games_one": "{{count}} Match",
+      "games_other": "{{count}} Matches",
+      "noMatchData": "Noch keine Match-Daten vorhanden.",
+      "form": "Form",
+      "streakWin": "{{count}}S",
+      "streakLoss": "{{count}}N",
+      "casualVsCompetitive": "Casual vs. Kompetitiv",
+      "ignoresSourceFilter": "Ignoriert den Quellen-Filter oben (der Zeitraum gilt weiterhin).",
+      "deltaLabel": "Differenz:",
+      "deltaValue": "{{value}} Pkt.",
+      "deltaCaption": "(kompetitiv vs. casual)",
+      "noData": "keine Daten",
+      "onlineVsOffline": "Online vs. Offline",
+      "online": "Online",
+      "offline": "Offline",
+      "rating": "Wertung",
+      "gamesSampled_one": "{{count}} Match ausgewertet",
+      "gamesSampled_other": "{{count}} Matches ausgewertet",
+      "ratingCaption": "Glicko-2, sitzungsbasiert · inoffiziell",
+      "ratingLocked": "Wertung wird ab {{threshold}} Matches freigeschaltet",
+      "ratingProgress": "Bisher {{played}}/{{threshold}} Matches",
+      "ratingUp": "Wertung höher als in der letzten Sitzung",
+      "ratingDown": "Wertung niedriger als in der letzten Sitzung",
+      "ratingUnchanged": "Wertung unverändert zur letzten Sitzung"
+    },
+    "tracker": {
+      "rate": "Quote"
+    },
+    "formCurve": {
+      "title": "Formkurve",
+      "window": "Fenster",
+      "windowAria": "Gleitendes Fenster",
+      "lastN": "Letzte {{count}}",
+      "cumulative": "Kumuliert",
+      "empty": "Erfasse ein Match, um das Diagramm zu sehen.",
+      "winRate": "Winrate",
+      "opponent": "Gegner: {{name}}"
+    },
+    "previous": {
+      "title": "Letzte Matches",
+      "limit": "Limit",
+      "limitAria": "Match-Limit",
+      "empty": "Noch keine Matches erfasst.",
+      "deleteAria": "Match löschen",
+      "confirmTitle": "Dieses Match löschen?",
+      "deleted": "Match gelöscht!",
+      "deleteFailed": "Match konnte nicht gelöscht werden. Bitte erneut versuchen."
+    },
+    "stages": {
+      "title": "Meistgespielte Stages",
+      "empty": "Noch keine Stage-Daten vorhanden."
+    },
+    "snapshot": {
+      "title": "Matchup-Überblick",
+      "noMatches": "Keine Matches erfasst",
+      "openLab": "Matchup Lab öffnen",
+      "strongest": "Stärkste Matchups",
+      "toughest": "Schwierigste Matchups",
+      "needMoreGames": "Spiele noch ein paar Matches ({{count}}+ pro Gegner), um dein schwierigstes Matchup zu ermitteln.",
+      "notEnough": "Nicht genug erfasste Matches für eine Auswertung."
+    },
+    "selectFighter": {
+      "aria": "Kämpfer auswählen",
+      "placeholder": "Kämpfer wählen"
+    },
+    "addMatch": {
+      "title": "Match hinzufügen",
+      "description": "Erfasse das Ergebnis eines gerade gespielten Matches.",
+      "singleGame": "Einzelnes Match",
+      "setMode": "Set (Bo3/Bo5)",
+      "saveSet": "Set speichern",
+      "added": "Match hinzugefügt!",
+      "addFailed": "Match konnte nicht hinzugefügt werden. Bitte erneut versuchen.",
+      "noGames": "Gib mindestens ein Spielergebnis ein, bevor du speicherst.",
+      "setRecorded": "Set erfasst: {{score}} vs. {{opponent}}",
+      "partialSave": "Nur {{saved}} von {{total}} Spielen wurden vor einem Fehler gespeichert. Prüfe die Match-Daten und trage fehlende Spiele erneut ein.",
+      "setFailed": "Set konnte nicht gespeichert werden. Bitte erneut versuchen."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -38,6 +38,127 @@
     "delete": "Delete",
     "win": "Win",
     "loss": "Loss",
-    "cannotBeUndone": "This action cannot be undone."
+    "cannotBeUndone": "This action cannot be undone.",
+    "wins": "Wins",
+    "losses": "Losses",
+    "casual": "Casual",
+    "competitive": "Competitive",
+    "unknown": "Unknown",
+    "notAvailable": "n/a"
+  },
+  "filters": {
+    "sourceAria": "Filter matches by source",
+    "rangeAria": "Filter matches by time range",
+    "all": "All",
+    "allTime": "All time",
+    "months3": "3m",
+    "months6": "6m",
+    "months12": "12m"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "No matches match the current filters.",
+      "clear": "Clear filters"
+    },
+    "pips": {
+      "empty": "No matches yet.",
+      "recentResults": "Last {{count}} results, newest first"
+    },
+    "glicko": {
+      "whatIs": "What is Glicko-2?",
+      "p1": "<strong>Glicko-2</strong> is the rating system used in chess and by many competitive ladders. Unlike a raw win rate, it weighs <em>who</em> you beat and how surprising the result was.",
+      "p2": "The <strong>±number (RD)</strong> is uncertainty: it shrinks as you play more and grows when you're inactive — so a 1500 ±50 player is proven, a 1500 ±300 player is unknown.",
+      "p3": "We use it because bracket play is bursty: Glicko-2 handles long gaps between tournaments and small samples far better than Elo or win-rate alone. Ratings here are unofficial and computed only from your synced/logged games."
+    }
+  },
+  "dashboard": {
+    "loading": "Loading your dashboard...",
+    "empty": {
+      "title": "You haven't picked any fighters yet!",
+      "subtitle": "Choose your primary and secondary fighters to start tracking matches.",
+      "choosePrimary": "Choose Primary Fighters",
+      "chooseSecondary": "Choose Secondary Fighters"
+    },
+    "hero": {
+      "overallRecord": "Overall Record",
+      "winRate": "{{rate}}% win rate",
+      "games_one": "{{count}} game",
+      "games_other": "{{count}} games",
+      "noMatchData": "No match data to report yet.",
+      "form": "Form",
+      "streakWin": "{{count}}W",
+      "streakLoss": "{{count}}L",
+      "casualVsCompetitive": "Casual vs Competitive",
+      "ignoresSourceFilter": "Ignores the source filter above (time range still applies).",
+      "deltaLabel": "Delta:",
+      "deltaValue": "{{value}}pts",
+      "deltaCaption": "(competitive vs casual)",
+      "noData": "no data",
+      "onlineVsOffline": "Online vs Offline",
+      "online": "Online",
+      "offline": "Offline",
+      "rating": "Rating",
+      "gamesSampled_one": "{{count}} game sampled",
+      "gamesSampled_other": "{{count}} games sampled",
+      "ratingCaption": "Glicko-2, session-based · unofficial",
+      "ratingLocked": "Rating unlocks at {{threshold}} games",
+      "ratingProgress": "{{played}}/{{threshold}} games so far",
+      "ratingUp": "Rating up from last session",
+      "ratingDown": "Rating down from last session",
+      "ratingUnchanged": "Rating unchanged from last session"
+    },
+    "tracker": {
+      "rate": "Rate"
+    },
+    "formCurve": {
+      "title": "Form Curve",
+      "window": "Window",
+      "windowAria": "Rolling window",
+      "lastN": "Last {{count}}",
+      "cumulative": "Cumulative",
+      "empty": "Submit a match to see the match chart.",
+      "winRate": "Win Rate",
+      "opponent": "Opponent: {{name}}"
+    },
+    "previous": {
+      "title": "Previous Matches",
+      "limit": "Limit",
+      "limitAria": "Match limit",
+      "empty": "No matches recorded yet.",
+      "deleteAria": "Delete match",
+      "confirmTitle": "Delete this match?",
+      "deleted": "Match deleted!",
+      "deleteFailed": "Failed to delete match. Please try again."
+    },
+    "stages": {
+      "title": "Most-Played Stages",
+      "empty": "No stage data to report yet."
+    },
+    "snapshot": {
+      "title": "Matchup Snapshot",
+      "noMatches": "No matches reported",
+      "openLab": "Open Matchup Lab",
+      "strongest": "Strongest Matchups",
+      "toughest": "Toughest Matchups",
+      "needMoreGames": "Play a few more games ({{count}}+ per opponent) to surface a toughest matchup.",
+      "notEnough": "Not enough reported matches to calculate."
+    },
+    "selectFighter": {
+      "aria": "Select fighter",
+      "placeholder": "Select a fighter"
+    },
+    "addMatch": {
+      "title": "Add Match",
+      "description": "Record the outcome of a match you just played.",
+      "singleGame": "Single game",
+      "setMode": "Set (Bo3/Bo5)",
+      "saveSet": "Save Set",
+      "added": "Match added!",
+      "addFailed": "Failed to add match. Please try again.",
+      "noGames": "Enter at least one game result before saving.",
+      "setRecorded": "Set recorded: {{score}} vs {{opponent}}",
+      "partialSave": "Only {{saved}} of {{total}} games saved before an error occurred. Check Match Data and re-enter any missing games.",
+      "setFailed": "Failed to save the set. Please try again."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -38,6 +38,127 @@
     "delete": "Eliminar",
     "win": "Victoria",
     "loss": "Derrota",
-    "cannotBeUndone": "Esta acción no se puede deshacer."
+    "cannotBeUndone": "Esta acción no se puede deshacer.",
+    "wins": "Victorias",
+    "losses": "Derrotas",
+    "casual": "Casual",
+    "competitive": "Competitivo",
+    "unknown": "Desconocido",
+    "notAvailable": "n/d"
+  },
+  "filters": {
+    "sourceAria": "Filtrar partidas por origen",
+    "rangeAria": "Filtrar partidas por periodo",
+    "all": "Todas",
+    "allTime": "Todo el tiempo",
+    "months3": "3 m",
+    "months6": "6 m",
+    "months12": "12 m"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "Ninguna partida coincide con los filtros actuales.",
+      "clear": "Borrar filtros"
+    },
+    "pips": {
+      "empty": "Aún no hay partidas.",
+      "recentResults": "Últimos {{count}} resultados, primero el más reciente"
+    },
+    "glicko": {
+      "whatIs": "¿Qué es Glicko-2?",
+      "p1": "<strong>Glicko-2</strong> es el sistema de puntuación que se usa en ajedrez y en muchas ligas competitivas. A diferencia de un simple porcentaje de victorias, pondera a <em>quién</em> vences y cuán sorprendente fue el resultado.",
+      "p2": "El <strong>número ± (RD)</strong> es la incertidumbre: se reduce cuanto más juegas y crece cuando estás inactivo — un jugador con 1500 ±50 está consolidado, uno con 1500 ±300 es una incógnita.",
+      "p3": "Lo usamos porque el juego de bracket va a rachas: Glicko-2 maneja los parones largos entre torneos y las muestras pequeñas mucho mejor que el Elo o el porcentaje de victorias por sí solos. Las puntuaciones de aquí no son oficiales y se calculan solo con tus partidas sincronizadas o registradas."
+    }
+  },
+  "dashboard": {
+    "loading": "Cargando tu panel...",
+    "empty": {
+      "title": "¡Aún no has elegido ningún luchador!",
+      "subtitle": "Elige tus luchadores principal y secundarios para empezar a registrar partidas.",
+      "choosePrimary": "Elegir luchadores principales",
+      "chooseSecondary": "Elegir luchadores secundarios"
+    },
+    "hero": {
+      "overallRecord": "Historial general",
+      "winRate": "{{rate}}% de victorias",
+      "games_one": "{{count}} partida",
+      "games_other": "{{count}} partidas",
+      "noMatchData": "Aún no hay datos de partidas.",
+      "form": "Forma",
+      "streakWin": "{{count}}V",
+      "streakLoss": "{{count}}D",
+      "casualVsCompetitive": "Casual vs Competitivo",
+      "ignoresSourceFilter": "Ignora el filtro de origen de arriba (el periodo sí se aplica).",
+      "deltaLabel": "Diferencia:",
+      "deltaValue": "{{value}} pts",
+      "deltaCaption": "(competitivo vs casual)",
+      "noData": "sin datos",
+      "onlineVsOffline": "Online vs Offline",
+      "online": "Online",
+      "offline": "Offline",
+      "rating": "Puntuación",
+      "gamesSampled_one": "{{count}} partida analizada",
+      "gamesSampled_other": "{{count}} partidas analizadas",
+      "ratingCaption": "Glicko-2, por sesiones · no oficial",
+      "ratingLocked": "La puntuación se desbloquea a las {{threshold}} partidas",
+      "ratingProgress": "{{played}}/{{threshold}} partidas hasta ahora",
+      "ratingUp": "Puntuación al alza desde la última sesión",
+      "ratingDown": "Puntuación a la baja desde la última sesión",
+      "ratingUnchanged": "Puntuación sin cambios desde la última sesión"
+    },
+    "tracker": {
+      "rate": "Ratio"
+    },
+    "formCurve": {
+      "title": "Curva de forma",
+      "window": "Ventana",
+      "windowAria": "Ventana móvil",
+      "lastN": "Últimas {{count}}",
+      "cumulative": "Acumulado",
+      "empty": "Registra una partida para ver la gráfica.",
+      "winRate": "% de victorias",
+      "opponent": "Rival: {{name}}"
+    },
+    "previous": {
+      "title": "Partidas anteriores",
+      "limit": "Límite",
+      "limitAria": "Límite de partidas",
+      "empty": "Aún no hay partidas registradas.",
+      "deleteAria": "Eliminar partida",
+      "confirmTitle": "¿Eliminar esta partida?",
+      "deleted": "¡Partida eliminada!",
+      "deleteFailed": "No se pudo eliminar la partida. Inténtalo de nuevo."
+    },
+    "stages": {
+      "title": "Escenarios más jugados",
+      "empty": "Aún no hay datos de escenarios."
+    },
+    "snapshot": {
+      "title": "Resumen de enfrentamientos",
+      "noMatches": "No hay partidas registradas",
+      "openLab": "Abrir Matchup Lab",
+      "strongest": "Enfrentamientos más favorables",
+      "toughest": "Enfrentamientos más difíciles",
+      "needMoreGames": "Juega algunas partidas más ({{count}}+ por rival) para revelar tu enfrentamiento más difícil.",
+      "notEnough": "No hay suficientes partidas registradas para calcularlo."
+    },
+    "selectFighter": {
+      "aria": "Seleccionar luchador",
+      "placeholder": "Selecciona un luchador"
+    },
+    "addMatch": {
+      "title": "Añadir partida",
+      "description": "Registra el resultado de una partida que acabas de jugar.",
+      "singleGame": "Partida suelta",
+      "setMode": "Set (Bo3/Bo5)",
+      "saveSet": "Guardar set",
+      "added": "¡Partida añadida!",
+      "addFailed": "No se pudo añadir la partida. Inténtalo de nuevo.",
+      "noGames": "Introduce al menos el resultado de una partida antes de guardar.",
+      "setRecorded": "Set registrado: {{score}} vs {{opponent}}",
+      "partialSave": "Solo se guardaron {{saved}} de {{total}} partidas antes de producirse un error. Revisa Datos de partidas y vuelve a introducir las que falten.",
+      "setFailed": "No se pudo guardar el set. Inténtalo de nuevo."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -38,6 +38,127 @@
     "delete": "Supprimer",
     "win": "Victoire",
     "loss": "Défaite",
-    "cannotBeUndone": "Cette action est irréversible."
+    "cannotBeUndone": "Cette action est irréversible.",
+    "wins": "Victoires",
+    "losses": "Défaites",
+    "casual": "Casual",
+    "competitive": "Compétitif",
+    "unknown": "Inconnu",
+    "notAvailable": "n/d"
+  },
+  "filters": {
+    "sourceAria": "Filtrer les matchs par source",
+    "rangeAria": "Filtrer les matchs par période",
+    "all": "Tous",
+    "allTime": "Depuis le début",
+    "months3": "3 m",
+    "months6": "6 m",
+    "months12": "12 m"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "Aucun match ne correspond aux filtres actuels.",
+      "clear": "Effacer les filtres"
+    },
+    "pips": {
+      "empty": "Pas encore de matchs.",
+      "recentResults": "{{count}} derniers résultats, du plus récent au plus ancien"
+    },
+    "glicko": {
+      "whatIs": "Qu'est-ce que Glicko-2 ?",
+      "p1": "<strong>Glicko-2</strong> est le système de classement utilisé aux échecs et sur de nombreux ladders compétitifs. Contrairement à un simple taux de victoire, il tient compte de <em>qui</em> vous battez et du caractère surprenant du résultat.",
+      "p2": "Le <strong>nombre ± (RD)</strong> mesure l'incertitude : il diminue à mesure que vous jouez et augmente en cas d'inactivité — un joueur à 1500 ±50 a fait ses preuves, un joueur à 1500 ±300 reste une inconnue.",
+      "p3": "Nous l'utilisons parce que le jeu en bracket est irrégulier : Glicko-2 gère bien mieux les longues pauses entre tournois et les petits échantillons que l'Elo ou le taux de victoire seuls. Les classements affichés ici ne sont pas officiels et sont calculés uniquement à partir de vos matchs synchronisés ou enregistrés."
+    }
+  },
+  "dashboard": {
+    "loading": "Chargement de votre tableau de bord...",
+    "empty": {
+      "title": "Vous n'avez pas encore choisi de combattant !",
+      "subtitle": "Choisissez vos combattants principaux et secondaires pour commencer à suivre vos matchs.",
+      "choosePrimary": "Choisir les combattants principaux",
+      "chooseSecondary": "Choisir les combattants secondaires"
+    },
+    "hero": {
+      "overallRecord": "Bilan global",
+      "winRate": "{{rate}}% de victoires",
+      "games_one": "{{count}} match",
+      "games_other": "{{count}} matchs",
+      "noMatchData": "Pas encore de données de match.",
+      "form": "Forme",
+      "streakWin": "{{count}}V",
+      "streakLoss": "{{count}}D",
+      "casualVsCompetitive": "Casual vs Compétitif",
+      "ignoresSourceFilter": "Ignore le filtre de source ci-dessus (la période s'applique toujours).",
+      "deltaLabel": "Écart :",
+      "deltaValue": "{{value}} pts",
+      "deltaCaption": "(compétitif vs casual)",
+      "noData": "aucune donnée",
+      "onlineVsOffline": "En ligne vs Hors ligne",
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "rating": "Classement",
+      "gamesSampled_one": "{{count}} match pris en compte",
+      "gamesSampled_other": "{{count}} matchs pris en compte",
+      "ratingCaption": "Glicko-2, par session · non officiel",
+      "ratingLocked": "Le classement se débloque à {{threshold}} matchs",
+      "ratingProgress": "{{played}}/{{threshold}} matchs pour l'instant",
+      "ratingUp": "Classement en hausse depuis la dernière session",
+      "ratingDown": "Classement en baisse depuis la dernière session",
+      "ratingUnchanged": "Classement inchangé depuis la dernière session"
+    },
+    "tracker": {
+      "rate": "Taux"
+    },
+    "formCurve": {
+      "title": "Courbe de forme",
+      "window": "Fenêtre",
+      "windowAria": "Fenêtre glissante",
+      "lastN": "{{count}} derniers",
+      "cumulative": "Cumulé",
+      "empty": "Enregistrez un match pour voir le graphique.",
+      "winRate": "Taux de victoire",
+      "opponent": "Adversaire : {{name}}"
+    },
+    "previous": {
+      "title": "Matchs précédents",
+      "limit": "Limite",
+      "limitAria": "Nombre de matchs",
+      "empty": "Aucun match enregistré pour l'instant.",
+      "deleteAria": "Supprimer le match",
+      "confirmTitle": "Supprimer ce match ?",
+      "deleted": "Match supprimé !",
+      "deleteFailed": "Échec de la suppression du match. Veuillez réessayer."
+    },
+    "stages": {
+      "title": "Stages les plus joués",
+      "empty": "Pas encore de données de stage."
+    },
+    "snapshot": {
+      "title": "Aperçu des matchups",
+      "noMatches": "Aucun match enregistré",
+      "openLab": "Ouvrir le Matchup Lab",
+      "strongest": "Matchups les plus favorables",
+      "toughest": "Matchups les plus difficiles",
+      "needMoreGames": "Jouez encore quelques matchs ({{count}}+ par adversaire) pour révéler votre matchup le plus difficile.",
+      "notEnough": "Pas assez de matchs enregistrés pour calculer."
+    },
+    "selectFighter": {
+      "aria": "Sélectionner un combattant",
+      "placeholder": "Sélectionnez un combattant"
+    },
+    "addMatch": {
+      "title": "Ajouter un match",
+      "description": "Enregistrez le résultat d'un match que vous venez de jouer.",
+      "singleGame": "Match simple",
+      "setMode": "Set (Bo3/Bo5)",
+      "saveSet": "Enregistrer le set",
+      "added": "Match ajouté !",
+      "addFailed": "Échec de l'ajout du match. Veuillez réessayer.",
+      "noGames": "Saisissez au moins le résultat d'une manche avant d'enregistrer.",
+      "setRecorded": "Set enregistré : {{score}} vs {{opponent}}",
+      "partialSave": "Seules {{saved}} manches sur {{total}} ont été enregistrées avant une erreur. Vérifiez les Données de matchs et ressaisissez les manches manquantes.",
+      "setFailed": "Échec de l'enregistrement du set. Veuillez réessayer."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -38,6 +38,127 @@
     "delete": "削除",
     "win": "勝ち",
     "loss": "負け",
-    "cannotBeUndone": "この操作は取り消せません。"
+    "cannotBeUndone": "この操作は取り消せません。",
+    "wins": "勝利数",
+    "losses": "敗北数",
+    "casual": "カジュアル",
+    "competitive": "大会",
+    "unknown": "不明",
+    "notAvailable": "—"
+  },
+  "filters": {
+    "sourceAria": "対戦を種別で絞り込む",
+    "rangeAria": "対戦を期間で絞り込む",
+    "all": "すべて",
+    "allTime": "全期間",
+    "months3": "3ヶ月",
+    "months6": "6ヶ月",
+    "months12": "12ヶ月"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "現在のフィルターに一致する対戦がありません。",
+      "clear": "フィルターを解除"
+    },
+    "pips": {
+      "empty": "まだ対戦がありません。",
+      "recentResults": "直近{{count}}戦の結果（新しい順）"
+    },
+    "glicko": {
+      "whatIs": "Glicko-2とは？",
+      "p1": "<strong>Glicko-2</strong>はチェスや多くの対戦ラダーで使われているレーティングシステムです。単純な勝率と違い、<em>誰に</em>勝ったか、その結果がどれだけ番狂わせだったかを重み付けします。",
+      "p2": "<strong>±の数値（RD）</strong>は不確実性です。対戦を重ねるほど小さくなり、ブランクが空くと大きくなります — 1500 ±50のプレイヤーは実力が確かで、1500 ±300のプレイヤーは未知数です。",
+      "p3": "ブラケット戦は間隔が空きがちなため、大会間の長いブランクや少ない対戦数の扱いに優れたGlicko-2を採用しています（Eloや勝率だけよりも適しています）。ここでのレーティングは非公式で、同期・記録された対戦のみから計算されます。"
+    }
+  },
+  "dashboard": {
+    "loading": "ダッシュボードを読み込み中...",
+    "empty": {
+      "title": "まだファイターを選んでいません！",
+      "subtitle": "メインとサブのファイターを選んで、対戦の記録を始めましょう。",
+      "choosePrimary": "メインファイターを選ぶ",
+      "chooseSecondary": "サブファイターを選ぶ"
+    },
+    "hero": {
+      "overallRecord": "通算戦績",
+      "winRate": "勝率{{rate}}%",
+      "games_one": "{{count}}戦",
+      "games_other": "{{count}}戦",
+      "noMatchData": "まだ対戦データがありません。",
+      "form": "調子",
+      "streakWin": "{{count}}連勝",
+      "streakLoss": "{{count}}連敗",
+      "casualVsCompetitive": "カジュアル vs 大会",
+      "ignoresSourceFilter": "上の種別フィルターは無視されます（期間は適用されます）。",
+      "deltaLabel": "差:",
+      "deltaValue": "{{value}}pt",
+      "deltaCaption": "（大会 vs カジュアル）",
+      "noData": "データなし",
+      "onlineVsOffline": "オンライン vs オフライン",
+      "online": "オンライン",
+      "offline": "オフライン",
+      "rating": "レーティング",
+      "gamesSampled_one": "{{count}}戦を集計",
+      "gamesSampled_other": "{{count}}戦を集計",
+      "ratingCaption": "Glicko-2・セッション制・非公式",
+      "ratingLocked": "レーティングは{{threshold}}戦で解放されます",
+      "ratingProgress": "現在{{played}}/{{threshold}}戦",
+      "ratingUp": "前回セッションからレーティング上昇",
+      "ratingDown": "前回セッションからレーティング下降",
+      "ratingUnchanged": "前回セッションからレーティング変化なし"
+    },
+    "tracker": {
+      "rate": "勝率"
+    },
+    "formCurve": {
+      "title": "調子の推移",
+      "window": "集計範囲",
+      "windowAria": "移動ウィンドウ",
+      "lastN": "直近{{count}}戦",
+      "cumulative": "累計",
+      "empty": "対戦を登録するとグラフが表示されます。",
+      "winRate": "勝率",
+      "opponent": "相手: {{name}}"
+    },
+    "previous": {
+      "title": "最近の対戦",
+      "limit": "表示数",
+      "limitAria": "表示する対戦数",
+      "empty": "まだ対戦が記録されていません。",
+      "deleteAria": "対戦を削除",
+      "confirmTitle": "この対戦を削除しますか？",
+      "deleted": "対戦を削除しました！",
+      "deleteFailed": "対戦を削除できませんでした。もう一度お試しください。"
+    },
+    "stages": {
+      "title": "よく遊ぶステージ",
+      "empty": "まだステージのデータがありません。"
+    },
+    "snapshot": {
+      "title": "相性スナップショット",
+      "noMatches": "対戦の記録がありません",
+      "openLab": "相性表を開く",
+      "strongest": "得意な相手",
+      "toughest": "苦手な相手",
+      "needMoreGames": "あと数戦（相手ごとに{{count}}戦以上）プレイすると、最も苦手な相性が表示されます。",
+      "notEnough": "計算に必要な対戦数が足りません。"
+    },
+    "selectFighter": {
+      "aria": "ファイターを選択",
+      "placeholder": "ファイターを選択"
+    },
+    "addMatch": {
+      "title": "対戦を追加",
+      "description": "プレイした対戦の結果を記録します。",
+      "singleGame": "1戦のみ",
+      "setMode": "セット（Bo3/Bo5）",
+      "saveSet": "セットを保存",
+      "added": "対戦を追加しました！",
+      "addFailed": "対戦を追加できませんでした。もう一度お試しください。",
+      "noGames": "保存する前に少なくとも1戦の結果を入力してください。",
+      "setRecorded": "セットを記録: {{score}} vs {{opponent}}",
+      "partialSave": "エラーが発生し、{{total}}戦中{{saved}}戦のみ保存されました。対戦データを確認し、足りない分を再入力してください。",
+      "setFailed": "セットを保存できませんでした。もう一度お試しください。"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -38,6 +38,127 @@
     "delete": "Excluir",
     "win": "Vitória",
     "loss": "Derrota",
-    "cannotBeUndone": "Esta ação não pode ser desfeita."
+    "cannotBeUndone": "Esta ação não pode ser desfeita.",
+    "wins": "Vitórias",
+    "losses": "Derrotas",
+    "casual": "Casual",
+    "competitive": "Competitivo",
+    "unknown": "Desconhecido",
+    "notAvailable": "n/d"
+  },
+  "filters": {
+    "sourceAria": "Filtrar partidas por origem",
+    "rangeAria": "Filtrar partidas por período",
+    "all": "Todas",
+    "allTime": "Todo o período",
+    "months3": "3 m",
+    "months6": "6 m",
+    "months12": "12 m"
+  },
+  "shared": {
+    "filteredNotice": {
+      "message": "Nenhuma partida corresponde aos filtros atuais.",
+      "clear": "Limpar filtros"
+    },
+    "pips": {
+      "empty": "Ainda não há partidas.",
+      "recentResults": "Últimos {{count}} resultados, do mais recente para o mais antigo"
+    },
+    "glicko": {
+      "whatIs": "O que é Glicko-2?",
+      "p1": "<strong>Glicko-2</strong> é o sistema de pontuação usado no xadrez e em muitas ladders competitivas. Diferente de uma taxa de vitórias simples, ele pesa <em>quem</em> você vence e o quão surpreendente foi o resultado.",
+      "p2": "O <strong>número ± (RD)</strong> é a incerteza: ele diminui conforme você joga e cresce quando você fica inativo — um jogador 1500 ±50 é comprovado, um 1500 ±300 é uma incógnita.",
+      "p3": "Nós o usamos porque o jogo de bracket é irregular: o Glicko-2 lida com longas pausas entre torneios e amostras pequenas muito melhor do que o Elo ou a taxa de vitórias sozinhos. As pontuações aqui não são oficiais e são calculadas apenas com suas partidas sincronizadas ou registradas."
+    }
+  },
+  "dashboard": {
+    "loading": "Carregando seu painel...",
+    "empty": {
+      "title": "Você ainda não escolheu nenhum lutador!",
+      "subtitle": "Escolha seus lutadores principal e secundários para começar a registrar partidas.",
+      "choosePrimary": "Escolher lutadores principais",
+      "chooseSecondary": "Escolher lutadores secundários"
+    },
+    "hero": {
+      "overallRecord": "Histórico geral",
+      "winRate": "{{rate}}% de vitórias",
+      "games_one": "{{count}} partida",
+      "games_other": "{{count}} partidas",
+      "noMatchData": "Ainda não há dados de partidas.",
+      "form": "Forma",
+      "streakWin": "{{count}}V",
+      "streakLoss": "{{count}}D",
+      "casualVsCompetitive": "Casual vs Competitivo",
+      "ignoresSourceFilter": "Ignora o filtro de origem acima (o período ainda se aplica).",
+      "deltaLabel": "Diferença:",
+      "deltaValue": "{{value}} pts",
+      "deltaCaption": "(competitivo vs casual)",
+      "noData": "sem dados",
+      "onlineVsOffline": "Online vs Offline",
+      "online": "Online",
+      "offline": "Offline",
+      "rating": "Pontuação",
+      "gamesSampled_one": "{{count}} partida analisada",
+      "gamesSampled_other": "{{count}} partidas analisadas",
+      "ratingCaption": "Glicko-2, por sessão · não oficial",
+      "ratingLocked": "A pontuação desbloqueia com {{threshold}} partidas",
+      "ratingProgress": "{{played}}/{{threshold}} partidas até agora",
+      "ratingUp": "Pontuação em alta desde a última sessão",
+      "ratingDown": "Pontuação em queda desde a última sessão",
+      "ratingUnchanged": "Pontuação inalterada desde a última sessão"
+    },
+    "tracker": {
+      "rate": "Taxa"
+    },
+    "formCurve": {
+      "title": "Curva de forma",
+      "window": "Janela",
+      "windowAria": "Janela móvel",
+      "lastN": "Últimas {{count}}",
+      "cumulative": "Acumulado",
+      "empty": "Registre uma partida para ver o gráfico.",
+      "winRate": "Taxa de vitórias",
+      "opponent": "Oponente: {{name}}"
+    },
+    "previous": {
+      "title": "Partidas anteriores",
+      "limit": "Limite",
+      "limitAria": "Limite de partidas",
+      "empty": "Nenhuma partida registrada ainda.",
+      "deleteAria": "Excluir partida",
+      "confirmTitle": "Excluir esta partida?",
+      "deleted": "Partida excluída!",
+      "deleteFailed": "Falha ao excluir a partida. Tente novamente."
+    },
+    "stages": {
+      "title": "Stages mais jogados",
+      "empty": "Ainda não há dados de stages."
+    },
+    "snapshot": {
+      "title": "Resumo de confrontos",
+      "noMatches": "Nenhuma partida registrada",
+      "openLab": "Abrir o Matchup Lab",
+      "strongest": "Confrontos mais favoráveis",
+      "toughest": "Confrontos mais difíceis",
+      "needMoreGames": "Jogue mais algumas partidas ({{count}}+ por oponente) para revelar seu confronto mais difícil.",
+      "notEnough": "Não há partidas registradas suficientes para calcular."
+    },
+    "selectFighter": {
+      "aria": "Selecionar lutador",
+      "placeholder": "Selecione um lutador"
+    },
+    "addMatch": {
+      "title": "Adicionar partida",
+      "description": "Registre o resultado de uma partida que você acabou de jogar.",
+      "singleGame": "Partida única",
+      "setMode": "Set (MD3/MD5)",
+      "saveSet": "Salvar set",
+      "added": "Partida adicionada!",
+      "addFailed": "Falha ao adicionar a partida. Tente novamente.",
+      "noGames": "Insira o resultado de pelo menos um game antes de salvar.",
+      "setRecorded": "Set registrado: {{score}} vs {{opponent}}",
+      "partialSave": "Apenas {{saved}} de {{total}} games foram salvos antes de um erro. Verifique os Dados de partidas e insira novamente os games que faltam.",
+      "setFailed": "Falha ao salvar o set. Tente novamente."
+    }
   }
 }

--- a/apps/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/Dashboard/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import type { Fighter } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
 import { useFighters } from '@/hooks/useFighters';
@@ -17,6 +18,7 @@ import { StageTiles } from './components/StageTiles';
 
 /** Ports legacy/src/screens/Dashboard. */
 export function DashboardPage() {
+  const { t } = useTranslation();
   const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
   const {
     matches,
@@ -49,24 +51,20 @@ export function DashboardPage() {
   };
 
   if (fightersLoading || matchesLoading) {
-    return <div className="text-muted-foreground">Loading your dashboard...</div>;
+    return <div className="text-muted-foreground">{t('dashboard.loading')}</div>;
   }
 
   if (fighterSprites.length === 0) {
     return (
       <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          You haven&apos;t picked any fighters yet!
-        </h1>
-        <p className="max-w-md text-muted-foreground">
-          Choose your primary and secondary fighters to start tracking matches.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('dashboard.empty.title')}</h1>
+        <p className="max-w-md text-muted-foreground">{t('dashboard.empty.subtitle')}</p>
         <div className="flex flex-wrap justify-center gap-2">
           <Button asChild>
-            <Link to="/choose-primary">Choose Primary Fighters</Link>
+            <Link to="/choose-primary">{t('dashboard.empty.choosePrimary')}</Link>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/choose-secondary">Choose Secondary Fighters</Link>
+            <Link to="/choose-secondary">{t('dashboard.empty.chooseSecondary')}</Link>
           </Button>
         </div>
       </div>

--- a/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
+++ b/apps/web/src/pages/Dashboard/components/AddMatchForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { CreateMatchInput } from '@smash-tracker/shared';
 import {
@@ -70,6 +71,7 @@ function buildDefaultValues(fighterId: number): MatchFormValues {
  * mutation (no cross-game transaction/rollback — see `handleSetSubmit`).
  */
 export function AddMatchForm() {
+  const { t } = useTranslation();
   const { fighter, fighterSprites } = useDashboardContext();
   const createMatch = useCreateMatch();
   const [open, setOpen] = useState(false);
@@ -100,10 +102,10 @@ export function AddMatchForm() {
     const input: CreateMatchInput = matchFormValuesToInput(values);
     try {
       await createMatch.mutateAsync(input);
-      toast.success('Match added!');
+      toast.success(t('dashboard.addMatch.added'));
       setOpen(false);
     } catch {
-      toast.error('Failed to add match. Please try again.');
+      toast.error(t('dashboard.addMatch.addFailed'));
     }
   }
 
@@ -116,7 +118,7 @@ export function AddMatchForm() {
    */
   async function handleSetSubmit(payloads: CreateMatchInput[]) {
     if (payloads.length === 0) {
-      toast.error('Enter at least one game result before saving.');
+      toast.error(t('dashboard.addMatch.noGames'));
       return;
     }
 
@@ -130,15 +132,20 @@ export function AddMatchForm() {
         payloads.map((p) => ({ result: p.win ? 'win' : 'loss', stageId: 0 })),
       );
       const opponentName = payloads[0]?.opponent ?? 'opponent';
-      toast.success(`Set recorded: ${formatSetScore(score)} vs ${opponentName}`);
+      toast.success(
+        t('dashboard.addMatch.setRecorded', {
+          score: formatSetScore(score),
+          opponent: opponentName,
+        }),
+      );
       setOpen(false);
     } catch {
       if (savedCount > 0) {
         toast.error(
-          `Only ${savedCount} of ${payloads.length} games saved before an error occurred. Check Match Data and re-enter any missing games.`,
+          t('dashboard.addMatch.partialSave', { saved: savedCount, total: payloads.length }),
         );
       } else {
-        toast.error('Failed to save the set. Please try again.');
+        toast.error(t('dashboard.addMatch.setFailed'));
       }
     }
   }
@@ -146,12 +153,12 @@ export function AddMatchForm() {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button disabled={fighterSprites.length === 0}>Add Match</Button>
+        <Button disabled={fighterSprites.length === 0}>{t('dashboard.addMatch.title')}</Button>
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Add Match</DialogTitle>
-          <DialogDescription>Record the outcome of a match you just played.</DialogDescription>
+          <DialogTitle>{t('dashboard.addMatch.title')}</DialogTitle>
+          <DialogDescription>{t('dashboard.addMatch.description')}</DialogDescription>
         </DialogHeader>
 
         <ToggleGroup
@@ -163,11 +170,11 @@ export function AddMatchForm() {
           }}
           className="mb-2"
         >
-          <ToggleGroupItem value="single" aria-label="Single game">
-            Single game
+          <ToggleGroupItem value="single" aria-label={t('dashboard.addMatch.singleGame')}>
+            {t('dashboard.addMatch.singleGame')}
           </ToggleGroupItem>
-          <ToggleGroupItem value="set" aria-label="Set (Bo3/Bo5)">
-            Set (Bo3/Bo5)
+          <ToggleGroupItem value="set" aria-label={t('dashboard.addMatch.setMode')}>
+            {t('dashboard.addMatch.setMode')}
           </ToggleGroupItem>
         </ToggleGroup>
 
@@ -176,10 +183,10 @@ export function AddMatchForm() {
             <MatchFormFields form={form} fighterSprites={fighterSprites} />
             <DialogFooter className="mt-4">
               <Button type="button" variant="outline" onClick={() => setOpen(false)}>
-                Cancel
+                {t('common.cancel')}
               </Button>
               <Button type="submit" disabled={createMatch.isPending}>
-                Save
+                {t('common.save')}
               </Button>
             </DialogFooter>
           </form>
@@ -193,10 +200,10 @@ export function AddMatchForm() {
             footer={
               <DialogFooter className="mt-4">
                 <Button type="button" variant="outline" onClick={() => setOpen(false)}>
-                  Cancel
+                  {t('common.cancel')}
                 </Button>
                 <Button type="submit" disabled={createMatch.isPending}>
-                  Save Set
+                  {t('dashboard.addMatch.saveSet')}
                 </Button>
               </DialogFooter>
             }

--- a/apps/web/src/pages/Dashboard/components/HeroStats.tsx
+++ b/apps/web/src/pages/Dashboard/components/HeroStats.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WinLossPips } from '@/components/WinLossPips';
@@ -39,13 +40,14 @@ export function HeroStats({
 }
 
 function OverallRecordCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { wins, losses, total, winRate } = getWinLossRecord(matches);
   const hasMatches = total > 0;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Overall Record</CardTitle>
+        <CardTitle>{t('dashboard.hero.overallRecord')}</CardTitle>
       </CardHeader>
       <CardContent>
         {hasMatches ? (
@@ -54,12 +56,16 @@ function OverallRecordCard({ matches }: { matches: Match[] }) {
               <span className="text-3xl font-bold">
                 {wins}-{losses}
               </span>
-              <p className="text-sm text-muted-foreground">{winRate}% win rate</p>
+              <p className="text-sm text-muted-foreground">
+                {t('dashboard.hero.winRate', { rate: winRate })}
+              </p>
             </div>
-            <span className="text-sm text-muted-foreground">{total} games</span>
+            <span className="text-sm text-muted-foreground">
+              {t('dashboard.hero.games', { count: total })}
+            </span>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('dashboard.hero.noMatchData')}</p>
         )}
       </CardContent>
     </Card>
@@ -67,13 +73,14 @@ function OverallRecordCard({ matches }: { matches: Match[] }) {
 }
 
 function FormCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { currentStreak, currentStreakIsWin } = getStreakSummary(matches);
   const hasMatches = matches.length > 0;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Form</CardTitle>
+        <CardTitle>{t('dashboard.hero.form')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <WinLossPips matches={matches} limit={10} />
@@ -85,8 +92,9 @@ function FormCard({ matches }: { matches: Match[] }) {
                 : 'bg-destructive/15 text-destructive'
             }`}
           >
-            {currentStreak}
-            {currentStreakIsWin ? 'W' : 'L'}
+            {currentStreakIsWin
+              ? t('dashboard.hero.streakWin', { count: currentStreak })
+              : t('dashboard.hero.streakLoss', { count: currentStreak })}
           </span>
         )}
       </CardContent>
@@ -101,6 +109,7 @@ function FormCard({ matches }: { matches: Match[] }) {
  * split isn't collapsed by it.
  */
 function CasualVsCompetitiveCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const casual = getWinLossRecord(filterBySource(matches, 'manual'));
   const competitive = getWinLossRecord(filterBySource(matches, 'startgg'));
   const bothHaveData = casual.total > 0 && competitive.total > 0;
@@ -109,26 +118,23 @@ function CasualVsCompetitiveCard({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Casual vs Competitive</CardTitle>
+        <CardTitle>{t('dashboard.hero.casualVsCompetitive')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
-        <p className="text-xs text-muted-foreground">
-          Ignores the source filter above (time range still applies).
-        </p>
+        <p className="text-xs text-muted-foreground">{t('dashboard.hero.ignoresSourceFilter')}</p>
         <div className="grid grid-cols-2 gap-2">
-          <SplitStat label="Casual" record={casual} />
-          <SplitStat label="Competitive" record={competitive} />
+          <SplitStat label={t('common.casual')} record={casual} />
+          <SplitStat label={t('common.competitive')} record={competitive} />
         </div>
         {bothHaveData && delta != null && (
           <p className="text-sm">
-            <span className="text-muted-foreground">Delta: </span>
+            <span className="text-muted-foreground">{t('dashboard.hero.deltaLabel')} </span>
             <span
               className={`font-semibold ${delta >= 0 ? 'text-emerald-500' : 'text-destructive'}`}
             >
-              {delta >= 0 ? '+' : ''}
-              {delta}pts
+              {t('dashboard.hero.deltaValue', { value: `${delta >= 0 ? '+' : ''}${delta}` })}
             </span>
-            <span className="text-muted-foreground"> (competitive vs casual)</span>
+            <span className="text-muted-foreground"> {t('dashboard.hero.deltaCaption')}</span>
           </p>
         )}
       </CardContent>
@@ -137,11 +143,12 @@ function CasualVsCompetitiveCard({ matches }: { matches: Match[] }) {
 }
 
 function SplitStat({ label, record }: { label: string; record: WinLossRecord }) {
+  const { t } = useTranslation();
   if (record.total === 0) {
     return (
       <div>
         <h3 className="text-sm text-muted-foreground">{label}</h3>
-        <p className="text-sm text-muted-foreground">no data</p>
+        <p className="text-sm text-muted-foreground">{t('dashboard.hero.noData')}</p>
       </div>
     );
   }
@@ -157,22 +164,23 @@ function SplitStat({ label, record }: { label: string; record: WinLossRecord }) 
 }
 
 function OnlineOfflineCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { online, offline } = getOnlineOfflineSplit(matches);
   const hasAny = online.total > 0 || offline.total > 0;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Online vs Offline</CardTitle>
+        <CardTitle>{t('dashboard.hero.onlineVsOffline')}</CardTitle>
       </CardHeader>
       <CardContent>
         {hasAny ? (
           <div className="grid grid-cols-2 gap-2">
-            <SplitStat label="Online" record={online} />
-            <SplitStat label="Offline" record={offline} />
+            <SplitStat label={t('dashboard.hero.online')} record={online} />
+            <SplitStat label={t('dashboard.hero.offline')} record={offline} />
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('dashboard.hero.noMatchData')}</p>
         )}
       </CardContent>
     </Card>
@@ -189,6 +197,7 @@ const RATING_UNLOCK_THRESHOLD = 5;
  * render given typical match volumes.
  */
 function RatingCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const hasEnoughGames = matches.length >= RATING_UNLOCK_THRESHOLD;
   const { periods, current } = computeRatingHistory(matches);
 
@@ -196,7 +205,7 @@ function RatingCard({ matches }: { matches: Match[] }) {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-1.5">
-          Rating
+          {t('dashboard.hero.rating')}
           <GlickoExplainer />
         </CardTitle>
       </CardHeader>
@@ -210,17 +219,20 @@ function RatingCard({ matches }: { matches: Match[] }) {
               <RatingTrendArrow periods={periods} />
             </div>
             <p className="text-sm text-muted-foreground">
-              {matches.length} game{matches.length === 1 ? '' : 's'} sampled
+              {t('dashboard.hero.gamesSampled', { count: matches.length })}
             </p>
-            <p className="text-xs text-muted-foreground">Glicko-2, session-based · unofficial</p>
+            <p className="text-xs text-muted-foreground">{t('dashboard.hero.ratingCaption')}</p>
           </>
         ) : (
           <>
             <p className="text-sm text-muted-foreground">
-              Rating unlocks at {RATING_UNLOCK_THRESHOLD} games
+              {t('dashboard.hero.ratingLocked', { threshold: RATING_UNLOCK_THRESHOLD })}
             </p>
             <p className="text-xs text-muted-foreground">
-              {matches.length}/{RATING_UNLOCK_THRESHOLD} games so far
+              {t('dashboard.hero.ratingProgress', {
+                played: matches.length,
+                threshold: RATING_UNLOCK_THRESHOLD,
+              })}
             </p>
           </>
         )}
@@ -235,6 +247,7 @@ function RatingCard({ matches }: { matches: Match[] }) {
  * single session played so far).
  */
 function RatingTrendArrow({ periods }: { periods: { rating: number }[] }) {
+  const { t } = useTranslation();
   if (periods.length < 2) {
     return null;
   }
@@ -246,7 +259,7 @@ function RatingTrendArrow({ periods }: { periods: { rating: number }[] }) {
   const delta = latest.rating - previous.rating;
   if (delta === 0) {
     return (
-      <span aria-label="Rating unchanged from last session" className="text-muted-foreground">
+      <span aria-label={t('dashboard.hero.ratingUnchanged')} className="text-muted-foreground">
         &rarr;
       </span>
     );
@@ -254,7 +267,7 @@ function RatingTrendArrow({ periods }: { periods: { rating: number }[] }) {
   const isUp = delta > 0;
   return (
     <span
-      aria-label={isUp ? 'Rating up from last session' : 'Rating down from last session'}
+      aria-label={isUp ? t('dashboard.hero.ratingUp') : t('dashboard.hero.ratingDown')}
       className={isUp ? 'text-emerald-500' : 'text-destructive'}
     >
       {isUp ? '▲' : '▼'} {Math.abs(delta)}

--- a/apps/web/src/pages/Dashboard/components/LastMatchesChart.tsx
+++ b/apps/web/src/pages/Dashboard/components/LastMatchesChart.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -53,6 +55,7 @@ export function buildSeries(matches: Match[], window: WindowValue): SeriesPoint[
 
 /** Ports legacy/src/screens/Dashboard/components/LastMatchesChart; upgraded to a rolling win-rate form curve with a window selector (V3 Phase C). */
 export function LastMatchesChart({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const { fighter } = useDashboardContext();
   const [window, setWindow] = useState<WindowValue>(10);
   const fighterMatches = fighter ? matches.filter((m) => m.fighter_id === fighter.id) : [];
@@ -61,30 +64,30 @@ export function LastMatchesChart({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Form Curve</CardTitle>
+        <CardTitle>{t('dashboard.formCurve.title')}</CardTitle>
         <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Window</span>
+          <span className="text-sm text-muted-foreground">{t('dashboard.formCurve.window')}</span>
           <Select value={String(window)} onValueChange={(v) => setWindow(parseWindow(v))}>
-            <SelectTrigger className="w-[130px]" aria-label="Rolling window">
+            <SelectTrigger className="w-[130px]" aria-label={t('dashboard.formCurve.windowAria')}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {WINDOW_OPTIONS.map((option) => (
                 <SelectItem key={option} value={String(option)}>
-                  Last {option}
+                  {t('dashboard.formCurve.lastN', { count: option })}
                 </SelectItem>
               ))}
-              <SelectItem value="cumulative">Cumulative</SelectItem>
+              <SelectItem value="cumulative">{t('dashboard.formCurve.cumulative')}</SelectItem>
             </SelectContent>
           </Select>
         </div>
       </CardHeader>
       <CardContent>
         {series.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Submit a match to see the match chart.</p>
+          <p className="text-sm text-muted-foreground">{t('dashboard.formCurve.empty')}</p>
         ) : (
           <div className="h-64">
-            <Line data={buildData(series)} options={buildOptions(series)} />
+            <Line data={buildData(series, t)} options={buildOptions(series, t, i18n.language)} />
           </div>
         )}
       </CardContent>
@@ -100,12 +103,12 @@ function parseWindow(value: string): WindowValue {
   return (WINDOW_OPTIONS as readonly number[]).includes(parsed) ? (parsed as WindowOption) : 10;
 }
 
-function buildData(series: SeriesPoint[]) {
+function buildData(series: SeriesPoint[], t: TFunction) {
   return {
     labels: series.map((point) => point.index.toString()),
     datasets: [
       {
-        label: 'Win Rate',
+        label: t('dashboard.formCurve.winRate'),
         ...redLineDataset(),
         data: series.map((point) => point.winRate),
       },
@@ -114,7 +117,7 @@ function buildData(series: SeriesPoint[]) {
 }
 
 /** Builds chart options with tooltip callbacks closed over `series` so they can look up the underlying Match for the hovered point (date + opponent), mirroring legacy MatchChart's tooltip title/footer. */
-function buildOptions(series: SeriesPoint[]): ChartOptions<'line'> {
+function buildOptions(series: SeriesPoint[], t: TFunction, locale: string): ChartOptions<'line'> {
   const theme = darkChartOptions();
   return {
     responsive: theme.responsive,
@@ -140,14 +143,16 @@ function buildOptions(series: SeriesPoint[]): ChartOptions<'line'> {
           title: (items) => {
             const point = series[items[0]?.dataIndex ?? -1];
             if (!point) return '';
-            return new Date(point.match.time).toLocaleDateString('en-US');
+            return new Date(point.match.time).toLocaleDateString(locale);
           },
           label: (item) => `: ${Math.round(Number(item.formattedValue) * 100) / 100}%`,
           footer: (items) => {
             const point = series[items[0]?.dataIndex ?? -1];
             if (!point) return '';
             const opponent = getFighterById(point.match.opponent_id);
-            return `Opponent: ${opponent?.name ?? 'Unknown'}`;
+            return t('dashboard.formCurve.opponent', {
+              name: opponent?.name ?? t('common.unknown'),
+            });
           },
         },
       },

--- a/apps/web/src/pages/Dashboard/components/MatchupSnapshot.tsx
+++ b/apps/web/src/pages/Dashboard/components/MatchupSnapshot.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -44,13 +45,14 @@ export function buildMatchupSnapshot(fighterMatches: Match[]): MatchupSnapshotDa
  * Phase C). Replaces the legacy-ratio-sorted `BestWorstMatchup`.
  */
 export function MatchupSnapshot({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { fighter } = useDashboardContext();
 
   if (!fighter || matches.length === 0) {
     return (
       <Card>
         <CardContent className="pt-6">
-          <h2 className="text-lg font-medium">No matches reported</h2>
+          <h2 className="text-lg font-medium">{t('dashboard.snapshot.noMatches')}</h2>
         </CardContent>
       </Card>
     );
@@ -62,20 +64,24 @@ export function MatchupSnapshot({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Matchup Snapshot</CardTitle>
+        <CardTitle>{t('dashboard.snapshot.title')}</CardTitle>
         <Button asChild variant="outline" size="sm">
-          <Link to="/matchups">Open Matchup Lab</Link>
+          <Link to="/matchups">{t('dashboard.snapshot.openLab')}</Link>
         </Button>
       </CardHeader>
       <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <MatchupList title="Strongest Matchups" entries={strongest} />
         <MatchupList
-          title="Toughest Matchups"
+          title={t('dashboard.snapshot.strongest')}
+          entries={strongest}
+          emptyHint={t('dashboard.snapshot.notEnough')}
+        />
+        <MatchupList
+          title={t('dashboard.snapshot.toughest')}
           entries={toughest}
           emptyHint={
             needsMoreData
-              ? `Play a few more games (${TOUGHEST_MIN_GAMES}+ per opponent) to surface a toughest matchup.`
-              : 'Not enough reported matches to calculate.'
+              ? t('dashboard.snapshot.needMoreGames', { count: TOUGHEST_MIN_GAMES })
+              : t('dashboard.snapshot.notEnough')
           }
         />
       </CardContent>
@@ -86,12 +92,13 @@ export function MatchupSnapshot({ matches }: { matches: Match[] }) {
 function MatchupList({
   title,
   entries,
-  emptyHint = 'Not enough reported matches to calculate.',
+  emptyHint,
 }: {
   title: string;
   entries: RankedMatchup[];
-  emptyHint?: string;
+  emptyHint: string;
 }) {
+  const { t } = useTranslation();
   return (
     <div>
       <h3 className="mb-2 text-sm text-muted-foreground">{title}</h3>
@@ -105,7 +112,7 @@ function MatchupList({
               <li key={entry.opponentFighterId} className="flex items-center gap-2">
                 {sprite && <img src={sprite.url} alt="" className="size-10 object-contain" />}
                 <div>
-                  <div className="font-medium">{sprite?.name ?? 'Unknown'}</div>
+                  <div className="font-medium">{sprite?.name ?? t('common.unknown')}</div>
                   <div className="text-sm text-muted-foreground">
                     {entry.wins}-{entry.losses} &middot; {entry.ratio}% ({entry.totalMatches})
                   </div>

--- a/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
+++ b/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,6 +31,7 @@ const LIMIT_OPTIONS = [5, 10, 20, 30];
 
 /** Ports legacy/src/screens/Dashboard/components/PreviousMatches. */
 export function PreviousMatches({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { fighter } = useDashboardContext();
   const [limit, setLimit] = useState(5);
   const [pendingDelete, setPendingDelete] = useState<Match | null>(null);
@@ -42,9 +44,9 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
     if (!pendingDelete) return;
     try {
       await deleteMatch.mutateAsync(pendingDelete.id);
-      toast.success('Match deleted!');
+      toast.success(t('dashboard.previous.deleted'));
     } catch {
-      toast.error('Failed to delete match. Please try again.');
+      toast.error(t('dashboard.previous.deleteFailed'));
     } finally {
       setPendingDelete(null);
     }
@@ -53,12 +55,12 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Previous Matches</CardTitle>
+        <CardTitle>{t('dashboard.previous.title')}</CardTitle>
         {recent.length > 0 && (
           <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Limit</span>
+            <span className="text-sm text-muted-foreground">{t('dashboard.previous.limit')}</span>
             <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
-              <SelectTrigger className="w-[80px]" aria-label="Match limit">
+              <SelectTrigger className="w-[80px]" aria-label={t('dashboard.previous.limitAria')}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -74,7 +76,7 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
       </CardHeader>
       <CardContent>
         {recent.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No matches recorded yet.</p>
+          <p className="text-sm text-muted-foreground">{t('dashboard.previous.empty')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {recent.map((match) => {
@@ -101,7 +103,7 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
                     <span
                       className={`font-medium ${match.win ? 'text-emerald-500' : 'text-destructive'}`}
                     >
-                      {match.win ? 'Win' : 'Loss'}
+                      {match.win ? t('common.win') : t('common.loss')}
                     </span>
                   </div>
                   {/* Synced matches can't be deleted (the next sync would
@@ -111,7 +113,7 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
                     <Button
                       variant="outline"
                       size="icon-sm"
-                      aria-label="Delete match"
+                      aria-label={t('dashboard.previous.deleteAria')}
                       onClick={() => setPendingDelete(match)}
                     >
                       <Trash2 />
@@ -130,12 +132,12 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete this match?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+            <AlertDialogTitle>{t('dashboard.previous.confirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('common.cannotBeUndone')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>{t('common.delete')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/pages/Dashboard/components/SelectFighter.tsx
+++ b/apps/web/src/pages/Dashboard/components/SelectFighter.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import {
   Select,
   SelectContent,
@@ -9,6 +10,7 @@ import { useDashboardContext } from '../DashboardContext';
 
 /** Ports legacy/src/screens/Dashboard/components/DashboardToolbar/components/SelectFighter. */
 export function SelectFighter() {
+  const { t } = useTranslation();
   const { fighter, fighterSprites, setFighter } = useDashboardContext();
 
   return (
@@ -21,8 +23,8 @@ export function SelectFighter() {
         }
       }}
     >
-      <SelectTrigger aria-label="Select fighter" className="w-[220px]">
-        <SelectValue placeholder="Select a fighter" />
+      <SelectTrigger aria-label={t('dashboard.selectFighter.aria')} className="w-[220px]">
+        <SelectValue placeholder={t('dashboard.selectFighter.placeholder')} />
       </SelectTrigger>
       <SelectContent>
         {fighterSprites.map((sprite) => (

--- a/apps/web/src/pages/Dashboard/components/StageTiles.tsx
+++ b/apps/web/src/pages/Dashboard/components/StageTiles.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { Match, Stage } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { stageAbbreviation } from '@/components/StageOption';
@@ -35,16 +36,17 @@ export function buildTopStageTiles(matches: Match[]): StageTile[] {
 
 /** Most-played stages as art tiles (account-wide, respects the global filter), per docs/analytics-vision.md Phase C. */
 export function StageTiles({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const tiles = buildTopStageTiles(matches);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Most-Played Stages</CardTitle>
+        <CardTitle>{t('dashboard.stages.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {tiles.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No stage data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('dashboard.stages.empty')}</p>
         ) : (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
             {tiles.map(({ stage, record }) => (

--- a/apps/web/src/pages/Dashboard/components/WinLossTracker.tsx
+++ b/apps/web/src/pages/Dashboard/components/WinLossTracker.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { filterByFighter, getWinLossRecord } from '@/lib/stats';
 import type { Match } from '@smash-tracker/shared';
@@ -5,6 +6,7 @@ import { useDashboardContext } from '../DashboardContext';
 
 /** Ports legacy/src/screens/Dashboard/components/WinLossTracker. */
 export function WinLossTracker({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const { fighter } = useDashboardContext();
 
   const fighterMatches = fighter ? filterByFighter(matches, fighter.id) : [];
@@ -14,16 +16,16 @@ export function WinLossTracker({ matches }: { matches: Match[] }) {
   return (
     <Card className="mx-auto w-full max-w-sm">
       <CardHeader>
-        <CardTitle className="text-center">Overall Record</CardTitle>
+        <CardTitle className="text-center">{t('dashboard.hero.overallRecord')}</CardTitle>
       </CardHeader>
       <CardContent className="flex justify-evenly">
-        <Stat label="Wins" value={hasMatches ? wins : 'n/a'} />
-        {hasMatches && <Stat label="Rate" value={`${winRate}%`} />}
-        <Stat label="Losses" value={hasMatches ? losses : 'n/a'} />
+        <Stat label={t('common.wins')} value={hasMatches ? wins : t('common.notAvailable')} />
+        {hasMatches && <Stat label={t('dashboard.tracker.rate')} value={`${winRate}%`} />}
+        <Stat label={t('common.losses')} value={hasMatches ? losses : t('common.notAvailable')} />
       </CardContent>
       {!hasMatches && (
         <p className="pb-4 text-center text-sm text-muted-foreground">
-          No match data to report yet.
+          {t('dashboard.hero.noMatchData')}
         </p>
       )}
     </Card>


### PR DESCRIPTION
## Summary

Second wave of V15 localization (follow-up to #141), covering the highest-traffic page first per the phase 2 plan.

- Extracts all hardcoded UI strings from `pages/Dashboard/**` into `dashboard.*` keys: hero stat cards, win/loss tracker, form curve chart, previous-matches list (incl. delete confirm + toasts), stage tiles, matchup snapshot, fighter select, and the Add Match dialog (mode toggle, footers, all success/failure toasts).
- Also extracts the shared components the dashboard renders: `AnalyticsFilterControls` (app chrome, missed in phase 1 — now `filters.*`), `FilteredEmptyNotice`, `GlickoExplainer`, and `WinLossPips` (`shared.*`).
- Adds shared vocabulary to `common.*` (Wins/Losses/Casual/Competitive/Unknown/n-a) for reuse by later pages.
- Translates every new key into es/fr/de/pt/ja, keeping FGC terms natural per locale (matchup/set/Bo3 loanwords where the scene uses them, 相性/連勝 etc. in ja, MD3/MD5 in pt-BR).

## Implementation notes

- Counts use i18next plural forms (`games_one`/`games_other`); ja intentionally carries identical `_one`/`_other` values so the key-parity CI test stays exact across locales.
- The Glicko explainer renders through `<Trans>` so its `<strong>`/`<em>` markup survives translation.
- The form-curve tooltip date now formats with the active locale instead of hardcoded `en-US`.
- `MatchupList.emptyHint` became a required prop (both callers now pass a translated string) rather than keeping an English default.

## Testing

- `pnpm --filter @smash-tracker/web lint` ✅ (0 errors; pre-existing react-refresh warnings only)
- `pnpm --filter @smash-tracker/web typecheck` ✅
- `pnpm --filter @smash-tracker/web test` ✅ 926/926 — English assertions unchanged since rendered English copy is identical; locale key parity enforced by `i18n.test.ts`
- One-off RTL smoke test (not committed) verified `<Trans>` renders real strong/em elements in en and lazily-loaded ja

🤖 Generated with [Claude Code](https://claude.com/claude-code)