### PR TITLE
Localization phase 2c: GSP tracker page

### DIFF
--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -223,5 +223,124 @@
       "edited": "Match bearbeitet!",
       "saveFailed": "Match konnte nicht gespeichert werden. Bitte erneut versuchen."
     }
+  },
+  "gsp": {
+    "loading": "GSP-Tracker wird geladen...",
+    "selectFighterAria": "Kämpfer auswählen",
+    "empty": {
+      "title": "Verfolge deinen GSP-Aufstieg",
+      "body": "GSP (Global Smash Power) ist das Online-Quickplay-Ranking von Smash Ultimate und wird pro Charakter geführt. Erfasse ein Quickplay-Match mit der GSP vom Ergebnisbildschirm — diese Seite zeichnet deinen Aufstieg auf, schlüsselt deine Gewinne und Verluste auf und schätzt, wie weit du von Elite Smash entfernt bist.",
+      "cta": "Match im Dashboard erfassen"
+    },
+    "header": {
+      "title": "GSP-Tracker",
+      "subtitle": "Global Smash Power gilt pro Charakter und die genaue Formel wird von Nintendo nie veröffentlicht — alles hier ist eine Schätzung aus deinen eigenen erfassten Matches und einem von der Community per Reverse Engineering rekonstruierten Modell der versteckten MMR hinter der GSP."
+    },
+    "deleteConfirm": {
+      "title": "Diesen GSP-Eintrag löschen?",
+      "body": "Das Match und seine GSP-Ablesung werden gemeinsam entfernt — diese Aktion kann nicht rückgängig gemacht werden.",
+      "deleted": "GSP-Eintrag gelöscht!",
+      "deleteFailed": "Eintrag konnte nicht gelöscht werden. Bitte erneut versuchen."
+    },
+    "hero": {
+      "currentGsp": "Aktuelle GSP",
+      "latestReading": "letzte Ablesung",
+      "noGsp": "Noch keine GSP erfasst",
+      "estMmr": "Gesch. MMR",
+      "tailReading": "Randbereich-Ablesung ({{zone}}) — ungefähr",
+      "modelLink": "Community-Modell (Reverse Engineering)",
+      "modelAccuracy": "(±1 GSP auf der Hauptkurve; Ränder ungefähr)",
+      "eliteThreshold": "Elite-Schwelle",
+      "thresholdAria": "Elite-Smash-Schwelle",
+      "saveThreshold": "Schwelle speichern",
+      "cancelThreshold": "Bearbeitung der Schwelle abbrechen",
+      "editThreshold": "Elite-Schwelle bearbeiten",
+      "recalibrated": "rekalibriert am {{date}}",
+      "fromAnchor": "vom Modellanker",
+      "computedCaption": "berechnet · {{calibration}} · Bearbeiten rekalibriert das Modell — hol dir die aktuelle Zahl von",
+      "invalidThreshold": "Gib eine positive ganze Zahl ein — Kommas sind okay, z. B. 10,300,000.",
+      "recalibratedToast": "Modell anhand deiner Schwellen-Ablesung rekalibriert!",
+      "thresholdSaveFailed": "Elite-Schwelle konnte nicht gespeichert werden. Bitte erneut versuchen.",
+      "distanceToElite": "Abstand zu Elite",
+      "elite": "ELITE",
+      "belowElite": "MMR {{mmr}} · unter Elite ({{elite}})",
+      "recentWinRate": "Aktuelle Winrate",
+      "lastNGames_one": "letztes Match",
+      "lastNGames_other": "letzte {{count}} Matches"
+    },
+    "curve": {
+      "title": "GSP-Kurve",
+      "gspViewAria": "GSP-Ansicht",
+      "mmrViewAria": "MMR-Ansicht",
+      "gspLabel": "GSP",
+      "eliteLine": "Elite-Schwelle",
+      "estMmrLabel": "Gesch. MMR",
+      "eliteMmrLine": "Elite (MMR {{mmr}})",
+      "mmrCaption": "Geschätzte versteckte MMR hinter jeder Ablesung (Community-Modell per Reverse Engineering) — anders als die GSP inflationiert sie nicht mit der Zeit: Eine flache Linie bedeutet konstantes Niveau. Gestrichelte Linie: Elite-Einstieg bei MMR {{mmr}}.",
+      "gspCaption": "Jeder Punkt ist eine nach dem Match erfasste GSP-Ablesung für diesen Kämpfer. Die gestrichelte Linie ist die berechnete Elite-Smash-Schwelle — eine Schätzung des Community-Modells, kein von Nintendo veröffentlichter Wert.",
+      "clickHint": "Klicke einen Punkt an, um die Ablesung zu bearbeiten.",
+      "locked": "Erfasse mindestens {{count}} Matches mit GSP-Ablesung für diesen Kämpfer, um die Kurve zu sehen."
+    },
+    "logger": {
+      "title": "Schnell-Logger",
+      "opponentCharacter": "Gegnerischer Charakter",
+      "selectCharacter": "Charakter wählen",
+      "gspAfterMatch": "GSP nach dem Match",
+      "gspPlaceholder": "z. B. 9 420 000",
+      "stageOptional": "Stage (optional)",
+      "logMatch": "Match erfassen",
+      "logging": "Wird erfasst...",
+      "chooseOpponent": "Wähle den Charakter des Gegners.",
+      "chooseResult": "Markiere dieses Match als Sieg oder Niederlage.",
+      "invalidGsp": "Gib die nach dem Match angezeigte GSP ein — Kommas sind okay, z. B. 10,300,000.",
+      "logged": "Match erfasst! GSP {{gsp}}",
+      "logFailed": "Match konnte nicht erfasst werden. Bitte erneut versuchen."
+    },
+    "log": {
+      "title": "GSP-Log",
+      "editEntry": "GSP-Eintrag vom {{date}} bearbeiten",
+      "deleteEntry": "GSP-Eintrag vom {{date}} löschen",
+      "showRecent": "Nur aktuelle anzeigen",
+      "showAll": "Alle {{count}} Einträge anzeigen"
+    },
+    "gains": {
+      "title": "Gewinn-Analyse",
+      "avgGainLifetime": "Ø Gewinn/Sieg (gesamt)",
+      "avgDropLifetime": "Ø Verlust/Niederlage (gesamt)",
+      "biggestGain": "Größter Einzelgewinn",
+      "avgGainLast20": "Ø Gewinn/Sieg (letzte 20)",
+      "avgDropLast20": "Ø Verlust/Niederlage (letzte 20)",
+      "biggestDrop": "Größter Einzelverlust",
+      "perWinTitle": "Gewinne pro Sieg im Zeitverlauf",
+      "shrinking": "— schrumpfen, während deine GSP steigt",
+      "growing": "— steigend",
+      "winNumber": "Sieg Nr. {{number}}",
+      "gainedGsp": "GSP gewonnen",
+      "empty": "Erfasse ein paar Siege und Niederlagen mit GSP-Ablesungen, um deine Trends zu sehen."
+    },
+    "road": {
+      "title": "Weg nach Elite",
+      "empty": "Erfasse ein Match mit GSP-Ablesung für diesen Kämpfer, um eine Prognose zu sehen.",
+      "alreadyElite": "Du bist schon in Elite Smash!",
+      "equilibriumTitle": "Stabil auf deinem Niveau",
+      "equilibriumBody": "Bei deiner aktuellen Winrate von {{rate}} % hält das Matchmaking dies gerade für dein Niveau — jedes Match tauscht ~{{points}} MMR in beide Richtungen, also bringt dich eine Winrate über 50 % nach oben, nicht mehr Matches. Arbeite weiter an den Matchups auf dieser Seite, dann folgt die Zahl.",
+      "cappedTitle": "mehr als {{max}} Netto-Siege",
+      "cappedBody": "Deine Winrate liegt nur knapp über 50 %, der erwartete Fortschritt pro Match ist also winzig — schon eine kleine Steigerung der Winrate verkürzt das drastisch.",
+      "projected_one": "~{{count}} weiteres Match",
+      "projected_other": "~{{count}} weitere Matches",
+      "projectedCaption": "bis Elite (MMR {{elite}}) bei deinen ~{{points}} MMR/Match und {{rate}} % Winrate (Schätzung des Community-Modells)",
+      "historyOne": "Aus deiner eigenen GSP-Historie: ~{{label}} weiteres Match ({{model}}).",
+      "historyMany": "Aus deiner eigenen GSP-Historie: ~{{label}} weitere Matches ({{model}}).",
+      "decayFit": "V10-Fit mit schrumpfenden Gewinnen",
+      "flatFallback": "flacher V10-Durchschnitt",
+      "assumption1": "Nimmt an, dass das Matchmaking dich weiter gegen Gegner mit ähnlicher MMR paart (jedes Match tauscht ~{{points}} MMR, der Wert der Community-Tabelle für ein ausgeglichenes Match) und dass deine aktuelle Winrate hält.",
+      "assumption2": "Basiert auf dem per Reverse Engineering rekonstruierten Community-MMR-Modell, nicht auf Nintendos Algorithmus — eine Simulation, keine Garantie."
+    },
+    "vsGlicko": {
+      "title": "Gesch. MMR vs. Glicko-2",
+      "mmrLabel": "Gesch. MMR (normalisiert)",
+      "glickoLabel": "Glicko-2 (normalisiert)",
+      "caption": "Dein Quickplay-Rating (geschätzte MMR für diesen Kämpfer, Community-Modell per Reverse Engineering) gegen dein gesamtes Glicko-2-Rating (alle Kämpfer/Sitzungen) — beide über dieses Fenster auf 0-100 normalisiert, da ihre Rohskalen nichts miteinander zu tun haben. Rating gegen Rating macht die Formen ehrlich vergleichbar; Abweichungen bedeuten meist, dass deine Quickplay-Form von deiner Gesamtform abweicht."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -223,5 +223,124 @@
       "edited": "Match edited!",
       "saveFailed": "Failed to save match. Please try again."
     }
+  },
+  "gsp": {
+    "loading": "Loading GSP tracker...",
+    "selectFighterAria": "Select fighter",
+    "empty": {
+      "title": "Track your GSP climb",
+      "body": "GSP (Global Smash Power) is Smash Ultimate's online quickplay ranking, tracked per-character. Log a quickplay match with the GSP shown on the results screen and this page will chart your climb, break down your win/loss gains, and estimate how far you are from Elite Smash.",
+      "cta": "Log a match on the Dashboard"
+    },
+    "header": {
+      "title": "GSP Tracker",
+      "subtitle": "Global Smash Power is per-character and its exact formula is never published by Nintendo — everything below is an estimate built from your own logged matches and a community-reverse-engineered model of the hidden MMR behind GSP."
+    },
+    "deleteConfirm": {
+      "title": "Delete this GSP entry?",
+      "body": "The match and its GSP reading are removed together — this action cannot be undone.",
+      "deleted": "GSP entry deleted!",
+      "deleteFailed": "Failed to delete the entry. Please try again."
+    },
+    "hero": {
+      "currentGsp": "Current GSP",
+      "latestReading": "latest reading",
+      "noGsp": "No GSP logged yet",
+      "estMmr": "Est. MMR",
+      "tailReading": "{{zone}}-tail reading — approximate",
+      "modelLink": "community-reverse-engineered model",
+      "modelAccuracy": "(±1 GSP in the main curve; tails approximate)",
+      "eliteThreshold": "Elite Threshold",
+      "thresholdAria": "Elite Smash threshold",
+      "saveThreshold": "Save threshold",
+      "cancelThreshold": "Cancel editing threshold",
+      "editThreshold": "Edit Elite threshold",
+      "recalibrated": "recalibrated {{date}}",
+      "fromAnchor": "from the model anchor",
+      "computedCaption": "computed · {{calibration}} · editing recalibrates the model — grab the current number from",
+      "invalidThreshold": "Enter a positive whole number — commas are fine, e.g. 10,300,000.",
+      "recalibratedToast": "Model recalibrated from your threshold reading!",
+      "thresholdSaveFailed": "Failed to save the Elite threshold. Please try again.",
+      "distanceToElite": "Distance to Elite",
+      "elite": "ELITE",
+      "belowElite": "MMR {{mmr}} · below Elite ({{elite}})",
+      "recentWinRate": "Recent Win Rate",
+      "lastNGames_one": "last {{count}} game",
+      "lastNGames_other": "last {{count}} games"
+    },
+    "curve": {
+      "title": "GSP Curve",
+      "gspViewAria": "GSP view",
+      "mmrViewAria": "MMR view",
+      "gspLabel": "GSP",
+      "eliteLine": "Elite threshold",
+      "estMmrLabel": "Est. MMR",
+      "eliteMmrLine": "Elite (MMR {{mmr}})",
+      "mmrCaption": "Estimated hidden MMR behind each reading (community-reverse-engineered model) — unlike GSP, it doesn't inflate over time, so a flat line means flat skill. Dashed line: Elite entry at MMR {{mmr}}.",
+      "gspCaption": "Every point is a logged post-match GSP reading for this fighter. The dashed line is the computed Elite Smash threshold — a community-model estimate, not a Nintendo-published value.",
+      "clickHint": "Click a point to edit that reading.",
+      "locked": "Log at least {{count}} matches with a GSP reading for this fighter to see the curve."
+    },
+    "logger": {
+      "title": "Quick Logger",
+      "opponentCharacter": "Opponent Character",
+      "selectCharacter": "Select a character",
+      "gspAfterMatch": "GSP After Match",
+      "gspPlaceholder": "e.g. 9,420,000",
+      "stageOptional": "Stage (optional)",
+      "logMatch": "Log Match",
+      "logging": "Logging...",
+      "chooseOpponent": "Choose the opponent's character.",
+      "chooseResult": "Mark this match as a win or loss.",
+      "invalidGsp": "Enter the GSP shown after the match — commas are fine, e.g. 10,300,000.",
+      "logged": "Match logged! GSP {{gsp}}",
+      "logFailed": "Failed to log the match. Please try again."
+    },
+    "log": {
+      "title": "GSP Log",
+      "editEntry": "Edit GSP entry from {{date}}",
+      "deleteEntry": "Delete GSP entry from {{date}}",
+      "showRecent": "Show recent only",
+      "showAll": "Show all {{count}} entries"
+    },
+    "gains": {
+      "title": "Gains Analysis",
+      "avgGainLifetime": "Avg gain/win (lifetime)",
+      "avgDropLifetime": "Avg drop/loss (lifetime)",
+      "biggestGain": "Biggest single gain",
+      "avgGainLast20": "Avg gain/win (last 20)",
+      "avgDropLast20": "Avg drop/loss (last 20)",
+      "biggestDrop": "Biggest single drop",
+      "perWinTitle": "Per-win gains over time",
+      "shrinking": "— shrinking as your GSP climbs",
+      "growing": "— trending up",
+      "winNumber": "Win #{{number}}",
+      "gainedGsp": "GSP gained",
+      "empty": "Log a few wins and losses with GSP readings to see your gain/loss trends."
+    },
+    "road": {
+      "title": "Road to Elite",
+      "empty": "Log a match with a GSP reading for this fighter to see a projection.",
+      "alreadyElite": "You're already in Elite Smash!",
+      "equilibriumTitle": "Holding steady at your level",
+      "equilibriumBody": "At your current {{rate}}% win rate, matchmaking thinks this is your level right now — every match trades ~{{points}} MMR both ways, so a >50% win rate is what moves you up, not more matches. Keep working the matchups on this page and the number will follow.",
+      "cappedTitle": "more than {{max}} net wins",
+      "cappedBody": "Your win rate is barely above 50%, so expected progress per match is tiny — a small bump in win rate shortens this dramatically.",
+      "projected_one": "~{{count}} more match",
+      "projected_other": "~{{count}} more matches",
+      "projectedCaption": "to Elite (MMR {{elite}}) at your ~{{points}} MMR/match and {{rate}}% win rate (community model estimate)",
+      "historyOne": "From your own GSP history instead: ~{{label}} more match ({{model}}).",
+      "historyMany": "From your own GSP history instead: ~{{label}} more matches ({{model}}).",
+      "decayFit": "V10's shrinking-gains fit",
+      "flatFallback": "V10's flat-average fallback",
+      "assumption1": "Assumes matchmaking keeps pairing you against similar-MMR opponents (each match trades ~{{points}} MMR, the community table's value for an even match) and that your recent win rate holds.",
+      "assumption2": "Built on the community-reverse-engineered MMR model, not Nintendo's algorithm — a simulation, not a guarantee."
+    },
+    "vsGlicko": {
+      "title": "Est. MMR vs Glicko-2",
+      "mmrLabel": "Est. MMR (normalized)",
+      "glickoLabel": "Glicko-2 (normalized)",
+      "caption": "Your quickplay rating (estimated MMR for this fighter, community-reverse-engineered model) vs. your overall Glicko-2 rating (every fighter/session) — both normalized to 0-100 over this window since their raw scales are unrelated. Rating-vs-rating makes the shapes honestly comparable; divergence usually means your quickplay form differs from your overall form."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -223,5 +223,124 @@
       "edited": "¡Partida editada!",
       "saveFailed": "No se pudo guardar la partida. Inténtalo de nuevo."
     }
+  },
+  "gsp": {
+    "loading": "Cargando el rastreador de GSP...",
+    "selectFighterAria": "Seleccionar luchador",
+    "empty": {
+      "title": "Sigue tu ascenso de GSP",
+      "body": "El GSP (Poder Smash Global) es la clasificación online de quickplay de Smash Ultimate, registrada por personaje. Registra una partida de quickplay con el GSP de la pantalla de resultados y esta página graficará tu ascenso, desglosará tus ganancias y pérdidas y estimará cuánto te falta para Elite Smash.",
+      "cta": "Registrar una partida en el Panel"
+    },
+    "header": {
+      "title": "Rastreador de GSP",
+      "subtitle": "El Poder Smash Global es por personaje y Nintendo nunca ha publicado su fórmula exacta — todo lo de abajo es una estimación construida con tus propias partidas registradas y un modelo comunitario, obtenido por ingeniería inversa, del MMR oculto tras el GSP."
+    },
+    "deleteConfirm": {
+      "title": "¿Eliminar esta entrada de GSP?",
+      "body": "La partida y su lectura de GSP se eliminan juntas — esta acción no se puede deshacer.",
+      "deleted": "¡Entrada de GSP eliminada!",
+      "deleteFailed": "No se pudo eliminar la entrada. Inténtalo de nuevo."
+    },
+    "hero": {
+      "currentGsp": "GSP actual",
+      "latestReading": "última lectura",
+      "noGsp": "Aún no hay GSP registrado",
+      "estMmr": "MMR est.",
+      "tailReading": "lectura en la cola ({{zone}}) — aproximada",
+      "modelLink": "modelo de ingeniería inversa de la comunidad",
+      "modelAccuracy": "(±1 GSP en la curva principal; las colas son aproximadas)",
+      "eliteThreshold": "Umbral Elite",
+      "thresholdAria": "Umbral de Elite Smash",
+      "saveThreshold": "Guardar umbral",
+      "cancelThreshold": "Cancelar edición del umbral",
+      "editThreshold": "Editar umbral Elite",
+      "recalibrated": "recalibrado el {{date}}",
+      "fromAnchor": "según el ancla del modelo",
+      "computedCaption": "calculado · {{calibration}} · editarlo recalibra el modelo — copia el número actual de",
+      "invalidThreshold": "Introduce un número entero positivo — las comas valen, p. ej. 10,300,000.",
+      "recalibratedToast": "¡Modelo recalibrado con tu lectura del umbral!",
+      "thresholdSaveFailed": "No se pudo guardar el umbral Elite. Inténtalo de nuevo.",
+      "distanceToElite": "Distancia a Elite",
+      "elite": "ELITE",
+      "belowElite": "MMR {{mmr}} · por debajo de Elite ({{elite}})",
+      "recentWinRate": "% de victorias reciente",
+      "lastNGames_one": "última partida",
+      "lastNGames_other": "últimas {{count}} partidas"
+    },
+    "curve": {
+      "title": "Curva de GSP",
+      "gspViewAria": "Vista GSP",
+      "mmrViewAria": "Vista MMR",
+      "gspLabel": "GSP",
+      "eliteLine": "Umbral Elite",
+      "estMmrLabel": "MMR est.",
+      "eliteMmrLine": "Elite (MMR {{mmr}})",
+      "mmrCaption": "MMR oculto estimado detrás de cada lectura (modelo de ingeniería inversa de la comunidad) — a diferencia del GSP, no se infla con el tiempo, así que una línea plana significa nivel estable. Línea discontinua: entrada a Elite en MMR {{mmr}}.",
+      "gspCaption": "Cada punto es una lectura de GSP registrada tras una partida con este luchador. La línea discontinua es el umbral calculado de Elite Smash — una estimación del modelo comunitario, no un valor publicado por Nintendo.",
+      "clickHint": "Haz clic en un punto para editar esa lectura.",
+      "locked": "Registra al menos {{count}} partidas con lectura de GSP para este luchador para ver la curva."
+    },
+    "logger": {
+      "title": "Registro rápido",
+      "opponentCharacter": "Personaje del rival",
+      "selectCharacter": "Selecciona un personaje",
+      "gspAfterMatch": "GSP tras la partida",
+      "gspPlaceholder": "p. ej. 9 420 000",
+      "stageOptional": "Escenario (opcional)",
+      "logMatch": "Registrar partida",
+      "logging": "Registrando...",
+      "chooseOpponent": "Elige el personaje del rival.",
+      "chooseResult": "Marca esta partida como victoria o derrota.",
+      "invalidGsp": "Introduce el GSP que aparece tras la partida — las comas valen, p. ej. 10,300,000.",
+      "logged": "¡Partida registrada! GSP {{gsp}}",
+      "logFailed": "No se pudo registrar la partida. Inténtalo de nuevo."
+    },
+    "log": {
+      "title": "Registro de GSP",
+      "editEntry": "Editar entrada de GSP del {{date}}",
+      "deleteEntry": "Eliminar entrada de GSP del {{date}}",
+      "showRecent": "Mostrar solo recientes",
+      "showAll": "Mostrar las {{count}} entradas"
+    },
+    "gains": {
+      "title": "Análisis de ganancias",
+      "avgGainLifetime": "Ganancia media/victoria (total)",
+      "avgDropLifetime": "Pérdida media/derrota (total)",
+      "biggestGain": "Mayor ganancia individual",
+      "avgGainLast20": "Ganancia media/victoria (últimas 20)",
+      "avgDropLast20": "Pérdida media/derrota (últimas 20)",
+      "biggestDrop": "Mayor pérdida individual",
+      "perWinTitle": "Ganancias por victoria a lo largo del tiempo",
+      "shrinking": "— se reducen a medida que sube tu GSP",
+      "growing": "— al alza",
+      "winNumber": "Victoria n.º {{number}}",
+      "gainedGsp": "GSP ganado",
+      "empty": "Registra algunas victorias y derrotas con lecturas de GSP para ver tus tendencias."
+    },
+    "road": {
+      "title": "Camino a Elite",
+      "empty": "Registra una partida con lectura de GSP para este luchador para ver una proyección.",
+      "alreadyElite": "¡Ya estás en Elite Smash!",
+      "equilibriumTitle": "Estable en tu nivel",
+      "equilibriumBody": "Con tu {{rate}}% de victorias actual, el matchmaking considera que este es tu nivel ahora mismo — cada partida intercambia ~{{points}} MMR en ambos sentidos, así que lo que te hace subir es un porcentaje de victorias >50%, no jugar más partidas. Sigue trabajando los enfrentamientos de esta página y el número te seguirá.",
+      "cappedTitle": "más de {{max}} victorias netas",
+      "cappedBody": "Tu porcentaje de victorias apenas supera el 50%, así que el progreso esperado por partida es mínimo — una pequeña mejora del porcentaje lo acorta drásticamente.",
+      "projected_one": "~{{count}} partida más",
+      "projected_other": "~{{count}} partidas más",
+      "projectedCaption": "para Elite (MMR {{elite}}) a tus ~{{points}} MMR/partida y {{rate}}% de victorias (estimación del modelo comunitario)",
+      "historyOne": "Según tu propio historial de GSP: ~{{label}} partida más ({{model}}).",
+      "historyMany": "Según tu propio historial de GSP: ~{{label}} partidas más ({{model}}).",
+      "decayFit": "ajuste de ganancias decrecientes de V10",
+      "flatFallback": "promedio plano de V10",
+      "assumption1": "Asume que el matchmaking sigue emparejándote con rivales de MMR similar (cada partida intercambia ~{{points}} MMR, el valor de la tabla comunitaria para una partida igualada) y que tu porcentaje de victorias reciente se mantiene.",
+      "assumption2": "Basado en el modelo de MMR de ingeniería inversa de la comunidad, no en el algoritmo de Nintendo — una simulación, no una garantía."
+    },
+    "vsGlicko": {
+      "title": "MMR est. vs Glicko-2",
+      "mmrLabel": "MMR est. (normalizado)",
+      "glickoLabel": "Glicko-2 (normalizado)",
+      "caption": "Tu nivel en quickplay (MMR estimado de este luchador, modelo de ingeniería inversa de la comunidad) frente a tu Glicko-2 global (todos los luchadores/sesiones) — ambos normalizados a 0-100 en esta ventana porque sus escalas no están relacionadas. Comparar nivel contra nivel hace las formas honestamente comparables; una divergencia suele significar que tu forma en quickplay difiere de tu forma general."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -223,5 +223,124 @@
       "edited": "Match modifié !",
       "saveFailed": "Échec de l'enregistrement du match. Veuillez réessayer."
     }
+  },
+  "gsp": {
+    "loading": "Chargement du suivi GSP...",
+    "selectFighterAria": "Sélectionner un combattant",
+    "empty": {
+      "title": "Suivez votre montée en GSP",
+      "body": "Le GSP (Global Smash Power) est le classement en ligne du quickplay de Smash Ultimate, suivi par personnage. Enregistrez un match de quickplay avec le GSP affiché sur l'écran des résultats : cette page tracera votre progression, détaillera vos gains par victoire/défaite et estimera la distance qui vous sépare du Smash Élite.",
+      "cta": "Enregistrer un match depuis le tableau de bord"
+    },
+    "header": {
+      "title": "Suivi GSP",
+      "subtitle": "Le Global Smash Power est propre à chaque personnage et sa formule exacte n'est jamais publiée par Nintendo — tout ce qui suit est une estimation construite à partir de vos matchs enregistrés et d'un modèle communautaire, obtenu par rétro-ingénierie, du MMR caché derrière le GSP."
+    },
+    "deleteConfirm": {
+      "title": "Supprimer cette entrée GSP ?",
+      "body": "Le match et sa lecture GSP sont supprimés ensemble — cette action est irréversible.",
+      "deleted": "Entrée GSP supprimée !",
+      "deleteFailed": "Échec de la suppression de l'entrée. Veuillez réessayer."
+    },
+    "hero": {
+      "currentGsp": "GSP actuel",
+      "latestReading": "dernière lecture",
+      "noGsp": "Aucun GSP enregistré pour l'instant",
+      "estMmr": "MMR est.",
+      "tailReading": "lecture en queue de courbe ({{zone}}) — approximative",
+      "modelLink": "modèle communautaire (rétro-ingénierie)",
+      "modelAccuracy": "(±1 GSP sur la courbe principale ; queues approximatives)",
+      "eliteThreshold": "Seuil Élite",
+      "thresholdAria": "Seuil du Smash Élite",
+      "saveThreshold": "Enregistrer le seuil",
+      "cancelThreshold": "Annuler la modification du seuil",
+      "editThreshold": "Modifier le seuil Élite",
+      "recalibrated": "recalibré le {{date}}",
+      "fromAnchor": "depuis l'ancre du modèle",
+      "computedCaption": "calculé · {{calibration}} · le modifier recalibre le modèle — récupérez le nombre actuel sur",
+      "invalidThreshold": "Saisissez un nombre entier positif — les virgules sont acceptées, p. ex. 10,300,000.",
+      "recalibratedToast": "Modèle recalibré à partir de votre lecture du seuil !",
+      "thresholdSaveFailed": "Échec de l'enregistrement du seuil Élite. Veuillez réessayer.",
+      "distanceToElite": "Distance jusqu'à l'Élite",
+      "elite": "ÉLITE",
+      "belowElite": "MMR {{mmr}} · sous l'Élite ({{elite}})",
+      "recentWinRate": "Taux de victoire récent",
+      "lastNGames_one": "dernier match",
+      "lastNGames_other": "{{count}} derniers matchs"
+    },
+    "curve": {
+      "title": "Courbe GSP",
+      "gspViewAria": "Vue GSP",
+      "mmrViewAria": "Vue MMR",
+      "gspLabel": "GSP",
+      "eliteLine": "Seuil Élite",
+      "estMmrLabel": "MMR est.",
+      "eliteMmrLine": "Élite (MMR {{mmr}})",
+      "mmrCaption": "MMR caché estimé derrière chaque lecture (modèle communautaire par rétro-ingénierie) — contrairement au GSP, il ne gonfle pas avec le temps : une ligne plate signifie un niveau stable. Ligne pointillée : entrée dans l'Élite à MMR {{mmr}}.",
+      "gspCaption": "Chaque point est une lecture GSP enregistrée après un match avec ce combattant. La ligne pointillée est le seuil calculé du Smash Élite — une estimation du modèle communautaire, pas une valeur publiée par Nintendo.",
+      "clickHint": "Cliquez sur un point pour modifier cette lecture.",
+      "locked": "Enregistrez au moins {{count}} matchs avec une lecture GSP pour ce combattant pour voir la courbe."
+    },
+    "logger": {
+      "title": "Saisie rapide",
+      "opponentCharacter": "Personnage adverse",
+      "selectCharacter": "Sélectionnez un personnage",
+      "gspAfterMatch": "GSP après le match",
+      "gspPlaceholder": "p. ex. 9 420 000",
+      "stageOptional": "Stage (facultatif)",
+      "logMatch": "Enregistrer le match",
+      "logging": "Enregistrement...",
+      "chooseOpponent": "Choisissez le personnage de l'adversaire.",
+      "chooseResult": "Indiquez si ce match est une victoire ou une défaite.",
+      "invalidGsp": "Saisissez le GSP affiché après le match — les virgules sont acceptées, p. ex. 10,300,000.",
+      "logged": "Match enregistré ! GSP {{gsp}}",
+      "logFailed": "Échec de l'enregistrement du match. Veuillez réessayer."
+    },
+    "log": {
+      "title": "Journal GSP",
+      "editEntry": "Modifier l'entrée GSP du {{date}}",
+      "deleteEntry": "Supprimer l'entrée GSP du {{date}}",
+      "showRecent": "N'afficher que les récentes",
+      "showAll": "Afficher les {{count}} entrées"
+    },
+    "gains": {
+      "title": "Analyse des gains",
+      "avgGainLifetime": "Gain moyen/victoire (global)",
+      "avgDropLifetime": "Perte moyenne/défaite (global)",
+      "biggestGain": "Plus gros gain",
+      "avgGainLast20": "Gain moyen/victoire (20 derniers)",
+      "avgDropLast20": "Perte moyenne/défaite (20 derniers)",
+      "biggestDrop": "Plus grosse perte",
+      "perWinTitle": "Gains par victoire au fil du temps",
+      "shrinking": "— ils diminuent à mesure que votre GSP monte",
+      "growing": "— en hausse",
+      "winNumber": "Victoire n° {{number}}",
+      "gainedGsp": "GSP gagné",
+      "empty": "Enregistrez quelques victoires et défaites avec lectures GSP pour voir vos tendances."
+    },
+    "road": {
+      "title": "Route vers l'Élite",
+      "empty": "Enregistrez un match avec une lecture GSP pour ce combattant pour voir une projection.",
+      "alreadyElite": "Vous êtes déjà dans le Smash Élite !",
+      "equilibriumTitle": "Stable à votre niveau",
+      "equilibriumBody": "À votre taux de victoire actuel de {{rate}} %, le matchmaking considère que c'est votre niveau en ce moment — chaque match échange ~{{points}} MMR dans les deux sens : c'est un taux de victoire >50 % qui vous fait monter, pas plus de matchs. Continuez à travailler les matchups de cette page et le chiffre suivra.",
+      "cappedTitle": "plus de {{max}} victoires nettes",
+      "cappedBody": "Votre taux de victoire dépasse à peine 50 %, donc la progression attendue par match est infime — une petite hausse du taux de victoire raccourcit cela nettement.",
+      "projected_one": "~{{count}} match de plus",
+      "projected_other": "~{{count}} matchs de plus",
+      "projectedCaption": "jusqu'à l'Élite (MMR {{elite}}) à ~{{points}} MMR/match et {{rate}} % de victoires (estimation du modèle communautaire)",
+      "historyOne": "D'après votre propre historique GSP : ~{{label}} match de plus ({{model}}).",
+      "historyMany": "D'après votre propre historique GSP : ~{{label}} matchs de plus ({{model}}).",
+      "decayFit": "ajustement à gains décroissants de V10",
+      "flatFallback": "moyenne plate de V10",
+      "assumption1": "Suppose que le matchmaking continue de vous opposer à des adversaires de MMR similaire (chaque match échange ~{{points}} MMR, la valeur de la table communautaire pour un match équilibré) et que votre taux de victoire récent se maintient.",
+      "assumption2": "Construit sur le modèle de MMR communautaire (rétro-ingénierie), pas sur l'algorithme de Nintendo — une simulation, pas une garantie."
+    },
+    "vsGlicko": {
+      "title": "MMR est. vs Glicko-2",
+      "mmrLabel": "MMR est. (normalisé)",
+      "glickoLabel": "Glicko-2 (normalisé)",
+      "caption": "Votre niveau en quickplay (MMR estimé pour ce combattant, modèle communautaire par rétro-ingénierie) face à votre classement Glicko-2 global (tous combattants/sessions) — les deux normalisés de 0 à 100 sur cette fenêtre, leurs échelles brutes n'étant pas liées. Comparer classement contre classement rend les formes honnêtement comparables ; une divergence signifie généralement que votre forme en quickplay diffère de votre forme générale."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -223,5 +223,124 @@
       "edited": "対戦を編集しました！",
       "saveFailed": "対戦を保存できませんでした。もう一度お試しください。"
     }
+  },
+  "gsp": {
+    "loading": "GSPトラッカーを読み込み中...",
+    "selectFighterAria": "ファイターを選択",
+    "empty": {
+      "title": "世界戦闘力（GSP）の推移を記録しよう",
+      "body": "GSP（世界戦闘力）はスマブラSPのオンライン・クイックプレイのランキングで、ファイターごとに記録されます。リザルト画面に表示されるGSPと一緒に対戦を記録すると、このページが推移をグラフ化し、勝敗ごとの増減を分析して、VIPマッチまでの距離を推定します。",
+      "cta": "ダッシュボードで対戦を記録"
+    },
+    "header": {
+      "title": "GSPトラッカー",
+      "subtitle": "世界戦闘力（GSP）はファイターごとの数値で、正確な計算式は任天堂から公開されていません — 以下はすべて、あなたが記録した対戦と、GSPの背後にある隠しレートをコミュニティが解析したモデルに基づく推定値です。"
+    },
+    "deleteConfirm": {
+      "title": "このGSP記録を削除しますか？",
+      "body": "対戦とそのGSP値は一緒に削除されます — この操作は取り消せません。",
+      "deleted": "GSP記録を削除しました！",
+      "deleteFailed": "記録を削除できませんでした。もう一度お試しください。"
+    },
+    "hero": {
+      "currentGsp": "現在のGSP",
+      "latestReading": "最新の記録",
+      "noGsp": "まだGSPの記録がありません",
+      "estMmr": "推定MMR",
+      "tailReading": "分布の端（{{zone}}）の値 — 概算",
+      "modelLink": "コミュニティ解析モデル",
+      "modelAccuracy": "（主要区間では±1 GSP、端は概算）",
+      "eliteThreshold": "VIPボーダー",
+      "thresholdAria": "VIPマッチのボーダー",
+      "saveThreshold": "ボーダーを保存",
+      "cancelThreshold": "ボーダーの編集をキャンセル",
+      "editThreshold": "VIPボーダーを編集",
+      "recalibrated": "{{date}}に再調整",
+      "fromAnchor": "モデルの基準点から",
+      "computedCaption": "計算値 · {{calibration}} · 編集するとモデルが再調整されます — 最新の数値の入手先:",
+      "invalidThreshold": "正の整数を入力してください — カンマ入りでも大丈夫です（例: 10,300,000）。",
+      "recalibratedToast": "入力されたボーダー値でモデルを再調整しました！",
+      "thresholdSaveFailed": "VIPボーダーを保存できませんでした。もう一度お試しください。",
+      "distanceToElite": "VIPまでの距離",
+      "elite": "VIP",
+      "belowElite": "MMR {{mmr}} · VIP基準（{{elite}}）未満",
+      "recentWinRate": "直近の勝率",
+      "lastNGames_one": "直近{{count}}戦",
+      "lastNGames_other": "直近{{count}}戦"
+    },
+    "curve": {
+      "title": "GSP推移",
+      "gspViewAria": "GSP表示",
+      "mmrViewAria": "MMR表示",
+      "gspLabel": "GSP",
+      "eliteLine": "VIPボーダー",
+      "estMmrLabel": "推定MMR",
+      "eliteMmrLine": "VIP（MMR {{mmr}}）",
+      "mmrCaption": "各記録の背後にある推定隠しレート（コミュニティ解析モデル）です。GSPと違って時間でインフレしないため、横ばいの線は実力が安定していることを意味します。点線: MMR {{mmr}}のVIPボーダー。",
+      "gspCaption": "各ポイントはこのファイターで対戦後に記録したGSPです。点線は計算されたVIPマッチのボーダー — コミュニティモデルの推定値であり、任天堂公表の値ではありません。",
+      "clickHint": "ポイントをクリックするとその記録を編集できます。",
+      "locked": "このファイターでGSP付きの対戦を{{count}}戦以上記録すると推移が表示されます。"
+    },
+    "logger": {
+      "title": "クイック記録",
+      "opponentCharacter": "相手のファイター",
+      "selectCharacter": "ファイターを選択",
+      "gspAfterMatch": "対戦後のGSP",
+      "gspPlaceholder": "例: 9,420,000",
+      "stageOptional": "ステージ（任意）",
+      "logMatch": "対戦を記録",
+      "logging": "記録中...",
+      "chooseOpponent": "相手のファイターを選んでください。",
+      "chooseResult": "この対戦の勝敗を選んでください。",
+      "invalidGsp": "対戦後に表示されたGSPを入力してください — カンマ入りでも大丈夫です（例: 10,300,000）。",
+      "logged": "対戦を記録しました！ GSP {{gsp}}",
+      "logFailed": "対戦を記録できませんでした。もう一度お試しください。"
+    },
+    "log": {
+      "title": "GSP記録",
+      "editEntry": "{{date}}のGSP記録を編集",
+      "deleteEntry": "{{date}}のGSP記録を削除",
+      "showRecent": "最近の分のみ表示",
+      "showAll": "全{{count}}件を表示"
+    },
+    "gains": {
+      "title": "増減分析",
+      "avgGainLifetime": "勝利あたり平均増加（通算）",
+      "avgDropLifetime": "敗北あたり平均減少（通算）",
+      "biggestGain": "1戦での最大増加",
+      "avgGainLast20": "勝利あたり平均増加（直近20戦）",
+      "avgDropLast20": "敗北あたり平均減少（直近20戦）",
+      "biggestDrop": "1戦での最大減少",
+      "perWinTitle": "勝利ごとの増加量の推移",
+      "shrinking": "— GSPが上がるにつれて縮小中",
+      "growing": "— 増加傾向",
+      "winNumber": "{{number}}勝目",
+      "gainedGsp": "獲得GSP",
+      "empty": "GSP付きの勝敗をいくつか記録すると増減の傾向が表示されます。"
+    },
+    "road": {
+      "title": "VIPへの道",
+      "empty": "このファイターでGSP付きの対戦を記録すると予測が表示されます。",
+      "alreadyElite": "すでにVIPマッチ入りしています！",
+      "equilibriumTitle": "今の実力で安定しています",
+      "equilibriumBody": "現在の勝率{{rate}}%では、マッチメイキングはここがあなたの実力だと判断しています — 各対戦で約{{points}}MMRを取り合うため、上に行くのに必要なのは50%超の勝率であって、対戦数ではありません。このページで相性を磨けば数字は付いてきます。",
+      "cappedTitle": "あと{{max}}勝（純勝利数）以上",
+      "cappedBody": "勝率が50%をわずかに上回る程度なので、1戦あたりの期待進捗はごくわずかです — 勝率が少し上がるだけで大きく短縮されます。",
+      "projected_one": "あと約{{count}}戦",
+      "projected_other": "あと約{{count}}戦",
+      "projectedCaption": "VIP（MMR {{elite}}）まで、約{{points}}MMR/戦・勝率{{rate}}%での見積もり（コミュニティモデルによる推定）",
+      "historyOne": "あなた自身のGSP履歴からの推定: あと約{{label}}戦（{{model}}）。",
+      "historyMany": "あなた自身のGSP履歴からの推定: あと約{{label}}戦（{{model}}）。",
+      "decayFit": "V10の逓減ゲインフィット",
+      "flatFallback": "V10の平均値フォールバック",
+      "assumption1": "マッチメイキングが今後も同程度のMMRの相手を当て続けること（各対戦で約{{points}}MMR — 互角の対戦に対するコミュニティ表の値 — を取り合う）と、直近の勝率が維持されることを前提とします。",
+      "assumption2": "コミュニティが解析したMMRモデルに基づくもので、任天堂のアルゴリズムそのものではありません — シミュレーションであり、保証ではありません。"
+    },
+    "vsGlicko": {
+      "title": "推定MMR vs Glicko-2",
+      "mmrLabel": "推定MMR（正規化）",
+      "glickoLabel": "Glicko-2（正規化）",
+      "caption": "クイックプレイでのレート（このファイターの推定MMR、コミュニティ解析モデル）と、全体のGlicko-2レート（全ファイター・全セッション）の比較です。生のスケールに関連がないため、どちらもこの期間で0〜100に正規化しています。レート同士の比較なので形を公平に見比べられます。乖離がある場合は、クイックプレイでの調子が全体の調子と違うことを意味します。"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -223,5 +223,124 @@
       "edited": "Partida editada!",
       "saveFailed": "Falha ao salvar a partida. Tente novamente."
     }
+  },
+  "gsp": {
+    "loading": "Carregando o rastreador de GSP...",
+    "selectFighterAria": "Selecionar lutador",
+    "empty": {
+      "title": "Acompanhe sua subida de GSP",
+      "body": "O GSP (Poder de Smash Global) é o ranking online de quickplay do Smash Ultimate, registrado por personagem. Registre uma partida de quickplay com o GSP mostrado na tela de resultados e esta página vai traçar sua subida, detalhar seus ganhos por vitória/derrota e estimar o quanto falta para o Elite Smash.",
+      "cta": "Registrar uma partida no Painel"
+    },
+    "header": {
+      "title": "Rastreador de GSP",
+      "subtitle": "O Poder de Smash Global é por personagem e sua fórmula exata nunca foi publicada pela Nintendo — tudo abaixo é uma estimativa construída com suas próprias partidas registradas e um modelo da comunidade, obtido por engenharia reversa, do MMR oculto por trás do GSP."
+    },
+    "deleteConfirm": {
+      "title": "Excluir esta entrada de GSP?",
+      "body": "A partida e sua leitura de GSP são removidas juntas — esta ação não pode ser desfeita.",
+      "deleted": "Entrada de GSP excluída!",
+      "deleteFailed": "Falha ao excluir a entrada. Tente novamente."
+    },
+    "hero": {
+      "currentGsp": "GSP atual",
+      "latestReading": "última leitura",
+      "noGsp": "Nenhum GSP registrado ainda",
+      "estMmr": "MMR est.",
+      "tailReading": "leitura na cauda ({{zone}}) — aproximada",
+      "modelLink": "modelo de engenharia reversa da comunidade",
+      "modelAccuracy": "(±1 GSP na curva principal; caudas aproximadas)",
+      "eliteThreshold": "Limite do Elite",
+      "thresholdAria": "Limite do Elite Smash",
+      "saveThreshold": "Salvar limite",
+      "cancelThreshold": "Cancelar edição do limite",
+      "editThreshold": "Editar limite do Elite",
+      "recalibrated": "recalibrado em {{date}}",
+      "fromAnchor": "da âncora do modelo",
+      "computedCaption": "calculado · {{calibration}} · editar recalibra o modelo — pegue o número atual em",
+      "invalidThreshold": "Insira um número inteiro positivo — vírgulas são aceitas, ex.: 10,300,000.",
+      "recalibratedToast": "Modelo recalibrado com a sua leitura do limite!",
+      "thresholdSaveFailed": "Falha ao salvar o limite do Elite. Tente novamente.",
+      "distanceToElite": "Distância até o Elite",
+      "elite": "ELITE",
+      "belowElite": "MMR {{mmr}} · abaixo do Elite ({{elite}})",
+      "recentWinRate": "Taxa de vitórias recente",
+      "lastNGames_one": "última partida",
+      "lastNGames_other": "últimas {{count}} partidas"
+    },
+    "curve": {
+      "title": "Curva de GSP",
+      "gspViewAria": "Visão GSP",
+      "mmrViewAria": "Visão MMR",
+      "gspLabel": "GSP",
+      "eliteLine": "Limite do Elite",
+      "estMmrLabel": "MMR est.",
+      "eliteMmrLine": "Elite (MMR {{mmr}})",
+      "mmrCaption": "MMR oculto estimado por trás de cada leitura (modelo de engenharia reversa da comunidade) — diferente do GSP, ele não infla com o tempo, então uma linha plana significa nível estável. Linha tracejada: entrada no Elite em MMR {{mmr}}.",
+      "gspCaption": "Cada ponto é uma leitura de GSP registrada após uma partida com este lutador. A linha tracejada é o limite calculado do Elite Smash — uma estimativa do modelo da comunidade, não um valor publicado pela Nintendo.",
+      "clickHint": "Clique em um ponto para editar essa leitura.",
+      "locked": "Registre pelo menos {{count}} partidas com leitura de GSP para este lutador para ver a curva."
+    },
+    "logger": {
+      "title": "Registro rápido",
+      "opponentCharacter": "Personagem do oponente",
+      "selectCharacter": "Selecione um personagem",
+      "gspAfterMatch": "GSP após a partida",
+      "gspPlaceholder": "ex.: 9 420 000",
+      "stageOptional": "Stage (opcional)",
+      "logMatch": "Registrar partida",
+      "logging": "Registrando...",
+      "chooseOpponent": "Escolha o personagem do oponente.",
+      "chooseResult": "Marque esta partida como vitória ou derrota.",
+      "invalidGsp": "Insira o GSP mostrado após a partida — vírgulas são aceitas, ex.: 10,300,000.",
+      "logged": "Partida registrada! GSP {{gsp}}",
+      "logFailed": "Falha ao registrar a partida. Tente novamente."
+    },
+    "log": {
+      "title": "Registro de GSP",
+      "editEntry": "Editar entrada de GSP de {{date}}",
+      "deleteEntry": "Excluir entrada de GSP de {{date}}",
+      "showRecent": "Mostrar só as recentes",
+      "showAll": "Mostrar todas as {{count}} entradas"
+    },
+    "gains": {
+      "title": "Análise de ganhos",
+      "avgGainLifetime": "Ganho médio/vitória (geral)",
+      "avgDropLifetime": "Perda média/derrota (geral)",
+      "biggestGain": "Maior ganho individual",
+      "avgGainLast20": "Ganho médio/vitória (últimas 20)",
+      "avgDropLast20": "Perda média/derrota (últimas 20)",
+      "biggestDrop": "Maior perda individual",
+      "perWinTitle": "Ganhos por vitória ao longo do tempo",
+      "shrinking": "— encolhendo conforme seu GSP sobe",
+      "growing": "— em alta",
+      "winNumber": "Vitória nº {{number}}",
+      "gainedGsp": "GSP ganho",
+      "empty": "Registre algumas vitórias e derrotas com leituras de GSP para ver suas tendências."
+    },
+    "road": {
+      "title": "Caminho para o Elite",
+      "empty": "Registre uma partida com leitura de GSP para este lutador para ver uma projeção.",
+      "alreadyElite": "Você já está no Elite Smash!",
+      "equilibriumTitle": "Estável no seu nível",
+      "equilibriumBody": "Com sua taxa de vitórias atual de {{rate}}%, o matchmaking considera que este é o seu nível agora — cada partida troca ~{{points}} MMR nos dois sentidos, então é uma taxa de vitórias acima de 50% que faz você subir, não mais partidas. Continue trabalhando os confrontos desta página e o número acompanha.",
+      "cappedTitle": "mais de {{max}} vitórias líquidas",
+      "cappedBody": "Sua taxa de vitórias mal passa de 50%, então o progresso esperado por partida é mínimo — um pequeno aumento na taxa encurta isso drasticamente.",
+      "projected_one": "~{{count}} partida a mais",
+      "projected_other": "~{{count}} partidas a mais",
+      "projectedCaption": "até o Elite (MMR {{elite}}) com seus ~{{points}} MMR/partida e {{rate}}% de vitórias (estimativa do modelo da comunidade)",
+      "historyOne": "Pelo seu próprio histórico de GSP: ~{{label}} partida a mais ({{model}}).",
+      "historyMany": "Pelo seu próprio histórico de GSP: ~{{label}} partidas a mais ({{model}}).",
+      "decayFit": "ajuste de ganhos decrescentes do V10",
+      "flatFallback": "média plana do V10",
+      "assumption1": "Assume que o matchmaking continua pareando você com oponentes de MMR parecido (cada partida troca ~{{points}} MMR, o valor da tabela da comunidade para uma partida equilibrada) e que sua taxa de vitórias recente se mantém.",
+      "assumption2": "Construído sobre o modelo de MMR de engenharia reversa da comunidade, não sobre o algoritmo da Nintendo — uma simulação, não uma garantia."
+    },
+    "vsGlicko": {
+      "title": "MMR est. vs Glicko-2",
+      "mmrLabel": "MMR est. (normalizado)",
+      "glickoLabel": "Glicko-2 (normalizado)",
+      "caption": "Seu nível no quickplay (MMR estimado deste lutador, modelo de engenharia reversa da comunidade) contra seu Glicko-2 geral (todos os lutadores/sessões) — ambos normalizados de 0 a 100 nesta janela, já que as escalas brutas não têm relação. Comparar rating com rating torna as formas honestamente comparáveis; divergência normalmente significa que sua forma no quickplay difere da sua forma geral."
+    }
   }
 }

