### PR TITLE
Localization phase 2b: shared match forms + zod validation messages

### DIFF
--- a/apps/web/src/components/match-form/EditMatchForm.tsx
+++ b/apps/web/src/components/match-form/EditMatchForm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { Fighter, Match, UpdateMatchInput } from '@smash-tracker/shared';
 import {
@@ -66,6 +67,7 @@ export function EditMatchForm({
    */
   onDelete?: (match: Match) => void;
 }) {
+  const { t } = useTranslation();
   const updateMatch = useUpdateMatch();
   const form = useMatchForm(matchToFormValues(match));
 
@@ -87,10 +89,10 @@ export function EditMatchForm({
     };
     try {
       await updateMatch.mutateAsync({ id: match.id, input });
-      toast.success('Match edited!');
+      toast.success(t('matchForm.edit.edited'));
       onOpenChange(false);
     } catch {
-      toast.error('Failed to save match. Please try again.');
+      toast.error(t('matchForm.edit.saveFailed'));
     }
   }
 
@@ -98,8 +100,8 @@ export function EditMatchForm({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Edit Match</DialogTitle>
-          <DialogDescription>Update the details of this recorded match.</DialogDescription>
+          <DialogTitle>{t('matchForm.edit.title')}</DialogTitle>
+          <DialogDescription>{t('matchForm.edit.description')}</DialogDescription>
         </DialogHeader>
         <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
           <MatchFormFields form={form} fighterSprites={fighterSprites} />
@@ -111,14 +113,14 @@ export function EditMatchForm({
                 className="sm:mr-auto"
                 onClick={() => onDelete(match)}
               >
-                Delete Match
+                {t('matchForm.edit.deleteMatch')}
               </Button>
             )}
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
+              {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={updateMatch.isPending}>
-              Save
+              {t('common.save')}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/components/match-form/MatchForm.tsx
+++ b/apps/web/src/components/match-form/MatchForm.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Check, ChevronDown, ChevronsUpDown } from 'lucide-react';
 import type { Fighter } from '@smash-tracker/shared';
 import { matchTypeValues, type CreateMatchInput } from '@smash-tracker/shared';
@@ -70,14 +72,10 @@ export function StageArtPreview({ stageId }: { stageId: number }) {
   );
 }
 
-export const MATCH_TYPE_LABELS: Record<(typeof matchTypeValues)[number], string> = {
-  none: 'None',
-  quickplay: 'QuickPlay',
-  'online-friendly': 'Online Friendly',
-  'online-tourney': 'Online Tourney',
-  'offline-friendly': 'Offline Friendly',
-  'offline-tourney': 'Offline Tourney',
-};
+/** Translated label for a shared match-type enum value (locale keys mirror the enum literals, hyphens included). */
+export function matchTypeLabel(t: TFunction, value: (typeof matchTypeValues)[number]): string {
+  return t(`matchForm.matchTypes.${value}`);
+}
 
 /**
  * Form-level validation schema, shared by AddMatchForm and EditMatchForm.
@@ -85,26 +83,43 @@ export const MATCH_TYPE_LABELS: Record<(typeof matchTypeValues)[number], string>
  * a boolean, stage/fighter ids are numbers) and get mapped to
  * `CreateMatchInput`/`UpdateMatchInput` by callers — including lowercasing
  * the opponent name, exactly as legacy did in `updateOpponent`.
+ *
+ * A factory (not a module constant) so validation messages come out of the
+ * active locale; `useMatchForm` rebuilds it per render with the current `t`.
  */
-export const matchFormSchema = z.object({
-  fighterId: z.number().int().positive({ message: 'Choose your fighter' }),
-  opponentFighterId: z.number().int().positive({ message: "Choose your opponent's fighter" }),
-  result: z.enum(['win', 'loss'], { message: 'Choose a result' }),
-  stageId: z.number().int().nonnegative(),
-  matchType: z.enum(matchTypeValues),
-  opponentName: z.string().min(1, 'Opponent name is required'),
-  notes: z.string().max(100, 'Limit 100 characters'),
-  /** Winner's remaining stocks, 0-3. `undefined`/`''` (the "not tracked" state) is allowed — see `STOCKS_NOT_TRACKED`. */
-  stocksLeft: z.number().int().min(0).max(3).optional(),
-  eventName: z.string().max(80, 'Limit 80 characters').optional(),
-  tournamentName: z.string().max(80, 'Limit 80 characters').optional(),
-  /** GSP shown on the results screen, held as the user's raw text (commas/spaces tolerated — see parseGspNumber); '' = not tracked. */
-  gsp: z.string().refine((value) => value.trim() === '' || parseGspNumber(value) !== null, {
-    message: 'Enter a number like 12,400,000 (or leave blank)',
-  }),
-});
+export function buildMatchFormSchema(t: TFunction) {
+  return z.object({
+    fighterId: z
+      .number()
+      .int()
+      .positive({ message: t('matchForm.validation.chooseFighter') }),
+    opponentFighterId: z
+      .number()
+      .int()
+      .positive({ message: t('matchForm.validation.chooseOpponentFighter') }),
+    result: z.enum(['win', 'loss'], { message: t('matchForm.validation.chooseResult') }),
+    stageId: z.number().int().nonnegative(),
+    matchType: z.enum(matchTypeValues),
+    opponentName: z.string().min(1, t('matchForm.validation.opponentRequired')),
+    notes: z.string().max(100, t('matchForm.validation.charLimit', { max: 100 })),
+    /** Winner's remaining stocks, 0-3. `undefined`/`''` (the "not tracked" state) is allowed — see `STOCKS_NOT_TRACKED`. */
+    stocksLeft: z.number().int().min(0).max(3).optional(),
+    eventName: z
+      .string()
+      .max(80, t('matchForm.validation.charLimit', { max: 80 }))
+      .optional(),
+    tournamentName: z
+      .string()
+      .max(80, t('matchForm.validation.charLimit', { max: 80 }))
+      .optional(),
+    /** GSP shown on the results screen, held as the user's raw text (commas/spaces tolerated — see parseGspNumber); '' = not tracked. */
+    gsp: z.string().refine((value) => value.trim() === '' || parseGspNumber(value) !== null, {
+      message: t('matchForm.validation.gspFormat'),
+    }),
+  });
+}
 
-export type MatchFormValues = z.infer<typeof matchFormSchema>;
+export type MatchFormValues = z.infer<ReturnType<typeof buildMatchFormSchema>>;
 
 /** Sentinel select value meaning "stocks not tracked for this game" — HTML selects need a string, and `''` reads naturally as unset. */
 export const STOCKS_NOT_TRACKED = 'unset';
@@ -131,8 +146,9 @@ export function matchFormValuesToInput(values: MatchFormValues): CreateMatchInpu
 }
 
 export function useMatchForm(defaultValues: MatchFormValues): UseFormReturn<MatchFormValues> {
+  const { t } = useTranslation();
   return useForm<MatchFormValues>({
-    resolver: zodResolver(matchFormSchema),
+    resolver: zodResolver(buildMatchFormSchema(t)),
     defaultValues,
   });
 }
@@ -147,12 +163,13 @@ export function useMatchForm(defaultValues: MatchFormValues): UseFormReturn<Matc
 export function StocksSelectField<TFieldValues extends Record<string, unknown>>({
   control,
   name = 'stocksLeft' as never,
-  label = 'Stocks Left (winner)',
+  label,
 }: {
   control: UseFormReturn<TFieldValues>['control'];
   name?: Parameters<typeof FormField<TFieldValues>>[0]['name'];
   label?: string;
 }) {
+  const { t } = useTranslation();
   return (
     <FormField
       control={control}
@@ -161,7 +178,7 @@ export function StocksSelectField<TFieldValues extends Record<string, unknown>>(
         const value = field.value as number | undefined;
         return (
           <FormItem>
-            <FormLabel>{label}</FormLabel>
+            <FormLabel>{label ?? t('matchForm.stocksLeft')}</FormLabel>
             <Select
               value={value === undefined ? STOCKS_NOT_TRACKED : String(value)}
               onValueChange={(v) =>
@@ -170,11 +187,11 @@ export function StocksSelectField<TFieldValues extends Record<string, unknown>>(
             >
               <FormControl>
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Not tracked" />
+                  <SelectValue placeholder={t('matchForm.notTracked')} />
                 </SelectTrigger>
               </FormControl>
               <SelectContent>
-                <SelectItem value={STOCKS_NOT_TRACKED}>Not tracked</SelectItem>
+                <SelectItem value={STOCKS_NOT_TRACKED}>{t('matchForm.notTracked')}</SelectItem>
                 {[0, 1, 2, 3].map((n) => (
                   <SelectItem key={n} value={String(n)}>
                     {n}
@@ -208,6 +225,7 @@ export function TournamentFields<TFieldValues extends Record<string, unknown>>({
   tournamentNameField?: Parameters<typeof FormField<TFieldValues>>[0]['name'];
   defaultOpen?: boolean;
 }) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(defaultOpen);
 
   return (
@@ -217,7 +235,7 @@ export function TournamentFields<TFieldValues extends Record<string, unknown>>({
           type="button"
           className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium"
         >
-          Tournament (optional)
+          {t('matchForm.tournament.sectionTitle')}
           <ChevronDown
             className={cn('size-4 transition-transform', open && 'rotate-180')}
             aria-hidden="true"
@@ -231,13 +249,13 @@ export function TournamentFields<TFieldValues extends Record<string, unknown>>({
             name={tournamentNameField}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Tournament Name</FormLabel>
+                <FormLabel>{t('matchForm.tournament.tournamentName')}</FormLabel>
                 <FormControl>
                   <Input
                     {...field}
                     value={(field.value as string | undefined) ?? ''}
                     maxLength={80}
-                    placeholder="e.g. The Big House 9"
+                    placeholder={t('matchForm.tournament.tournamentPlaceholder')}
                   />
                 </FormControl>
                 <FormMessage />
@@ -249,13 +267,13 @@ export function TournamentFields<TFieldValues extends Record<string, unknown>>({
             name={eventNameField}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Event Name</FormLabel>
+                <FormLabel>{t('matchForm.tournament.eventName')}</FormLabel>
                 <FormControl>
                   <Input
                     {...field}
                     value={(field.value as string | undefined) ?? ''}
                     maxLength={80}
-                    placeholder="e.g. Ultimate Singles"
+                    placeholder={t('matchForm.tournament.eventPlaceholder')}
                   />
                 </FormControl>
                 <FormMessage />
@@ -263,10 +281,7 @@ export function TournamentFields<TFieldValues extends Record<string, unknown>>({
             )}
           />
         </div>
-        <p className="text-xs text-muted-foreground">
-          Tournament and event names entered here are stored the same way as start.gg imports, so
-          manually-tracked tournaments show up alongside synced ones in Tournament views.
-        </p>
+        <p className="text-xs text-muted-foreground">{t('matchForm.tournament.hint')}</p>
       </CollapsibleContent>
     </Collapsible>
   );
@@ -288,6 +303,7 @@ export function MatchFormFields({
   /** The fighters offered for "Your Fighter" — the signed-in user's primary+secondary selections. */
   fighterSprites: Fighter[];
 }) {
+  const { t } = useTranslation();
   const { data: opponents = [] } = useOpponents();
   const { data: allMatches = [] } = useMatches();
   const [opponentPopoverOpen, setOpponentPopoverOpen] = useState(false);
@@ -306,7 +322,7 @@ export function MatchFormFields({
             name="fighterId"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Your Fighter</FormLabel>
+                <FormLabel>{t('matchForm.yourFighter')}</FormLabel>
                 <Select
                   value={String(field.value)}
                   onValueChange={(v) => field.onChange(Number(v))}
@@ -334,7 +350,7 @@ export function MatchFormFields({
             name="opponentFighterId"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Opponent Fighter</FormLabel>
+                <FormLabel>{t('matchForm.opponentFighter')}</FormLabel>
                 <Select
                   value={String(field.value)}
                   onValueChange={(v) => field.onChange(Number(v))}
@@ -364,7 +380,7 @@ export function MatchFormFields({
           name="result"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Result</FormLabel>
+              <FormLabel>{t('matchForm.result')}</FormLabel>
               <FormControl>
                 <ToggleGroup
                   type="single"
@@ -374,11 +390,11 @@ export function MatchFormFields({
                     if (value) field.onChange(value);
                   }}
                 >
-                  <ToggleGroupItem value="win" aria-label="Win">
-                    Win
+                  <ToggleGroupItem value="win" aria-label={t('common.win')}>
+                    {t('common.win')}
                   </ToggleGroupItem>
-                  <ToggleGroupItem value="loss" aria-label="Loss">
-                    Loss
+                  <ToggleGroupItem value="loss" aria-label={t('common.loss')}>
+                    {t('common.loss')}
                   </ToggleGroupItem>
                 </ToggleGroup>
               </FormControl>
@@ -392,7 +408,7 @@ export function MatchFormFields({
           name="stageId"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Map</FormLabel>
+              <FormLabel>{t('matchForm.map')}</FormLabel>
               <Select value={String(field.value)} onValueChange={(v) => field.onChange(Number(v))}>
                 <FormControl>
                   <SelectTrigger className="w-full">
@@ -405,7 +421,7 @@ export function MatchFormFields({
                   </SelectItem>
                   {mostPlayed.length > 0 && (
                     <SelectGroup>
-                      <SelectLabel>Most played</SelectLabel>
+                      <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
                       {mostPlayed.map((s) => (
                         <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
                           <StageOption stage={s} />
@@ -414,7 +430,7 @@ export function MatchFormFields({
                     </SelectGroup>
                   )}
                   <SelectGroup>
-                    <SelectLabel>All stages</SelectLabel>
+                    <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
                     {allStages.map((s) => (
                       <SelectItem key={`all-${s.id}`} value={String(s.id)}>
                         <StageOption stage={s} />
@@ -436,13 +452,13 @@ export function MatchFormFields({
           name="gsp"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>GSP after match (optional)</FormLabel>
+              <FormLabel>{t('matchForm.gspAfterMatch')}</FormLabel>
               <FormControl>
                 <Input
                   {...field}
                   type="text"
                   inputMode="numeric"
-                  placeholder="e.g. 12,400,000"
+                  placeholder={t('matchForm.gspPlaceholder')}
                   className="max-w-xs"
                 />
               </FormControl>
@@ -456,7 +472,7 @@ export function MatchFormFields({
           name="matchType"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Match Type</FormLabel>
+              <FormLabel>{t('matchForm.matchType')}</FormLabel>
               <FormControl>
                 <ToggleGroup
                   type="single"
@@ -469,7 +485,7 @@ export function MatchFormFields({
                 >
                   {matchTypeValues.map((value) => (
                     <ToggleGroupItem key={value} value={value}>
-                      {MATCH_TYPE_LABELS[value]}
+                      {matchTypeLabel(t, value)}
                     </ToggleGroupItem>
                   ))}
                 </ToggleGroup>
@@ -487,7 +503,7 @@ export function MatchFormFields({
             name="opponentName"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Opponent</FormLabel>
+                <FormLabel>{t('matchForm.opponent')}</FormLabel>
                 <Popover open={opponentPopoverOpen} onOpenChange={setOpponentPopoverOpen}>
                   <PopoverTrigger asChild>
                     <FormControl>
@@ -498,7 +514,7 @@ export function MatchFormFields({
                         aria-expanded={opponentPopoverOpen}
                         className="w-full justify-between font-normal"
                       >
-                        {field.value || 'Type to filter or add...'}
+                        {field.value || t('matchForm.opponentCombobox')}
                         <ChevronsUpDown className="opacity-50" />
                       </Button>
                     </FormControl>
@@ -506,7 +522,7 @@ export function MatchFormFields({
                   <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
                     <Command>
                       <CommandInput
-                        placeholder="Type a name..."
+                        placeholder={t('matchForm.opponentSearch')}
                         value={field.value}
                         onValueChange={(value) => field.onChange(value)}
                         // Select-all on focus: the field arrives pre-filled
@@ -515,7 +531,7 @@ export function MatchFormFields({
                         onFocus={(e) => e.currentTarget.select()}
                       />
                       <CommandList>
-                        <CommandEmpty>Press enter to add a new opponent.</CommandEmpty>
+                        <CommandEmpty>{t('matchForm.opponentAddHint')}</CommandEmpty>
                         <CommandGroup>
                           {opponents.map((name) => (
                             <CommandItem
@@ -547,9 +563,13 @@ export function MatchFormFields({
             name="notes"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Notes</FormLabel>
+                <FormLabel>{t('matchForm.notes')}</FormLabel>
                 <FormControl>
-                  <Textarea {...field} maxLength={100} placeholder="Optional notes..." />
+                  <Textarea
+                    {...field}
+                    maxLength={100}
+                    placeholder={t('matchForm.notesPlaceholder')}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/apps/web/src/components/match-form/SetWizard.tsx
+++ b/apps/web/src/components/match-form/SetWizard.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState, type ReactNode } from 'react';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import type { Fighter } from '@smash-tracker/shared';
 import { matchTypeValues } from '@smash-tracker/shared';
@@ -40,7 +42,7 @@ import { StageOption } from '@/components/StageOption';
 import { useOpponents } from '@/hooks/useOpponents';
 import { useMatches } from '@/hooks/useMatches';
 import { getGroupedStageOptions } from '@/lib/stageOptions';
-import { alphaSpriteList, TournamentFields, MATCH_TYPE_LABELS } from './MatchForm';
+import { alphaSpriteList, TournamentFields, matchTypeLabel } from './MatchForm';
 import {
   setFormatValues,
   winsNeededFor,
@@ -56,23 +58,42 @@ import {
   type SetSharedValues,
 } from './setWizardLogic';
 
-/** Validation for the fields entered once per set (fighter, opponent, match type, tournament). */
-export const setSharedFormSchema = z.object({
-  fighterId: z.number().int().positive({ message: 'Choose your fighter' }),
-  opponentFighterId: z.number().int().positive({ message: "Choose your opponent's fighter" }),
-  opponentName: z.string().min(1, 'Opponent name is required'),
-  matchType: z.enum(matchTypeValues),
-  format: z.enum(setFormatValues),
-  eventName: z.string().max(80, 'Limit 80 characters').optional(),
-  tournamentName: z.string().max(80, 'Limit 80 characters').optional(),
-});
-export type SetSharedFormValues = z.infer<typeof setSharedFormSchema>;
+/**
+ * Validation for the fields entered once per set (fighter, opponent, match
+ * type, tournament). A factory for the same reason as
+ * `buildMatchFormSchema`: messages come out of the active locale.
+ */
+export function buildSetSharedFormSchema(t: TFunction) {
+  return z.object({
+    fighterId: z
+      .number()
+      .int()
+      .positive({ message: t('matchForm.validation.chooseFighter') }),
+    opponentFighterId: z
+      .number()
+      .int()
+      .positive({ message: t('matchForm.validation.chooseOpponentFighter') }),
+    opponentName: z.string().min(1, t('matchForm.validation.opponentRequired')),
+    matchType: z.enum(matchTypeValues),
+    format: z.enum(setFormatValues),
+    eventName: z
+      .string()
+      .max(80, t('matchForm.validation.charLimit', { max: 80 }))
+      .optional(),
+    tournamentName: z
+      .string()
+      .max(80, t('matchForm.validation.charLimit', { max: 80 }))
+      .optional(),
+  });
+}
+export type SetSharedFormValues = z.infer<ReturnType<typeof buildSetSharedFormSchema>>;
 
 export function useSetSharedForm(
   defaultValues: SetSharedFormValues,
 ): UseFormReturn<SetSharedFormValues> {
+  const { t } = useTranslation();
   return useForm<SetSharedFormValues>({
-    resolver: zodResolver(setSharedFormSchema),
+    resolver: zodResolver(buildSetSharedFormSchema(t)),
     defaultValues,
   });
 }
@@ -90,6 +111,23 @@ export function defaultSetSharedValues(fighterId: number): SetSharedFormValues {
     eventName: '',
     tournamentName: '',
   };
+}
+
+/** Game numbers to render: 1..maxGames while each game is still reachable under `format` given the results entered so far. Cheap enough (≤5 iterations) to recompute per render. */
+function getVisibleGameNumbers(
+  format: SetFormat,
+  games: SetGameValues[],
+  maxGames: number,
+): number[] {
+  const numbers: number[] = [];
+  for (let n = 1; n <= maxGames; n += 1) {
+    if (shouldShowGame(format, n, games)) {
+      numbers.push(n);
+    } else {
+      break;
+    }
+  }
+  return numbers;
 }
 
 function sharedFormToSetShared(values: SetSharedFormValues): SetSharedValues {
@@ -131,6 +169,7 @@ export function SetWizard({
   /** Rendered inside the wizard's own `<form>` (e.g. Cancel/Save buttons) so a submit button here triggers `onSubmit` via normal form submission. */
   footer?: ReactNode;
 }) {
+  const { t } = useTranslation();
   const { data: opponents = [] } = useOpponents();
   const { data: allMatches = [] } = useMatches();
   const [opponentPopoverOpen, setOpponentPopoverOpen] = useState(false);
@@ -141,17 +180,7 @@ export function SetWizard({
   const needed = winsNeededFor(format);
   const maxGames = maxGamesFor(format);
 
-  const visibleGameNumbers = useMemo(() => {
-    const numbers: number[] = [];
-    for (let n = 1; n <= maxGames; n += 1) {
-      if (shouldShowGame(format, n, games)) {
-        numbers.push(n);
-      } else {
-        break;
-      }
-    }
-    return numbers;
-  }, [format, games, maxGames]);
+  const visibleGameNumbers = getVisibleGameNumbers(format, games, maxGames);
 
   function updateGame(index: number, patch: Partial<SetGameValues>) {
     const next = [...games];
@@ -183,7 +212,7 @@ export function SetWizard({
       <form onSubmit={form.handleSubmit(handleSubmit)} noValidate>
         <div className="flex flex-col gap-4">
           <FormItem>
-            <FormLabel>Set Format</FormLabel>
+            <FormLabel>{t('matchForm.set.format')}</FormLabel>
             <FormControl>
               <ToggleGroup
                 type="single"
@@ -193,10 +222,10 @@ export function SetWizard({
                   if (value) handleFormatChange(value as SetFormat);
                 }}
               >
-                <ToggleGroupItem value="bo3" aria-label="Best of 3">
+                <ToggleGroupItem value="bo3" aria-label={t('matchForm.set.bestOf3')}>
                   Bo3
                 </ToggleGroupItem>
-                <ToggleGroupItem value="bo5" aria-label="Best of 5">
+                <ToggleGroupItem value="bo5" aria-label={t('matchForm.set.bestOf5')}>
                   Bo5
                 </ToggleGroupItem>
               </ToggleGroup>
@@ -209,7 +238,7 @@ export function SetWizard({
               name="fighterId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Your Fighter</FormLabel>
+                  <FormLabel>{t('matchForm.yourFighter')}</FormLabel>
                   <Select
                     value={String(field.value)}
                     onValueChange={(v) => field.onChange(Number(v))}
@@ -237,7 +266,7 @@ export function SetWizard({
               name="opponentFighterId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Opponent Fighter (game 1)</FormLabel>
+                  <FormLabel>{t('matchForm.set.opponentFighterGame1')}</FormLabel>
                   <Select
                     value={String(field.value)}
                     onValueChange={(v) => field.onChange(Number(v))}
@@ -267,7 +296,7 @@ export function SetWizard({
             name="matchType"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Match Type</FormLabel>
+                <FormLabel>{t('matchForm.matchType')}</FormLabel>
                 <FormControl>
                   <ToggleGroup
                     type="single"
@@ -280,7 +309,7 @@ export function SetWizard({
                   >
                     {matchTypeValues.map((value) => (
                       <ToggleGroupItem key={value} value={value}>
-                        {MATCH_TYPE_LABELS[value]}
+                        {matchTypeLabel(t, value)}
                       </ToggleGroupItem>
                     ))}
                   </ToggleGroup>
@@ -295,7 +324,7 @@ export function SetWizard({
             name="opponentName"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Opponent</FormLabel>
+                <FormLabel>{t('matchForm.opponent')}</FormLabel>
                 <Popover open={opponentPopoverOpen} onOpenChange={setOpponentPopoverOpen}>
                   <PopoverTrigger asChild>
                     <FormControl>
@@ -306,7 +335,7 @@ export function SetWizard({
                         aria-expanded={opponentPopoverOpen}
                         className="w-full justify-between font-normal"
                       >
-                        {field.value || 'Type to filter or add...'}
+                        {field.value || t('matchForm.opponentCombobox')}
                         <ChevronsUpDown className="opacity-50" />
                       </Button>
                     </FormControl>
@@ -314,7 +343,7 @@ export function SetWizard({
                   <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
                     <Command>
                       <CommandInput
-                        placeholder="Type a name..."
+                        placeholder={t('matchForm.opponentSearch')}
                         value={field.value}
                         onValueChange={(value) => field.onChange(value)}
                         // Select-all on focus — same rationale as the
@@ -323,7 +352,7 @@ export function SetWizard({
                         onFocus={(e) => e.currentTarget.select()}
                       />
                       <CommandList>
-                        <CommandEmpty>Press enter to add a new opponent.</CommandEmpty>
+                        <CommandEmpty>{t('matchForm.opponentAddHint')}</CommandEmpty>
                         <CommandGroup>
                           {opponents.map((name) => (
                             <CommandItem
@@ -353,10 +382,10 @@ export function SetWizard({
           <TournamentFields control={form.control} />
 
           <div className="flex items-center justify-between rounded-md border px-3 py-2">
-            <span className="text-sm font-medium">Set score</span>
+            <span className="text-sm font-medium">{t('matchForm.set.score')}</span>
             <Badge variant={decided ? 'success' : 'secondary'} data-testid="set-score-chip">
-              {formatSetScore(score)}
-              {decided ? ' — set decided' : ` (first to ${needed})`}
+              {formatSetScore(score)}{' '}
+              {decided ? t('matchForm.set.decided') : t('matchForm.set.firstTo', { count: needed })}
             </Badge>
           </div>
 
@@ -366,9 +395,11 @@ export function SetWizard({
               const game = games[index] ?? buildDefaultGameValues();
               return (
                 <div key={gameNumber} className="flex flex-col gap-3 rounded-md border p-3">
-                  <span className="text-sm font-semibold">Game {gameNumber}</span>
+                  <span className="text-sm font-semibold">
+                    {t('matchForm.set.game', { number: gameNumber })}
+                  </span>
                   <FormItem>
-                    <FormLabel>Result</FormLabel>
+                    <FormLabel>{t('matchForm.result')}</FormLabel>
                     <ToggleGroup
                       type="single"
                       variant="outline"
@@ -377,17 +408,23 @@ export function SetWizard({
                         if (value) updateGame(index, { result: value as 'win' | 'loss' });
                       }}
                     >
-                      <ToggleGroupItem value="win" aria-label={`Game ${gameNumber} Win`}>
-                        Win
+                      <ToggleGroupItem
+                        value="win"
+                        aria-label={t('matchForm.set.gameWinAria', { number: gameNumber })}
+                      >
+                        {t('common.win')}
                       </ToggleGroupItem>
-                      <ToggleGroupItem value="loss" aria-label={`Game ${gameNumber} Loss`}>
-                        Loss
+                      <ToggleGroupItem
+                        value="loss"
+                        aria-label={t('matchForm.set.gameLossAria', { number: gameNumber })}
+                      >
+                        {t('common.loss')}
                       </ToggleGroupItem>
                     </ToggleGroup>
                   </FormItem>
 
                   <FormItem>
-                    <FormLabel>Stage</FormLabel>
+                    <FormLabel>{t('matchForm.set.stage')}</FormLabel>
                     <Select
                       value={String(game.stageId)}
                       onValueChange={(v) => updateGame(index, { stageId: Number(v) })}
@@ -403,7 +440,7 @@ export function SetWizard({
                         </SelectItem>
                         {mostPlayed.length > 0 && (
                           <SelectGroup>
-                            <SelectLabel>Most played</SelectLabel>
+                            <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
                             {mostPlayed.map((s) => (
                               <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
                                 <StageOption stage={s} />
@@ -412,7 +449,7 @@ export function SetWizard({
                           </SelectGroup>
                         )}
                         <SelectGroup>
-                          <SelectLabel>All stages</SelectLabel>
+                          <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
                           {allStages.map((s) => (
                             <SelectItem key={`all-${s.id}`} value={String(s.id)}>
                               <StageOption stage={s} />
@@ -424,7 +461,7 @@ export function SetWizard({
                   </FormItem>
 
                   <FormItem>
-                    <FormLabel>Stocks Left (winner)</FormLabel>
+                    <FormLabel>{t('matchForm.stocksLeft')}</FormLabel>
                     <Select
                       value={game.stocksLeft === undefined ? 'unset' : String(game.stocksLeft)}
                       onValueChange={(v) =>
@@ -433,11 +470,11 @@ export function SetWizard({
                     >
                       <FormControl>
                         <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Not tracked" />
+                          <SelectValue placeholder={t('matchForm.notTracked')} />
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value="unset">Not tracked</SelectItem>
+                        <SelectItem value="unset">{t('matchForm.notTracked')}</SelectItem>
                         {[0, 1, 2, 3].map((n) => (
                           <SelectItem key={n} value={String(n)}>
                             {n}

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -160,5 +160,68 @@
       "partialSave": "Nur {{saved}} von {{total}} Spielen wurden vor einem Fehler gespeichert. Prüfe die Match-Daten und trage fehlende Spiele erneut ein.",
       "setFailed": "Set konnte nicht gespeichert werden. Bitte erneut versuchen."
     }
+  },
+  "matchForm": {
+    "yourFighter": "Dein Kämpfer",
+    "opponentFighter": "Gegnerischer Kämpfer",
+    "result": "Ergebnis",
+    "map": "Stage",
+    "mostPlayed": "Meistgespielt",
+    "allStages": "Alle Stages",
+    "stocksLeft": "Verbleibende Stocks (Sieger)",
+    "notTracked": "Nicht erfasst",
+    "gspAfterMatch": "GSP nach dem Match (optional)",
+    "gspPlaceholder": "z. B. 12 400 000",
+    "matchType": "Match-Typ",
+    "matchTypes": {
+      "none": "Keiner",
+      "quickplay": "QuickPlay",
+      "online-friendly": "Online-Friendly",
+      "online-tourney": "Online-Turnier",
+      "offline-friendly": "Offline-Friendly",
+      "offline-tourney": "Offline-Turnier"
+    },
+    "opponent": "Gegner",
+    "opponentCombobox": "Tippen zum Filtern oder Hinzufügen...",
+    "opponentSearch": "Namen eingeben...",
+    "opponentAddHint": "Enter drücken, um einen neuen Gegner hinzuzufügen.",
+    "notes": "Notizen",
+    "notesPlaceholder": "Optionale Notizen...",
+    "tournament": {
+      "sectionTitle": "Turnier (optional)",
+      "tournamentName": "Turniername",
+      "tournamentPlaceholder": "z. B. The Big House 9",
+      "eventName": "Eventname",
+      "eventPlaceholder": "z. B. Ultimate Singles",
+      "hint": "Hier eingetragene Turnier- und Eventnamen werden genauso gespeichert wie start.gg-Importe — manuell erfasste Turniere erscheinen in den Turnier-Ansichten neben den synchronisierten."
+    },
+    "validation": {
+      "chooseFighter": "Wähle deinen Kämpfer",
+      "chooseOpponentFighter": "Wähle den Kämpfer des Gegners",
+      "chooseResult": "Wähle ein Ergebnis",
+      "opponentRequired": "Gegnername ist erforderlich",
+      "charLimit": "Maximal {{max}} Zeichen",
+      "gspFormat": "Gib eine Zahl wie 12 400 000 ein (oder lass das Feld leer)"
+    },
+    "set": {
+      "format": "Set-Format",
+      "bestOf3": "Best of 3",
+      "bestOf5": "Best of 5",
+      "opponentFighterGame1": "Gegnerischer Kämpfer (Spiel 1)",
+      "score": "Set-Stand",
+      "decided": "— Set entschieden",
+      "firstTo": "(zuerst auf {{count}})",
+      "game": "Spiel {{number}}",
+      "gameWinAria": "Spiel {{number}} Sieg",
+      "gameLossAria": "Spiel {{number}} Niederlage",
+      "stage": "Stage"
+    },
+    "edit": {
+      "title": "Match bearbeiten",
+      "description": "Aktualisiere die Details dieses erfassten Matches.",
+      "deleteMatch": "Match löschen",
+      "edited": "Match bearbeitet!",
+      "saveFailed": "Match konnte nicht gespeichert werden. Bitte erneut versuchen."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -160,5 +160,68 @@
       "partialSave": "Only {{saved}} of {{total}} games saved before an error occurred. Check Match Data and re-enter any missing games.",
       "setFailed": "Failed to save the set. Please try again."
     }
+  },
+  "matchForm": {
+    "yourFighter": "Your Fighter",
+    "opponentFighter": "Opponent Fighter",
+    "result": "Result",
+    "map": "Map",
+    "mostPlayed": "Most played",
+    "allStages": "All stages",
+    "stocksLeft": "Stocks Left (winner)",
+    "notTracked": "Not tracked",
+    "gspAfterMatch": "GSP after match (optional)",
+    "gspPlaceholder": "e.g. 12,400,000",
+    "matchType": "Match Type",
+    "matchTypes": {
+      "none": "None",
+      "quickplay": "QuickPlay",
+      "online-friendly": "Online Friendly",
+      "online-tourney": "Online Tourney",
+      "offline-friendly": "Offline Friendly",
+      "offline-tourney": "Offline Tourney"
+    },
+    "opponent": "Opponent",
+    "opponentCombobox": "Type to filter or add...",
+    "opponentSearch": "Type a name...",
+    "opponentAddHint": "Press enter to add a new opponent.",
+    "notes": "Notes",
+    "notesPlaceholder": "Optional notes...",
+    "tournament": {
+      "sectionTitle": "Tournament (optional)",
+      "tournamentName": "Tournament Name",
+      "tournamentPlaceholder": "e.g. The Big House 9",
+      "eventName": "Event Name",
+      "eventPlaceholder": "e.g. Ultimate Singles",
+      "hint": "Tournament and event names entered here are stored the same way as start.gg imports, so manually-tracked tournaments show up alongside synced ones in Tournament views."
+    },
+    "validation": {
+      "chooseFighter": "Choose your fighter",
+      "chooseOpponentFighter": "Choose your opponent's fighter",
+      "chooseResult": "Choose a result",
+      "opponentRequired": "Opponent name is required",
+      "charLimit": "Limit {{max}} characters",
+      "gspFormat": "Enter a number like 12,400,000 (or leave blank)"
+    },
+    "set": {
+      "format": "Set Format",
+      "bestOf3": "Best of 3",
+      "bestOf5": "Best of 5",
+      "opponentFighterGame1": "Opponent Fighter (game 1)",
+      "score": "Set score",
+      "decided": "— set decided",
+      "firstTo": "(first to {{count}})",
+      "game": "Game {{number}}",
+      "gameWinAria": "Game {{number}} Win",
+      "gameLossAria": "Game {{number}} Loss",
+      "stage": "Stage"
+    },
+    "edit": {
+      "title": "Edit Match",
+      "description": "Update the details of this recorded match.",
+      "deleteMatch": "Delete Match",
+      "edited": "Match edited!",
+      "saveFailed": "Failed to save match. Please try again."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -160,5 +160,68 @@
       "partialSave": "Solo se guardaron {{saved}} de {{total}} partidas antes de producirse un error. Revisa Datos de partidas y vuelve a introducir las que falten.",
       "setFailed": "No se pudo guardar el set. Inténtalo de nuevo."
     }
+  },
+  "matchForm": {
+    "yourFighter": "Tu luchador",
+    "opponentFighter": "Luchador del rival",
+    "result": "Resultado",
+    "map": "Escenario",
+    "mostPlayed": "Más jugados",
+    "allStages": "Todos los escenarios",
+    "stocksLeft": "Vidas restantes (ganador)",
+    "notTracked": "Sin registrar",
+    "gspAfterMatch": "GSP tras la partida (opcional)",
+    "gspPlaceholder": "p. ej. 12 400 000",
+    "matchType": "Tipo de partida",
+    "matchTypes": {
+      "none": "Ninguno",
+      "quickplay": "QuickPlay",
+      "online-friendly": "Amistoso online",
+      "online-tourney": "Torneo online",
+      "offline-friendly": "Amistoso offline",
+      "offline-tourney": "Torneo offline"
+    },
+    "opponent": "Rival",
+    "opponentCombobox": "Escribe para filtrar o añadir...",
+    "opponentSearch": "Escribe un nombre...",
+    "opponentAddHint": "Pulsa Intro para añadir un nuevo rival.",
+    "notes": "Notas",
+    "notesPlaceholder": "Notas opcionales...",
+    "tournament": {
+      "sectionTitle": "Torneo (opcional)",
+      "tournamentName": "Nombre del torneo",
+      "tournamentPlaceholder": "p. ej. The Big House 9",
+      "eventName": "Nombre del evento",
+      "eventPlaceholder": "p. ej. Ultimate Singles",
+      "hint": "Los nombres de torneo y evento introducidos aquí se guardan igual que las importaciones de start.gg, así que los torneos registrados a mano aparecen junto a los sincronizados en las vistas de Torneo."
+    },
+    "validation": {
+      "chooseFighter": "Elige tu luchador",
+      "chooseOpponentFighter": "Elige el luchador del rival",
+      "chooseResult": "Elige un resultado",
+      "opponentRequired": "El nombre del rival es obligatorio",
+      "charLimit": "Máximo {{max}} caracteres",
+      "gspFormat": "Introduce un número como 12 400 000 (o déjalo en blanco)"
+    },
+    "set": {
+      "format": "Formato del set",
+      "bestOf3": "Al mejor de 3",
+      "bestOf5": "Al mejor de 5",
+      "opponentFighterGame1": "Luchador del rival (partida 1)",
+      "score": "Marcador del set",
+      "decided": "— set decidido",
+      "firstTo": "(primero a {{count}})",
+      "game": "Partida {{number}}",
+      "gameWinAria": "Victoria en la partida {{number}}",
+      "gameLossAria": "Derrota en la partida {{number}}",
+      "stage": "Escenario"
+    },
+    "edit": {
+      "title": "Editar partida",
+      "description": "Actualiza los datos de esta partida registrada.",
+      "deleteMatch": "Eliminar partida",
+      "edited": "¡Partida editada!",
+      "saveFailed": "No se pudo guardar la partida. Inténtalo de nuevo."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -160,5 +160,68 @@
       "partialSave": "Seules {{saved}} manches sur {{total}} ont été enregistrées avant une erreur. Vérifiez les Données de matchs et ressaisissez les manches manquantes.",
       "setFailed": "Échec de l'enregistrement du set. Veuillez réessayer."
     }
+  },
+  "matchForm": {
+    "yourFighter": "Votre combattant",
+    "opponentFighter": "Combattant adverse",
+    "result": "Résultat",
+    "map": "Stage",
+    "mostPlayed": "Les plus joués",
+    "allStages": "Tous les stages",
+    "stocksLeft": "Stocks restants (vainqueur)",
+    "notTracked": "Non suivi",
+    "gspAfterMatch": "GSP après le match (facultatif)",
+    "gspPlaceholder": "p. ex. 12 400 000",
+    "matchType": "Type de match",
+    "matchTypes": {
+      "none": "Aucun",
+      "quickplay": "QuickPlay",
+      "online-friendly": "Amical en ligne",
+      "online-tourney": "Tournoi en ligne",
+      "offline-friendly": "Amical hors ligne",
+      "offline-tourney": "Tournoi hors ligne"
+    },
+    "opponent": "Adversaire",
+    "opponentCombobox": "Tapez pour filtrer ou ajouter...",
+    "opponentSearch": "Tapez un nom...",
+    "opponentAddHint": "Appuyez sur Entrée pour ajouter un nouvel adversaire.",
+    "notes": "Notes",
+    "notesPlaceholder": "Notes facultatives...",
+    "tournament": {
+      "sectionTitle": "Tournoi (facultatif)",
+      "tournamentName": "Nom du tournoi",
+      "tournamentPlaceholder": "p. ex. The Big House 9",
+      "eventName": "Nom de l'évènement",
+      "eventPlaceholder": "p. ex. Ultimate Singles",
+      "hint": "Les noms de tournoi et d'évènement saisis ici sont stockés comme les imports start.gg : les tournois suivis manuellement apparaissent donc aux côtés des tournois synchronisés dans les vues Tournoi."
+    },
+    "validation": {
+      "chooseFighter": "Choisissez votre combattant",
+      "chooseOpponentFighter": "Choisissez le combattant adverse",
+      "chooseResult": "Choisissez un résultat",
+      "opponentRequired": "Le nom de l'adversaire est requis",
+      "charLimit": "Limite de {{max}} caractères",
+      "gspFormat": "Saisissez un nombre comme 12 400 000 (ou laissez vide)"
+    },
+    "set": {
+      "format": "Format du set",
+      "bestOf3": "Meilleur des 3",
+      "bestOf5": "Meilleur des 5",
+      "opponentFighterGame1": "Combattant adverse (manche 1)",
+      "score": "Score du set",
+      "decided": "— set décidé",
+      "firstTo": "(premier à {{count}})",
+      "game": "Manche {{number}}",
+      "gameWinAria": "Victoire manche {{number}}",
+      "gameLossAria": "Défaite manche {{number}}",
+      "stage": "Stage"
+    },
+    "edit": {
+      "title": "Modifier le match",
+      "description": "Mettez à jour les détails de ce match enregistré.",
+      "deleteMatch": "Supprimer le match",
+      "edited": "Match modifié !",
+      "saveFailed": "Échec de l'enregistrement du match. Veuillez réessayer."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -160,5 +160,68 @@
       "partialSave": "エラーが発生し、{{total}}戦中{{saved}}戦のみ保存されました。対戦データを確認し、足りない分を再入力してください。",
       "setFailed": "セットを保存できませんでした。もう一度お試しください。"
     }
+  },
+  "matchForm": {
+    "yourFighter": "自分のファイター",
+    "opponentFighter": "相手のファイター",
+    "result": "結果",
+    "map": "ステージ",
+    "mostPlayed": "よく遊ぶステージ",
+    "allStages": "すべてのステージ",
+    "stocksLeft": "残ストック（勝者）",
+    "notTracked": "記録なし",
+    "gspAfterMatch": "対戦後のGSP（任意）",
+    "gspPlaceholder": "例: 12,400,000",
+    "matchType": "対戦の種類",
+    "matchTypes": {
+      "none": "未指定",
+      "quickplay": "クイックプレイ",
+      "online-friendly": "オンラインフリー",
+      "online-tourney": "オンライン大会",
+      "offline-friendly": "オフラインフリー",
+      "offline-tourney": "オフライン大会"
+    },
+    "opponent": "相手",
+    "opponentCombobox": "入力して絞り込み・追加...",
+    "opponentSearch": "名前を入力...",
+    "opponentAddHint": "Enterキーで新しい相手を追加します。",
+    "notes": "メモ",
+    "notesPlaceholder": "メモ（任意）...",
+    "tournament": {
+      "sectionTitle": "大会（任意）",
+      "tournamentName": "大会名",
+      "tournamentPlaceholder": "例: The Big House 9",
+      "eventName": "種目名",
+      "eventPlaceholder": "例: Ultimate Singles",
+      "hint": "ここで入力した大会名・種目名はstart.ggのインポートと同じ形式で保存されるため、手動で記録した大会も同期された大会と並んで大会ページに表示されます。"
+    },
+    "validation": {
+      "chooseFighter": "自分のファイターを選んでください",
+      "chooseOpponentFighter": "相手のファイターを選んでください",
+      "chooseResult": "結果を選んでください",
+      "opponentRequired": "相手の名前を入力してください",
+      "charLimit": "{{max}}文字以内で入力してください",
+      "gspFormat": "12,400,000 のような数値を入力してください（空欄でも可）"
+    },
+    "set": {
+      "format": "セット形式",
+      "bestOf3": "3本勝負（Bo3）",
+      "bestOf5": "5本勝負（Bo5）",
+      "opponentFighterGame1": "相手のファイター（1戦目）",
+      "score": "セットスコア",
+      "decided": "— セット確定",
+      "firstTo": "（先取{{count}}）",
+      "game": "{{number}}戦目",
+      "gameWinAria": "{{number}}戦目 勝ち",
+      "gameLossAria": "{{number}}戦目 負け",
+      "stage": "ステージ"
+    },
+    "edit": {
+      "title": "対戦を編集",
+      "description": "記録済みの対戦内容を更新します。",
+      "deleteMatch": "対戦を削除",
+      "edited": "対戦を編集しました！",
+      "saveFailed": "対戦を保存できませんでした。もう一度お試しください。"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -160,5 +160,68 @@
       "partialSave": "Apenas {{saved}} de {{total}} games foram salvos antes de um erro. Verifique os Dados de partidas e insira novamente os games que faltam.",
       "setFailed": "Falha ao salvar o set. Tente novamente."
     }
+  },
+  "matchForm": {
+    "yourFighter": "Seu lutador",
+    "opponentFighter": "Lutador do oponente",
+    "result": "Resultado",
+    "map": "Stage",
+    "mostPlayed": "Mais jogados",
+    "allStages": "Todos os stages",
+    "stocksLeft": "Vidas restantes (vencedor)",
+    "notTracked": "Não registrado",
+    "gspAfterMatch": "GSP após a partida (opcional)",
+    "gspPlaceholder": "ex.: 12 400 000",
+    "matchType": "Tipo de partida",
+    "matchTypes": {
+      "none": "Nenhum",
+      "quickplay": "QuickPlay",
+      "online-friendly": "Amistoso online",
+      "online-tourney": "Torneio online",
+      "offline-friendly": "Amistoso offline",
+      "offline-tourney": "Torneio offline"
+    },
+    "opponent": "Oponente",
+    "opponentCombobox": "Digite para filtrar ou adicionar...",
+    "opponentSearch": "Digite um nome...",
+    "opponentAddHint": "Pressione Enter para adicionar um novo oponente.",
+    "notes": "Notas",
+    "notesPlaceholder": "Notas opcionais...",
+    "tournament": {
+      "sectionTitle": "Torneio (opcional)",
+      "tournamentName": "Nome do torneio",
+      "tournamentPlaceholder": "ex.: The Big House 9",
+      "eventName": "Nome do evento",
+      "eventPlaceholder": "ex.: Ultimate Singles",
+      "hint": "Os nomes de torneio e evento inseridos aqui são armazenados da mesma forma que as importações do start.gg, então torneios registrados manualmente aparecem junto aos sincronizados nas telas de Torneio."
+    },
+    "validation": {
+      "chooseFighter": "Escolha seu lutador",
+      "chooseOpponentFighter": "Escolha o lutador do oponente",
+      "chooseResult": "Escolha um resultado",
+      "opponentRequired": "O nome do oponente é obrigatório",
+      "charLimit": "Máximo de {{max}} caracteres",
+      "gspFormat": "Insira um número como 12 400 000 (ou deixe em branco)"
+    },
+    "set": {
+      "format": "Formato do set",
+      "bestOf3": "Melhor de 3",
+      "bestOf5": "Melhor de 5",
+      "opponentFighterGame1": "Lutador do oponente (game 1)",
+      "score": "Placar do set",
+      "decided": "— set decidido",
+      "firstTo": "(primeiro a {{count}})",
+      "game": "Game {{number}}",
+      "gameWinAria": "Vitória no game {{number}}",
+      "gameLossAria": "Derrota no game {{number}}",
+      "stage": "Stage"
+    },
+    "edit": {
+      "title": "Editar partida",
+      "description": "Atualize os detalhes desta partida registrada.",
+      "deleteMatch": "Excluir partida",
+      "edited": "Partida editada!",
+      "saveFailed": "Falha ao salvar a partida. Tente novamente."
+    }
   }
 }


### PR DESCRIPTION
## Summary

Stacked on #142 (retarget to master after it merges — GitHub does this automatically). Localizes `components/match-form/`:

- All field labels, placeholders, select-group headers, and the opponent-combobox copy in `MatchFormFields`, shared by the Add Match and Edit Match dialogs.
- The set wizard: format toggle (Bo3/Bo5 stay literal, aria-labels translate), score chip ("— set decided" / "(first to N)"), per-game result/stage/stocks rows.
- The Edit Match dialog and its success/failure toasts.
- All keys translated into es/fr/de/pt/ja (match-type labels keep FGC-natural terms per locale: "Amistoso online", "Offline-Friendly", "オンライン大会", etc.).

## Implementation notes

- **Validation messages**: the zod schemas become factories — `buildMatchFormSchema(t)` / `buildSetSharedFormSchema(t)` — so messages resolve in the active locale. `useMatchForm`/`useSetSharedForm` rebuild the resolver with the current `t`; types now derive via `z.infer<ReturnType<…>>`. Neither schema was consumed outside these modules.
- `MATCH_TYPE_LABELS` is replaced by `matchTypeLabel(t, value)`; the locale keys mirror the shared enum literals (hyphens included) so no mapping table is needed.
- The `visibleGameNumbers` `useMemo` became a module-level pure function: the React Compiler couldn't preserve the manual memo once the component gained a hook, and a ≤5-iteration loop doesn't need memoizing.
- Localized GSP examples use space separators (`12 400 000`) because `parseGspNumber` accepts commas/spaces but not dot separators — a dotted example would teach users an input the parser rejects.

## Testing

- `pnpm --filter @smash-tracker/web lint` ✅ (0 errors)
- `pnpm --filter @smash-tracker/web typecheck` ✅
- `pnpm --filter @smash-tracker/web test` ✅ 926/926 (English assertions on 'Choose a result', 'Stocks Left (winner)', 'Game 1 Win', etc. unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)