--- a/apps/web/src/pages/Gsp/GspPage.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { Fighter, Match } from '@smash-tracker/shared';
 import { getGspGainStats, getGspMatches, getGspSeries } from '@smash-tracker/shared';
@@ -47,6 +48,7 @@ import { GspVsGlicko } from './components/GspVsGlicko';
  * through Match Data.
  */
 export function GspPage() {
+  const { t } = useTranslation();
   const { data: matches = [], isLoading: matchesLoading } = useMatches();
   const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
   const { data: gspSettings, isLoading: settingsLoading } = useGspSettings();
@@ -81,28 +83,23 @@ export function GspPage() {
   const isLoading = matchesLoading || fightersLoading || settingsLoading;
 
   if (isLoading) {
-    return <div className="text-muted-foreground">Loading GSP tracker...</div>;
+    return <div className="text-muted-foreground">{t('gsp.loading')}</div>;
   }
 
   if (fighterOptions.length === 0) {
     return (
       <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">Track your GSP climb</h1>
-        <p className="max-w-md text-muted-foreground">
-          GSP (Global Smash Power) is Smash Ultimate&apos;s online quickplay ranking, tracked
-          per-character. Log a quickplay match with the GSP shown on the results screen and this
-          page will chart your climb, break down your win/loss gains, and estimate how far you are
-          from Elite Smash.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('gsp.empty.title')}</h1>
+        <p className="max-w-md text-muted-foreground">{t('gsp.empty.body')}</p>
         <Button asChild className="mt-2">
-          <Link to="/dashboard">Log a match on the Dashboard</Link>
+          <Link to="/dashboard">{t('gsp.empty.cta')}</Link>
         </Button>
       </div>
     );
   }
 
   if (!fighter || !gspSettings) {
-    return <div className="text-muted-foreground">Loading GSP tracker...</div>;
+    return <div className="text-muted-foreground">{t('gsp.loading')}</div>;
   }
 
   // Index-parity: gspMatches[i] is the match behind series[i] (the series is
@@ -117,9 +114,9 @@ export function GspPage() {
     if (!pendingDelete) return;
     try {
       await deleteMatch.mutateAsync(pendingDelete.id);
-      toast.success('GSP entry deleted!');
+      toast.success(t('gsp.deleteConfirm.deleted'));
     } catch {
-      toast.error('Failed to delete the entry. Please try again.');
+      toast.error(t('gsp.deleteConfirm.deleteFailed'));
     } finally {
       setPendingDelete(null);
     }
@@ -128,12 +125,8 @@ export function GspPage() {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col items-center gap-2 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">GSP Tracker</h1>
-        <p className="max-w-lg text-sm text-muted-foreground">
-          Global Smash Power is per-character and its exact formula is never published by Nintendo —
-          everything below is an estimate built from your own logged matches and a
-          community-reverse-engineered model of the hidden MMR behind GSP.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('gsp.header.title')}</h1>
+        <p className="max-w-lg text-sm text-muted-foreground">{t('gsp.header.subtitle')}</p>
         <GspFighterSelect
           fighter={fighter}
           fighterOptions={fighterOptions}
@@ -181,14 +174,12 @@ export function GspPage() {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete this GSP entry?</AlertDialogTitle>
-            <AlertDialogDescription>
-              The match and its GSP reading are removed together — this action cannot be undone.
-            </AlertDialogDescription>
+            <AlertDialogTitle>{t('gsp.deleteConfirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('gsp.deleteConfirm.body')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>{t('common.delete')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/pages/Gsp/components/GainsAnalysis.tsx
+++ b/apps/web/src/pages/Gsp/components/GainsAnalysis.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   BarElement,
   CategoryScale,
@@ -14,12 +16,12 @@ import { chartColors, darkChartOptions } from '@/lib/chartTheme';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
-function buildPerWinGainsData(perWinGains: number[]) {
+function buildPerWinGainsData(perWinGains: number[], t: TFunction) {
   return {
     labels: perWinGains.map((_, i) => String(i + 1)),
     datasets: [
       {
-        label: 'GSP gained',
+        label: t('gsp.gains.gainedGsp'),
         data: perWinGains,
         backgroundColor: chartColors.red,
         borderRadius: 2,
@@ -28,7 +30,7 @@ function buildPerWinGainsData(perWinGains: number[]) {
   };
 }
 
-function buildPerWinGainsOptions(): ChartOptions<'bar'> {
+function buildPerWinGainsOptions(t: TFunction): ChartOptions<'bar'> {
   const theme = darkChartOptions();
   return {
     responsive: true,
@@ -47,7 +49,7 @@ function buildPerWinGainsOptions(): ChartOptions<'bar'> {
         borderColor: chartColors.tooltipBorder,
         borderWidth: 1,
         callbacks: {
-          title: (items) => `Win #${items[0]?.label ?? ''}`,
+          title: (items) => t('gsp.gains.winNumber', { number: items[0]?.label ?? '' }),
           label: (item) => `+${Number(item.parsed.y).toLocaleString()} GSP`,
         },
       },
@@ -76,57 +78,56 @@ function formatGsp(value: number | null): string {
  * bell-curve tail effect).
  */
 export function GainsAnalysis({ stats }: { stats: GspGainStats }) {
+  const { t } = useTranslation();
   const hasData = stats.perWinGains.length > 0 || stats.avgDropPerLossLifetime !== null;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Gains Analysis</CardTitle>
+        <CardTitle>{t('gsp.gains.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {hasData ? (
           <>
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
               <StatBlock
-                label="Avg gain/win (lifetime)"
+                label={t('gsp.gains.avgGainLifetime')}
                 value={formatGsp(stats.avgGainPerWinLifetime)}
               />
               <StatBlock
-                label="Avg drop/loss (lifetime)"
+                label={t('gsp.gains.avgDropLifetime')}
                 value={formatGsp(stats.avgDropPerLossLifetime)}
               />
-              <StatBlock label="Biggest single gain" value={formatGsp(stats.biggestGain)} />
+              <StatBlock label={t('gsp.gains.biggestGain')} value={formatGsp(stats.biggestGain)} />
               <StatBlock
-                label="Avg gain/win (last 20)"
+                label={t('gsp.gains.avgGainLast20')}
                 value={formatGsp(stats.avgGainPerWinLast20)}
               />
               <StatBlock
-                label="Avg drop/loss (last 20)"
+                label={t('gsp.gains.avgDropLast20')}
                 value={formatGsp(stats.avgDropPerLossLast20)}
               />
-              <StatBlock label="Biggest single drop" value={formatGsp(stats.biggestDrop)} />
+              <StatBlock label={t('gsp.gains.biggestDrop')} value={formatGsp(stats.biggestDrop)} />
             </div>
 
             {stats.perWinGains.length > 0 && (
               <div>
                 <p className="mb-1 text-sm font-medium text-muted-foreground">
-                  Per-win gains over time
-                  {stats.gainTrend === 'shrinking' && ' — shrinking as your GSP climbs'}
-                  {stats.gainTrend === 'growing' && ' — trending up'}
+                  {t('gsp.gains.perWinTitle')}
+                  {stats.gainTrend === 'shrinking' && ` ${t('gsp.gains.shrinking')}`}
+                  {stats.gainTrend === 'growing' && ` ${t('gsp.gains.growing')}`}
                 </p>
                 <div className="h-32">
                   <Bar
-                    data={buildPerWinGainsData(stats.perWinGains)}
-                    options={buildPerWinGainsOptions()}
+                    data={buildPerWinGainsData(stats.perWinGains, t)}
+                    options={buildPerWinGainsOptions(t)}
                   />
                 </div>
               </div>
             )}
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">
-            Log a few wins and losses with GSP readings to see your gain/loss trends.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('gsp.gains.empty')}</p>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Gsp/components/GspCurve.test.ts
+++ b/apps/web/src/pages/Gsp/components/GspCurve.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { GspPoint, GspSettings } from '@smash-tracker/shared';
 import { GSP_MODEL, estimateT, mmrToGsp } from '@smash-tracker/shared';
+// Bundled-English i18n instance (see src/test/setup.ts) — the builders take
+// `t`/locale so chart labels localize; passing i18n.t keeps assertions English.
+import i18n from '@/i18n';
 import { buildGspCurveData, buildGspCurveOptions, buildMmrCurveData } from './GspCurve';
 
 describe('buildGspCurveData', () => {
@@ -10,7 +13,7 @@ describe('buildGspCurveData', () => {
       { time: 2, gsp: 9_100_000, win: true },
     ];
 
-    const data = buildGspCurveData(series, 10_000_000);
+    const data = buildGspCurveData(series, 10_000_000, i18n.t, 'en');
 
     expect(data.labels).toHaveLength(2);
     expect(data.datasets[0]!.data).toEqual([9_000_000, 9_100_000]);
@@ -19,7 +22,7 @@ describe('buildGspCurveData', () => {
   });
 
   it('handles an empty series', () => {
-    const data = buildGspCurveData([], 10_000_000);
+    const data = buildGspCurveData([], 10_000_000, i18n.t, 'en');
     expect(data.labels).toEqual([]);
     expect(data.datasets[0]!.data).toEqual([]);
     expect(data.datasets[1]!.data).toEqual([]);
@@ -39,7 +42,7 @@ describe('buildMmrCurveData', () => {
       { time: t1Ms, gsp: Math.round(mmrToGsp(1100, estimateT(t1Ms))), win: true },
     ];
 
-    const data = buildMmrCurveData(series, neverSaved);
+    const data = buildMmrCurveData(series, neverSaved, i18n.t, 'en');
 
     expect(data.labels).toHaveLength(2);
     expect(data.datasets[0]!.label).toBe('Est. MMR');
@@ -57,12 +60,12 @@ describe('buildMmrCurveData', () => {
     ];
     expect(series[1]!.gsp).toBeGreaterThan(series[0]!.gsp);
 
-    const data = buildMmrCurveData(series, neverSaved);
+    const data = buildMmrCurveData(series, neverSaved, i18n.t, 'en');
     expect(data.datasets[0]!.data).toEqual([1050, 1050]);
   });
 
   it('handles an empty series', () => {
-    const data = buildMmrCurveData([], neverSaved);
+    const data = buildMmrCurveData([], neverSaved, i18n.t, 'en');
     expect(data.labels).toEqual([]);
     expect(data.datasets[0]!.data).toEqual([]);
     expect(data.datasets[1]!.data).toEqual([]);
@@ -76,14 +79,14 @@ describe('buildGspCurveOptions', () => {
   ];
 
   it('omits click/hover handlers when no onPointClick is given', () => {
-    const options = buildGspCurveOptions(series);
+    const options = buildGspCurveOptions(series, 'en');
     expect(options.onClick).toBeUndefined();
     expect(options.onHover).toBeUndefined();
   });
 
   it('resolves a click on the GSP dataset to the point index', () => {
     const clicks: number[] = [];
-    const options = buildGspCurveOptions(series, (index) => clicks.push(index));
+    const options = buildGspCurveOptions(series, 'en', (index) => clicks.push(index));
 
     type OnClick = NonNullable<typeof options.onClick>;
     const onClick = options.onClick as OnClick;
@@ -104,7 +107,7 @@ describe('buildGspCurveOptions', () => {
 
   it('ignores clicks that only hit the Elite reference line', () => {
     const clicks: number[] = [];
-    const options = buildGspCurveOptions(series, (index) => clicks.push(index));
+    const options = buildGspCurveOptions(series, 'en', (index) => clicks.push(index));
     (options.onClick as NonNullable<typeof options.onClick>).call(
       undefined as never,
       undefined as never,

--- a/apps/web/src/pages/Gsp/components/GspCurve.tsx
+++ b/apps/web/src/pages/Gsp/components/GspCurve.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -26,8 +28,8 @@ export const GSP_CURVE_UNLOCK_THRESHOLD = 2;
 /** The two y-axis scales the curve can plot (V10.1 adds the converted-MMR view). */
 export type GspCurveView = 'gsp' | 'mmr';
 
-function formatPointLabel(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+function formatPointLabel(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, { month: 'short', day: 'numeric' });
 }
 
 /**
@@ -36,18 +38,23 @@ function formatPointLabel(time: number): string {
  * horizontal line regardless of x-axis spacing. Exported as a pure builder so
  * it's unit-testable without rendering chart.js.
  */
-export function buildGspCurveData(series: GspPoint[], eliteThreshold: number) {
-  const labels = series.map((p) => formatPointLabel(p.time));
+export function buildGspCurveData(
+  series: GspPoint[],
+  eliteThreshold: number,
+  t: TFunction,
+  locale: string,
+) {
+  const labels = series.map((p) => formatPointLabel(p.time, locale));
   return {
     labels,
     datasets: [
       {
-        label: 'GSP',
+        label: t('gsp.curve.gspLabel'),
         ...redLineDataset(),
         data: series.map((p) => p.gsp),
       },
       {
-        label: 'Elite threshold',
+        label: t('gsp.curve.eliteLine'),
         data: series.map(() => eliteThreshold),
         borderColor: chartColors.grid,
         backgroundColor: chartColors.grid,
@@ -68,19 +75,24 @@ export function buildGspCurveData(series: GspPoint[], eliteThreshold: number) {
  * ../lib/gspMmrModel.ts), with a flat Elite line at the fixed Elite entry
  * MMR (1142). Same pure-builder convention as `buildGspCurveData`.
  */
-export function buildMmrCurveData(series: GspPoint[], settings: GspSettings) {
+export function buildMmrCurveData(
+  series: GspPoint[],
+  settings: GspSettings,
+  t: TFunction,
+  locale: string,
+) {
   const calibration = calibrationFromSettings(settings);
   const mmrSeries = toMmrSeries(series, calibration);
   return {
-    labels: mmrSeries.map((p) => formatPointLabel(p.time)),
+    labels: mmrSeries.map((p) => formatPointLabel(p.time, locale)),
     datasets: [
       {
-        label: 'Est. MMR',
+        label: t('gsp.curve.estMmrLabel'),
         ...redLineDataset(),
         data: mmrSeries.map((p) => Math.round(p.mmr)),
       },
       {
-        label: `Elite (MMR ${GSP_MODEL.ELITE_MMR})`,
+        label: t('gsp.curve.eliteMmrLine', { mmr: GSP_MODEL.ELITE_MMR }),
         data: mmrSeries.map(() => GSP_MODEL.ELITE_MMR),
         borderColor: chartColors.grid,
         backgroundColor: chartColors.grid,
@@ -97,6 +109,7 @@ export function buildMmrCurveData(series: GspPoint[], settings: GspSettings) {
 
 export function buildGspCurveOptions(
   series: GspPoint[],
+  locale: string,
   onPointClick?: (index: number) => void,
 ): ChartOptions<'line'> {
   const theme = darkChartOptions();
@@ -141,7 +154,7 @@ export function buildGspCurveOptions(
         callbacks: {
           title: (items) => {
             const point = series[items[0]?.dataIndex ?? -1];
-            return point ? new Date(point.time).toLocaleDateString('en-US') : '';
+            return point ? new Date(point.time).toLocaleDateString(locale) : '';
           },
           label: (item) => `${item.dataset.label}: ${Number(item.parsed.y).toLocaleString()}`,
         },
@@ -169,6 +182,7 @@ export function GspCurve({
   /** V14: click a reading on the curve to act on it (the page opens the edit dialog for that match). Index-aligned with `series`/`getGspMatches`. */
   onPointClick?: (index: number) => void;
 }) {
+  const { t, i18n } = useTranslation();
   const nowMs = useNowMs();
   const [view, setView] = useState<GspCurveView>('gsp');
   const hasEnoughReadings = series.length >= GSP_CURVE_UNLOCK_THRESHOLD;
@@ -179,7 +193,7 @@ export function GspCurve({
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center justify-between gap-2">
-          GSP Curve
+          {t('gsp.curve.title')}
           <ToggleGroup
             type="single"
             variant="outline"
@@ -189,10 +203,10 @@ export function GspCurve({
               if (value === 'gsp' || value === 'mmr') setView(value);
             }}
           >
-            <ToggleGroupItem value="gsp" aria-label="GSP view">
+            <ToggleGroupItem value="gsp" aria-label={t('gsp.curve.gspViewAria')}>
               GSP
             </ToggleGroupItem>
-            <ToggleGroupItem value="mmr" aria-label="MMR view">
+            <ToggleGroupItem value="mmr" aria-label={t('gsp.curve.mmrViewAria')}>
               MMR
             </ToggleGroupItem>
           </ToggleGroup>
@@ -205,31 +219,26 @@ export function GspCurve({
               <Line
                 data={
                   view === 'mmr'
-                    ? buildMmrCurveData(series, settings)
-                    : buildGspCurveData(series, eliteThreshold)
+                    ? buildMmrCurveData(series, settings, t, i18n.language)
+                    : buildGspCurveData(series, eliteThreshold, t, i18n.language)
                 }
-                options={buildGspCurveOptions(series, onPointClick)}
+                options={buildGspCurveOptions(series, i18n.language, onPointClick)}
               />
             </div>
             {view === 'mmr' ? (
               <p className="text-xs text-muted-foreground">
-                Estimated hidden MMR behind each reading (community-reverse-engineered model) —
-                unlike GSP, it doesn&apos;t inflate over time, so a flat line means flat skill.
-                Dashed line: Elite entry at MMR {GSP_MODEL.ELITE_MMR}.
+                {t('gsp.curve.mmrCaption', { mmr: GSP_MODEL.ELITE_MMR })}
               </p>
             ) : (
               <p className="text-xs text-muted-foreground">
-                Every point is a logged post-match GSP reading for this fighter. The dashed line is
-                the computed Elite Smash threshold — a community-model estimate, not a
-                Nintendo-published value.
-                {onPointClick && ' Click a point to edit that reading.'}
+                {t('gsp.curve.gspCaption')}
+                {onPointClick && ` ${t('gsp.curve.clickHint')}`}
               </p>
             )}
           </>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Log at least {GSP_CURVE_UNLOCK_THRESHOLD} matches with a GSP reading for this fighter to
-            see the curve.
+            {t('gsp.curve.locked', { count: GSP_CURVE_UNLOCK_THRESHOLD })}
           </p>
         )}
       </CardContent>

--- a/apps/web/src/pages/Gsp/components/GspFighterSelect.tsx
+++ b/apps/web/src/pages/Gsp/components/GspFighterSelect.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { Fighter } from '@smash-tracker/shared';
 import { cn } from '@/lib/utils';
 
@@ -17,11 +18,12 @@ export function GspFighterSelect({
   fighterOptions: Fighter[];
   onChange: (fighter: Fighter) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       className="flex flex-wrap items-center justify-center gap-2"
       role="group"
-      aria-label="Select fighter"
+      aria-label={t('gsp.selectFighterAria')}
     >
       {fighterOptions.map((option) => {
         const selected = option.id === fighter?.id;

--- a/apps/web/src/pages/Gsp/components/GspHero.tsx
+++ b/apps/web/src/pages/Gsp/components/GspHero.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pencil, Check, X } from 'lucide-react';
 import type { GspPoint, GspSettings } from '@smash-tracker/shared';
 import { GSP_MODEL } from '@smash-tracker/shared';
@@ -48,6 +49,7 @@ export function getRecentGspWinRate(series: GspPoint[], windowSize = 20): number
  * GSP threshold), and recent GSP win rate.
  */
 export function GspHero({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
+  const { t } = useTranslation();
   const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const winRate = getRecentGspWinRate(series);
 
@@ -59,24 +61,24 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-      <HeroCard label="Current GSP">
+      <HeroCard label={t('gsp.hero.currentGsp')}>
         {lastPoint !== null ? (
           <>
             <span className="text-3xl font-bold">{lastPoint.gsp.toLocaleString()}</span>
-            <p className="text-sm text-muted-foreground">latest reading</p>
+            <p className="text-sm text-muted-foreground">{t('gsp.hero.latestReading')}</p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+          <p className="text-sm text-muted-foreground">{t('gsp.hero.noGsp')}</p>
         )}
       </HeroCard>
 
-      <HeroCard label="Est. MMR">
+      <HeroCard label={t('gsp.hero.estMmr')}>
         {estimate !== null && roundedMmr !== null ? (
           <>
             <span className="text-3xl font-bold">{roundedMmr.toLocaleString()}</span>
             {estimate.zone !== 'main' && (
               <p className="text-xs font-medium text-amber-500">
-                {estimate.zone}-tail reading &mdash; approximate
+                {t('gsp.hero.tailReading', { zone: estimate.zone })}
               </p>
             )}
             <p className="text-xs text-muted-foreground">
@@ -86,24 +88,24 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
                 rel="noreferrer"
                 className="underline underline-offset-2 hover:text-foreground"
               >
-                community-reverse-engineered model
+                {t('gsp.hero.modelLink')}
               </a>{' '}
-              (&plusmn;1 GSP in the main curve; tails approximate)
+              {t('gsp.hero.modelAccuracy')}
             </p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+          <p className="text-sm text-muted-foreground">{t('gsp.hero.noGsp')}</p>
         )}
       </HeroCard>
 
       <EliteThresholdCard settings={settings} />
 
-      <HeroCard label="Distance to Elite">
+      <HeroCard label={t('gsp.hero.distanceToElite')}>
         {roundedMmr === null ? (
-          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+          <p className="text-sm text-muted-foreground">{t('gsp.hero.noGsp')}</p>
         ) : isElite ? (
           <span className="w-fit rounded-full bg-emerald-500/15 px-2 py-0.5 text-sm font-semibold text-emerald-500">
-            ELITE
+            {t('gsp.hero.elite')}
           </span>
         ) : (
           <>
@@ -111,22 +113,25 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
               {(GSP_MODEL.ELITE_MMR - roundedMmr).toLocaleString()}
             </span>
             <p className="text-sm text-muted-foreground">
-              MMR {roundedMmr.toLocaleString()} &middot; below Elite ({GSP_MODEL.ELITE_MMR})
+              {t('gsp.hero.belowElite', {
+                mmr: roundedMmr.toLocaleString(),
+                elite: GSP_MODEL.ELITE_MMR,
+              })}
             </p>
           </>
         )}
       </HeroCard>
 
-      <HeroCard label="Recent Win Rate">
+      <HeroCard label={t('gsp.hero.recentWinRate')}>
         {winRate !== null ? (
           <>
             <span className="text-3xl font-bold">{Math.round(winRate * 100)}%</span>
             <p className="text-sm text-muted-foreground">
-              last {Math.min(series.length, 20)} games
+              {t('gsp.hero.lastNGames', { count: Math.min(series.length, 20) })}
             </p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">No GSP logged yet</p>
+          <p className="text-sm text-muted-foreground">{t('gsp.hero.noGsp')}</p>
         )}
       </HeroCard>
     </div>
@@ -143,6 +148,7 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
  * display keeps drifting forward from there, same as the real threshold does.
  */
 function EliteThresholdCard({ settings }: { settings: GspSettings }) {
+  const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(settings.eliteThreshold));
   const updateSettings = useUpdateGspSettings();
@@ -153,28 +159,30 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
 
   const calibrationLabel =
     settings.updatedAt > 0
-      ? `recalibrated ${new Date(settings.updatedAt).toLocaleDateString()}`
-      : 'from the model anchor';
+      ? t('gsp.hero.recalibrated', { date: new Date(settings.updatedAt).toLocaleDateString() })
+      : t('gsp.hero.fromAnchor');
 
   async function save() {
     const parsed = parseGspNumber(draft);
     if (parsed === null || parsed <= 0) {
-      toast.error('Enter a positive whole number — commas are fine, e.g. 10,300,000.');
+      toast.error(t('gsp.hero.invalidThreshold'));
       return;
     }
     try {
       await updateSettings.mutateAsync({ eliteThreshold: parsed });
-      toast.success('Model recalibrated from your threshold reading!');
+      toast.success(t('gsp.hero.recalibratedToast'));
       setEditing(false);
     } catch {
-      toast.error('Failed to save the Elite threshold. Please try again.');
+      toast.error(t('gsp.hero.thresholdSaveFailed'));
     }
   }
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium text-muted-foreground">Elite Threshold</CardTitle>
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {t('gsp.hero.eliteThreshold')}
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-1">
         {editing ? (
@@ -186,7 +194,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
               inputMode="numeric"
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
-              aria-label="Elite Smash threshold"
+              aria-label={t('gsp.hero.thresholdAria')}
               className="h-8 w-32"
               autoFocus
             />
@@ -194,7 +202,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
               type="button"
               size="icon-sm"
               variant="ghost"
-              aria-label="Save threshold"
+              aria-label={t('gsp.hero.saveThreshold')}
               onClick={() => void save()}
               disabled={updateSettings.isPending}
             >
@@ -204,7 +212,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
               type="button"
               size="icon-sm"
               variant="ghost"
-              aria-label="Cancel editing threshold"
+              aria-label={t('gsp.hero.cancelThreshold')}
               onClick={() => {
                 setDraft(String(settings.eliteThreshold));
                 setEditing(false);
@@ -220,7 +228,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
               type="button"
               size="icon-xs"
               variant="ghost"
-              aria-label="Edit Elite threshold"
+              aria-label={t('gsp.hero.editThreshold')}
               onClick={() => setEditing(true)}
             >
               <Pencil className="size-3.5" />
@@ -228,8 +236,7 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
           </div>
         )}
         <p className="text-xs text-muted-foreground">
-          computed &middot; {calibrationLabel} &middot; editing recalibrates the model &mdash; grab
-          the current number from{' '}
+          {t('gsp.hero.computedCaption', { calibration: calibrationLabel })}{' '}
           <a
             href={ELITEGSP_URL}
             target="_blank"

--- a/apps/web/src/pages/Gsp/components/GspMatchLog.tsx
+++ b/apps/web/src/pages/Gsp/components/GspMatchLog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pencil, Trash2 } from 'lucide-react';
 import type { Match } from '@smash-tracker/shared';
 import { Badge } from '@/components/ui/badge';
@@ -8,8 +9,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 /** Rows shown before the "Show all" toggle — enough to catch a recent typo without burying the page. */
 const DEFAULT_VISIBLE_ROWS = 8;
 
-function formatDate(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', {
+function formatDate(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -34,6 +35,7 @@ export function GspMatchLog({
   onEdit: (match: Match) => void;
   onDelete: (match: Match) => void;
 }) {
+  const { t, i18n } = useTranslation();
   const [showAll, setShowAll] = useState(false);
 
   if (gspMatches.length === 0) {
@@ -53,7 +55,7 @@ export function GspMatchLog({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>GSP Log</CardTitle>
+        <CardTitle>{t('gsp.log.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
         <ul className="flex flex-col gap-2">
@@ -63,9 +65,11 @@ export function GspMatchLog({
               className="flex items-center justify-between gap-2 rounded-md border p-2"
             >
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                <span className="w-24 text-xs text-muted-foreground">{formatDate(match.time)}</span>
+                <span className="w-24 text-xs text-muted-foreground">
+                  {formatDate(match.time, i18n.language)}
+                </span>
                 <Badge variant={match.win ? 'success' : 'destructive'}>
-                  {match.win ? 'Win' : 'Loss'}
+                  {match.win ? t('common.win') : t('common.loss')}
                 </Badge>
                 <span className="font-medium tabular-nums">{match.gsp!.toLocaleString()}</span>
                 {delta !== null && (
@@ -81,7 +85,9 @@ export function GspMatchLog({
                 <Button
                   variant="outline"
                   size="icon-sm"
-                  aria-label={`Edit GSP entry from ${formatDate(match.time)}`}
+                  aria-label={t('gsp.log.editEntry', {
+                    date: formatDate(match.time, i18n.language),
+                  })}
                   onClick={() => onEdit(match)}
                 >
                   <Pencil />
@@ -89,7 +95,9 @@ export function GspMatchLog({
                 <Button
                   variant="outline"
                   size="icon-sm"
-                  aria-label={`Delete GSP entry from ${formatDate(match.time)}`}
+                  aria-label={t('gsp.log.deleteEntry', {
+                    date: formatDate(match.time, i18n.language),
+                  })}
                   onClick={() => onDelete(match)}
                 >
                   <Trash2 />
@@ -105,7 +113,7 @@ export function GspMatchLog({
             className="self-center"
             onClick={() => setShowAll((prev) => !prev)}
           >
-            {showAll ? 'Show recent only' : `Show all ${rows.length} entries`}
+            {showAll ? t('gsp.log.showRecent') : t('gsp.log.showAll', { count: rows.length })}
           </Button>
         )}
       </CardContent>

--- a/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
+++ b/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -21,12 +23,14 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip,
 function buildChartData(
   mmr: { time: number; value: number }[],
   glicko: { time: number; value: number }[],
+  t: TFunction,
+  locale: string,
 ) {
   const allTimes = [...new Set([...mmr.map((p) => p.time), ...glicko.map((p) => p.time)])].sort(
     (a, b) => a - b,
   );
-  const labels = allTimes.map((t) =>
-    new Date(t).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  const labels = allTimes.map((time) =>
+    new Date(time).toLocaleDateString(locale, { month: 'short', day: 'numeric' }),
   );
 
   const mmrByTime = new Map(mmr.map((p) => [p.time, p.value]));
@@ -36,13 +40,13 @@ function buildChartData(
     labels,
     datasets: [
       {
-        label: 'Est. MMR (normalized)',
+        label: t('gsp.vsGlicko.mmrLabel'),
         ...redLineDataset(),
         spanGaps: true,
         data: allTimes.map((t) => mmrByTime.get(t) ?? null),
       },
       {
-        label: 'Glicko-2 (normalized)',
+        label: t('gsp.vsGlicko.glickoLabel'),
         borderColor: chartColors.tick,
         backgroundColor: chartColors.tick,
         pointBackgroundColor: chartColors.tick,
@@ -95,6 +99,7 @@ export function GspVsGlicko({
   allMatches: Match[];
   settings: GspSettings;
 }) {
+  const { t, i18n } = useTranslation();
   const { periods } = computeRatingHistory(allMatches);
 
   if (gspSeries.length < GSP_VS_GLICKO_MIN_POINTS || periods.length < GSP_VS_GLICKO_MIN_POINTS) {
@@ -110,19 +115,16 @@ export function GspVsGlicko({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Est. MMR vs Glicko-2</CardTitle>
+        <CardTitle>{t('gsp.vsGlicko.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <div className="h-64">
-          <Line data={buildChartData(mmr, glicko)} options={buildChartOptions()} />
+          <Line
+            data={buildChartData(mmr, glicko, t, i18n.language)}
+            options={buildChartOptions()}
+          />
         </div>
-        <p className="text-xs text-muted-foreground">
-          Your quickplay rating (estimated MMR for this fighter, community-reverse-engineered model)
-          vs. your overall Glicko-2 rating (every fighter/session) — both normalized to 0-100 over
-          this window since their raw scales are unrelated. Rating-vs-rating makes the shapes
-          honestly comparable; divergence usually means your quickplay form differs from your
-          overall form.
-        </p>
+        <p className="text-xs text-muted-foreground">{t('gsp.vsGlicko.caption')}</p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { Fighter, GspPoint, GspSettings } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -46,6 +47,7 @@ export function QuickLogger({
   lastPoint: GspPoint | null;
   settings: GspSettings;
 }) {
+  const { t } = useTranslation();
   const lastGsp = lastPoint?.gsp ?? null;
   const createMatch = useCreateMatch();
   const [opponentFighterId, setOpponentFighterId] = useState<number | undefined>(undefined);
@@ -67,16 +69,16 @@ export function QuickLogger({
 
   async function handleSubmit() {
     if (!opponentFighterId) {
-      toast.error("Choose the opponent's character.");
+      toast.error(t('gsp.logger.chooseOpponent'));
       return;
     }
     if (!result) {
-      toast.error('Mark this match as a win or loss.');
+      toast.error(t('gsp.logger.chooseResult'));
       return;
     }
     const gsp = parseGspNumber(gspInput);
     if (gsp === null) {
-      toast.error('Enter the GSP shown after the match — commas are fine, e.g. 10,300,000.');
+      toast.error(t('gsp.logger.invalidGsp'));
       return;
     }
 
@@ -113,10 +115,12 @@ export function QuickLogger({
       });
       const deltaLabel =
         delta === null ? '' : ` (${delta >= 0 ? '+' : ''}${delta.toLocaleString()} GSP)`;
-      toast.success(`Match logged! GSP ${gsp.toLocaleString()}${deltaLabel}${mmrDeltaLabel}`);
+      toast.success(
+        `${t('gsp.logger.logged', { gsp: gsp.toLocaleString() })}${deltaLabel}${mmrDeltaLabel}`,
+      );
       resetForNextMatch(gsp);
     } catch {
-      toast.error('Failed to log the match. Please try again.');
+      toast.error(t('gsp.logger.logFailed'));
     } finally {
       setSubmitting(false);
     }
@@ -126,7 +130,7 @@ export function QuickLogger({
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          Quick Logger
+          {t('gsp.logger.title')}
           <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground">
             <img src={fighter.url} alt="" className="size-5 object-contain" />
             {fighter.name}
@@ -137,14 +141,14 @@ export function QuickLogger({
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium" htmlFor="gsp-logger-opponent">
-              Opponent Character
+              {t('gsp.logger.opponentCharacter')}
             </label>
             <Select
               value={opponentFighterId !== undefined ? String(opponentFighterId) : undefined}
               onValueChange={(v) => setOpponentFighterId(Number(v))}
             >
               <SelectTrigger id="gsp-logger-opponent" className="w-full">
-                <SelectValue placeholder="Select a character" />
+                <SelectValue placeholder={t('gsp.logger.selectCharacter')} />
               </SelectTrigger>
               <SelectContent>
                 {alphaSpriteList.map((s) => (
@@ -158,7 +162,7 @@ export function QuickLogger({
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <span className="text-sm font-medium">Result</span>
+            <span className="text-sm font-medium">{t('matchForm.result')}</span>
             <ToggleGroup
               type="single"
               variant="outline"
@@ -167,11 +171,11 @@ export function QuickLogger({
                 if (value === 'win' || value === 'loss') setResult(value);
               }}
             >
-              <ToggleGroupItem value="win" aria-label="Win">
-                Win
+              <ToggleGroupItem value="win" aria-label={t('common.win')}>
+                {t('common.win')}
               </ToggleGroupItem>
-              <ToggleGroupItem value="loss" aria-label="Loss">
-                Loss
+              <ToggleGroupItem value="loss" aria-label={t('common.loss')}>
+                {t('common.loss')}
               </ToggleGroupItem>
             </ToggleGroup>
           </div>
@@ -180,7 +184,7 @@ export function QuickLogger({
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium" htmlFor="gsp-logger-gsp">
-              GSP After Match
+              {t('gsp.logger.gspAfterMatch')}
             </label>
             {/* type="text": browsers reject comma pastes into type="number"
                 outright, and elitegsp.com / the game's UI both format GSP
@@ -191,13 +195,13 @@ export function QuickLogger({
               inputMode="numeric"
               value={gspInput}
               onChange={(e) => setGspInput(e.target.value)}
-              placeholder="e.g. 9,420,000"
+              placeholder={t('gsp.logger.gspPlaceholder')}
             />
           </div>
 
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium" htmlFor="gsp-logger-stage">
-              Stage (optional)
+              {t('gsp.logger.stageOptional')}
             </label>
             <Select value={String(stageId)} onValueChange={(v) => setStageId(Number(v))}>
               <SelectTrigger id="gsp-logger-stage" className="w-full">
@@ -208,7 +212,7 @@ export function QuickLogger({
                   {NO_SELECTION_STAGE.name}
                 </SelectItem>
                 <SelectGroup>
-                  <SelectLabel>All stages</SelectLabel>
+                  <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
                   {alphaStageList.map((s) => (
                     <SelectItem key={s.id} value={String(s.id)}>
                       <StageOption stage={s} />
@@ -221,7 +225,7 @@ export function QuickLogger({
         </div>
 
         <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
-          {submitting ? 'Logging...' : 'Log Match'}
+          {submitting ? t('gsp.logger.logging') : t('gsp.logger.logMatch')}
         </Button>
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Gsp/components/RoadToElite.tsx
+++ b/apps/web/src/pages/Gsp/components/RoadToElite.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { PartyPopper } from 'lucide-react';
 import type { GspPoint, GspSettings } from '@smash-tracker/shared';
 import {
@@ -28,6 +29,7 @@ import { useNowMs } from '../lib/useNowMs';
  * "from your own GSP history" cross-check line, when it can compute.
  */
 export function RoadToElite({ series, settings }: { series: GspPoint[]; settings: GspSettings }) {
+  const { t } = useTranslation();
   const nowMs = useNowMs();
   const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const winRate = getRecentGspWinRate(series) ?? 0;
@@ -50,66 +52,65 @@ export function RoadToElite({ series, settings }: { series: GspPoint[]; settings
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Road to Elite</CardTitle>
+        <CardTitle>{t('gsp.road.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         {mmrProjection === null ? (
-          <p className="text-sm text-muted-foreground">
-            Log a match with a GSP reading for this fighter to see a projection.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('gsp.road.empty')}</p>
         ) : mmrProjection.status === 'already-elite' ? (
           <div className="flex items-center gap-2 text-emerald-500">
             <PartyPopper className="size-6" />
-            <p className="text-lg font-semibold">You&apos;re already in Elite Smash!</p>
+            <p className="text-lg font-semibold">{t('gsp.road.alreadyElite')}</p>
           </div>
         ) : mmrProjection.status === 'equilibrium' ? (
           <>
-            <p className="text-lg font-semibold">Holding steady at your level</p>
+            <p className="text-lg font-semibold">{t('gsp.road.equilibriumTitle')}</p>
             <p className="text-sm text-muted-foreground">
-              At your current {Math.round(winRate * 100)}% win rate, matchmaking thinks this is your
-              level right now — every match trades ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR both ways, so
-              a &gt;50% win rate is what moves you up, not more matches. Keep working the matchups
-              on this page and the number will follow.
+              {t('gsp.road.equilibriumBody', {
+                rate: Math.round(winRate * 100),
+                points: ASSUMED_MMR_POINTS_PER_MATCH,
+              })}
             </p>
           </>
         ) : mmrProjection.status === 'capped' ? (
           <>
-            <p className="text-2xl font-bold">more than {MAX_PROJECTED_MATCHES} net wins</p>
-            <p className="text-sm text-muted-foreground">
-              Your win rate is barely above 50%, so expected progress per match is tiny — a small
-              bump in win rate shortens this dramatically.
+            <p className="text-2xl font-bold">
+              {t('gsp.road.cappedTitle', { max: MAX_PROJECTED_MATCHES })}
             </p>
+            <p className="text-sm text-muted-foreground">{t('gsp.road.cappedBody')}</p>
           </>
         ) : (
           <>
             <p className="text-2xl font-bold">
-              ~{mmrProjection.matchesNeeded} more match
-              {mmrProjection.matchesNeeded === 1 ? '' : 'es'}
+              {t('gsp.road.projected', { count: mmrProjection.matchesNeeded })}
             </p>
             <p className="text-sm text-muted-foreground">
-              to Elite (MMR {GSP_MODEL.ELITE_MMR}) at your ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR/match
-              and {Math.round(winRate * 100)}% win rate (community model estimate)
+              {t('gsp.road.projectedCaption', {
+                elite: GSP_MODEL.ELITE_MMR,
+                points: ASSUMED_MMR_POINTS_PER_MATCH,
+                rate: Math.round(winRate * 100),
+              })}
             </p>
             {decayProjection && (
               <p className="text-xs text-muted-foreground">
-                From your own GSP history instead: ~{decayProjection.matchesNeededLabel} more match
-                {decayProjection.matchesNeededLabel === '1' ? '' : 'es'} (V10&apos;s{' '}
-                {decayProjection.model === 'exponential-decay'
-                  ? 'shrinking-gains fit'
-                  : 'flat-average fallback'}
-                ).
+                {t(
+                  decayProjection.matchesNeededLabel === '1'
+                    ? 'gsp.road.historyOne'
+                    : 'gsp.road.historyMany',
+                  {
+                    label: decayProjection.matchesNeededLabel,
+                    model: t(
+                      decayProjection.model === 'exponential-decay'
+                        ? 'gsp.road.decayFit'
+                        : 'gsp.road.flatFallback',
+                    ),
+                  },
+                )}
               </p>
             )}
             <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
-              <li>
-                Assumes matchmaking keeps pairing you against similar-MMR opponents (each match
-                trades ~{ASSUMED_MMR_POINTS_PER_MATCH} MMR, the community table&apos;s value for an
-                even match) and that your recent win rate holds.
-              </li>
-              <li>
-                Built on the community-reverse-engineered MMR model, not Nintendo&apos;s algorithm —
-                a simulation, not a guarantee.
-              </li>
+              <li>{t('gsp.road.assumption1', { points: ASSUMED_MMR_POINTS_PER_MATCH })}</li>
+              <li>{t('gsp.road.assumption2')}</li>
             </ul>
           </>
         )}


### PR DESCRIPTION
## Summary

Stacked on #143 (which stacks on #142; GitHub retargets as they merge). Localizes `pages/Gsp/` into `gsp.*` keys across all six locales:

- Page chrome: loading/empty states, header + model disclaimer, the shared delete confirmation and its toasts.
- Hero row: current GSP, estimated MMR (incl. tail-reading warning and model-accuracy caption), the editable Elite-threshold card (aria labels, recalibration toasts, computed caption), distance to Elite, recent win rate.
- GSP/MMR curve: title, view-toggle aria labels, both captions, click-to-edit hint, locked state, and chart legend labels.
- Quick logger: labels, placeholders, validation toasts, and the logged-match toast.
- GSP log rows (win/loss badges, edit/delete aria labels, show all/recent), gains analysis stat blocks + chart tooltip, all four Road to Elite projection states, and the MMR-vs-Glicko overlay.

## Translation notes

- Japanese uses the actual in-game terms: 世界戦闘力 for GSP in prose (GSP kept as the metric abbreviation) and VIPマッチ/VIPボーダー for Elite Smash/Elite threshold. Other locales keep "Elite Smash" as the community term (fr: Smash Élite, matching the French game UI).
- Numeric GSP examples in placeholders keep comma/space separators only (what `parseGspNumber` accepts).

## Implementation notes

- The exported pure chart builders (`buildGspCurveData`, `buildMmrCurveData`, `buildGspCurveOptions`, plus the private ones in GainsAnalysis/GspVsGlicko) now take `t` and/or a locale so legend labels and date axes localize; `GspCurve.test.ts` passes the bundled-English `i18n.t` so its label assertions stay unchanged.
- Date formatting throughout the page (curve labels/tooltips, log rows, vs-Glicko axis) uses the active language instead of hardcoded `en-US`.
- The quick logger reuses `matchForm.result` / `matchForm.allStages` / `common.win|loss` rather than duplicating keys.
- Plural forms via i18next `_one`/`_other` for "~N more match(es)" and "last N games"; ja carries identical values in both forms to satisfy the key-parity CI test.

## Testing

- `pnpm --filter @smash-tracker/web lint` ✅ (0 errors)
- `pnpm --filter @smash-tracker/web typecheck` ✅
- `pnpm --filter @smash-tracker/web test` ✅ 926/926

🤖 Generated with [Claude Code](https://claude.com/claude-code)