### PR TITLE
Localization phase 2d: Match Data page + VOD notes dialog

### DIFF
--- a/apps/web/src/components/vod/VodNotesDialog.tsx
+++ b/apps/web/src/components/vod/VodNotesDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Plus, Trash2 } from 'lucide-react';
 import type { Match, UpdateMatchInput, VodTimestamp } from '@smash-tracker/shared';
@@ -64,6 +65,7 @@ export function VodNotesDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const { t } = useTranslation();
   const updateMatch = useUpdateMatch();
   const [url, setUrl] = useState(match.vodUrl ?? '');
   const [timestamps, setTimestamps] = useState<VodTimestamp[]>(match.vodTimestamps ?? []);
@@ -85,16 +87,16 @@ export function VodNotesDialog({
   function handleAddTimestamp() {
     const seconds = parseTimestamp(timeInput);
     if (seconds == null) {
-      setTimeError('Enter a time as m:ss or h:mm:ss');
+      setTimeError(t('shared.vod.timeFormatError'));
       return;
     }
     const note = noteInput.trim();
     if (!note) {
-      setTimeError('Enter a note for this timestamp');
+      setTimeError(t('shared.vod.noteRequired'));
       return;
     }
     if (timestamps.length >= MAX_TIMESTAMPS) {
-      setTimeError(`Limit ${MAX_TIMESTAMPS} timestamps per match`);
+      setTimeError(t('shared.vod.timestampLimit', { max: MAX_TIMESTAMPS }));
       return;
     }
     setTimestamps((prev) => [...prev, { seconds, note }].sort((a, b) => a.seconds - b.seconds));
@@ -115,10 +117,10 @@ export function VodNotesDialog({
     });
     try {
       await updateMatch.mutateAsync({ id: match.id, input });
-      toast.success('VOD notes saved!');
+      toast.success(t('shared.vod.saved'));
       onOpenChange(false);
     } catch {
-      toast.error('Failed to save VOD notes. Please try again.');
+      toast.error(t('shared.vod.saveFailed'));
     }
   }
 
@@ -126,16 +128,13 @@ export function VodNotesDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>VOD Notes</DialogTitle>
-          <DialogDescription>
-            Attach a VOD link and timestamped notes, e.g. &quot;2:41 — missed punish on
-            shield&quot;.
-          </DialogDescription>
+          <DialogTitle>{t('shared.vod.title')}</DialogTitle>
+          <DialogDescription>{t('shared.vod.description')}</DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="vod-url">VOD URL</Label>
+            <Label htmlFor="vod-url">{t('shared.vod.url')}</Label>
             <Input
               id="vod-url"
               type="url"
@@ -146,11 +145,11 @@ export function VodNotesDialog({
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label>Timestamps</Label>
+            <Label>{t('shared.vod.timestamps')}</Label>
             {timestamps.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No timestamp notes yet.</p>
+              <p className="text-sm text-muted-foreground">{t('shared.vod.noTimestamps')}</p>
             ) : (
-              <ul className="flex flex-col gap-2" aria-label="Timestamp notes">
+              <ul className="flex flex-col gap-2" aria-label={t('shared.vod.timestampsAria')}>
                 {timestamps.map((stamp, index) => (
                   <li
                     key={`${stamp.seconds}-${index}`}
@@ -175,7 +174,9 @@ export function VodNotesDialog({
                       type="button"
                       variant="outline"
                       size="icon-sm"
-                      aria-label={`Delete timestamp ${formatTimestamp(stamp.seconds)}`}
+                      aria-label={t('shared.vod.deleteTimestamp', {
+                        time: formatTimestamp(stamp.seconds),
+                      })}
                       onClick={() => handleRemoveTimestamp(index)}
                     >
                       <Trash2 />
@@ -192,8 +193,8 @@ export function VodNotesDialog({
                   setTimeInput(e.target.value);
                   setTimeError(null);
                 }}
-                placeholder="m:ss"
-                aria-label="Timestamp time"
+                placeholder={t('shared.vod.timePlaceholder')}
+                aria-label={t('shared.vod.timeAria')}
                 className="w-24"
               />
               <Input
@@ -202,14 +203,14 @@ export function VodNotesDialog({
                   setNoteInput(e.target.value);
                   setTimeError(null);
                 }}
-                placeholder="Note"
-                aria-label="Timestamp note"
+                placeholder={t('shared.vod.notePlaceholder')}
+                aria-label={t('shared.vod.noteAria')}
                 maxLength={200}
                 className="min-w-[10rem] flex-1"
               />
               <Button type="button" variant="outline" size="icon-sm" onClick={handleAddTimestamp}>
                 <Plus />
-                <span className="sr-only">Add timestamp</span>
+                <span className="sr-only">{t('shared.vod.addTimestamp')}</span>
               </Button>
             </div>
             {timeError && <p className="text-sm text-destructive">{timeError}</p>}
@@ -218,10 +219,10 @@ export function VodNotesDialog({
 
         <DialogFooter className="mt-4">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button type="button" onClick={handleSave} disabled={updateMatch.isPending}>
-            Save
+            {t('common.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -44,7 +44,11 @@
     "casual": "Casual",
     "competitive": "Kompetitiv",
     "unknown": "Unbekannt",
-    "notAvailable": "k. A."
+    "notAvailable": "k. A.",
+    "noMatchData": "Noch keine Match-Daten vorhanden.",
+    "rate": "Quote",
+    "games_one": "{{count}} Match",
+    "games_other": "{{count}} Matches"
   },
   "filters": {
     "sourceAria": "Matches nach Quelle filtern",
@@ -56,6 +60,37 @@
     "months12": "12 M"
   },
   "shared": {
+    "noFighters": {
+      "title": "Du hast noch keine Kämpfer ausgewählt!",
+      "subtitle": "Wähle deine Main- und Secondary-Kämpfer, um Matches zu erfassen.",
+      "choosePrimary": "Main-Kämpfer wählen",
+      "chooseSecondary": "Secondary-Kämpfer wählen"
+    },
+    "matchDelete": {
+      "aria": "Match löschen",
+      "confirmTitle": "Dieses Match löschen?",
+      "deleted": "Match gelöscht!",
+      "deleteFailed": "Match konnte nicht gelöscht werden. Bitte erneut versuchen."
+    },
+    "vod": {
+      "title": "VOD-Notizen",
+      "description": "Hänge einen VOD-Link und Notizen mit Zeitstempel an, z. B. „2:41 — Punish auf Schild verpasst“.",
+      "url": "VOD-URL",
+      "timestamps": "Zeitstempel",
+      "noTimestamps": "Noch keine Zeitstempel-Notizen.",
+      "timestampsAria": "Zeitstempel-Notizen",
+      "deleteTimestamp": "Zeitstempel {{time}} löschen",
+      "timePlaceholder": "m:ss",
+      "timeAria": "Zeitstempel-Zeit",
+      "notePlaceholder": "Notiz",
+      "noteAria": "Zeitstempel-Notiz",
+      "addTimestamp": "Zeitstempel hinzufügen",
+      "timeFormatError": "Gib eine Zeit als m:ss oder h:mm:ss ein",
+      "noteRequired": "Gib eine Notiz für diesen Zeitstempel ein",
+      "timestampLimit": "Maximal {{max}} Zeitstempel pro Match",
+      "saved": "VOD-Notizen gespeichert!",
+      "saveFailed": "VOD-Notizen konnten nicht gespeichert werden. Bitte erneut versuchen."
+    },
     "filteredNotice": {
       "message": "Keine Matches entsprechen den aktuellen Filtern.",
       "clear": "Filter zurücksetzen"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "Dein Dashboard wird geladen...",
-    "empty": {
-      "title": "Du hast noch keine Kämpfer ausgewählt!",
-      "subtitle": "Wähle deine Main- und Secondary-Kämpfer, um Matches zu erfassen.",
-      "choosePrimary": "Main-Kämpfer wählen",
-      "chooseSecondary": "Secondary-Kämpfer wählen"
-    },
     "hero": {
       "overallRecord": "Gesamtbilanz",
       "winRate": "{{rate}} % Winrate",
-      "games_one": "{{count}} Match",
-      "games_other": "{{count}} Matches",
-      "noMatchData": "Noch keine Match-Daten vorhanden.",
       "form": "Form",
       "streakWin": "{{count}}S",
       "streakLoss": "{{count}}N",
@@ -107,9 +133,6 @@
       "ratingDown": "Wertung niedriger als in der letzten Sitzung",
       "ratingUnchanged": "Wertung unverändert zur letzten Sitzung"
     },
-    "tracker": {
-      "rate": "Quote"
-    },
     "formCurve": {
       "title": "Formkurve",
       "window": "Fenster",
@@ -124,11 +147,7 @@
       "title": "Letzte Matches",
       "limit": "Limit",
       "limitAria": "Match-Limit",
-      "empty": "Noch keine Matches erfasst.",
-      "deleteAria": "Match löschen",
-      "confirmTitle": "Dieses Match löschen?",
-      "deleted": "Match gelöscht!",
-      "deleteFailed": "Match konnte nicht gelöscht werden. Bitte erneut versuchen."
+      "empty": "Noch keine Matches erfasst."
     },
     "stages": {
       "title": "Meistgespielte Stages",
@@ -341,6 +360,53 @@
       "mmrLabel": "Gesch. MMR (normalisiert)",
       "glickoLabel": "Glicko-2 (normalisiert)",
       "caption": "Dein Quickplay-Rating (geschätzte MMR für diesen Kämpfer, Community-Modell per Reverse Engineering) gegen dein gesamtes Glicko-2-Rating (alle Kämpfer/Sitzungen) — beide über dieses Fenster auf 0-100 normalisiert, da ihre Rohskalen nichts miteinander zu tun haben. Rating gegen Rating macht die Formen ehrlich vergleichbar; Abweichungen bedeuten meist, dass deine Quickplay-Form von deiner Gesamtform abweicht."
+    }
+  },
+  "matchData": {
+    "loading": "Match-Daten werden geladen...",
+    "title": "Match-Verlauf",
+    "noMatches": "Du hast noch keine Matches — erfasse eins und schau hier wieder vorbei, um deine Daten zu sehen!",
+    "goToDashboard": "Zum Dashboard",
+    "table": {
+      "columns": {
+        "date": "Datum",
+        "fighter": "Kämpfer",
+        "opponentFighter": "Gegner",
+        "opponentName": "Gegnername",
+        "stage": "Stage",
+        "matchType": "Typ",
+        "win": "Ergebnis",
+        "tournament": "Turnier",
+        "notes": "Notizen",
+        "manage": "Verwalten"
+      },
+      "editVod": "VOD-Notizen bearbeiten",
+      "addVod": "VOD-Notizen hinzufügen",
+      "synced": "Synchronisiert",
+      "syncedTitle": "Synchronisiert von {{source}} — die Spieldaten verwaltet der Sync",
+      "editMatch": "Match bearbeiten",
+      "searchPlaceholder": "{{count}} Einträge durchsuchen...",
+      "searchAria": "Matches filtern",
+      "allOption": "Alle: {{label}}",
+      "columnsButton": "Spalten",
+      "toggleColumns": "Spalten ein-/ausblenden",
+      "exportCsv": "CSV exportieren",
+      "noneFound": "Keine Matches gefunden.",
+      "pageOf": "Seite {{page}} von {{total}}",
+      "rowsPerPage": "Zeilen pro Seite",
+      "showN": "{{count}} anzeigen"
+    },
+    "roster": {
+      "title": "Roster-Nutzung",
+      "showAll": "Alle anzeigen ({{count}} weitere)",
+      "showLess": "Weniger anzeigen"
+    },
+    "stages": {
+      "title": "Stage-Auswertung",
+      "selectAria": "Stage auswählen",
+      "noneOnStage": "Keine erfassten Matches auf dieser Stage.",
+      "winsShort": "{{count}}S",
+      "lossesShort": "{{count}}N"
     }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -44,7 +44,11 @@
     "casual": "Casual",
     "competitive": "Competitive",
     "unknown": "Unknown",
-    "notAvailable": "n/a"
+    "notAvailable": "n/a",
+    "noMatchData": "No match data to report yet.",
+    "rate": "Rate",
+    "games_one": "{{count}} game",
+    "games_other": "{{count}} games"
   },
   "filters": {
     "sourceAria": "Filter matches by source",
@@ -56,6 +60,37 @@
     "months12": "12m"
   },
   "shared": {
+    "noFighters": {
+      "title": "You haven't picked any fighters yet!",
+      "subtitle": "Choose your primary and secondary fighters to start tracking matches.",
+      "choosePrimary": "Choose Primary Fighters",
+      "chooseSecondary": "Choose Secondary Fighters"
+    },
+    "matchDelete": {
+      "aria": "Delete match",
+      "confirmTitle": "Delete this match?",
+      "deleted": "Match deleted!",
+      "deleteFailed": "Failed to delete match. Please try again."
+    },
+    "vod": {
+      "title": "VOD Notes",
+      "description": "Attach a VOD link and timestamped notes, e.g. \"2:41 — missed punish on shield\".",
+      "url": "VOD URL",
+      "timestamps": "Timestamps",
+      "noTimestamps": "No timestamp notes yet.",
+      "timestampsAria": "Timestamp notes",
+      "deleteTimestamp": "Delete timestamp {{time}}",
+      "timePlaceholder": "m:ss",
+      "timeAria": "Timestamp time",
+      "notePlaceholder": "Note",
+      "noteAria": "Timestamp note",
+      "addTimestamp": "Add timestamp",
+      "timeFormatError": "Enter a time as m:ss or h:mm:ss",
+      "noteRequired": "Enter a note for this timestamp",
+      "timestampLimit": "Limit {{max}} timestamps per match",
+      "saved": "VOD notes saved!",
+      "saveFailed": "Failed to save VOD notes. Please try again."
+    },
     "filteredNotice": {
       "message": "No matches match the current filters.",
       "clear": "Clear filters"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "Loading your dashboard...",
-    "empty": {
-      "title": "You haven't picked any fighters yet!",
-      "subtitle": "Choose your primary and secondary fighters to start tracking matches.",
-      "choosePrimary": "Choose Primary Fighters",
-      "chooseSecondary": "Choose Secondary Fighters"
-    },
     "hero": {
       "overallRecord": "Overall Record",
       "winRate": "{{rate}}% win rate",
-      "games_one": "{{count}} game",
-      "games_other": "{{count}} games",
-      "noMatchData": "No match data to report yet.",
       "form": "Form",
       "streakWin": "{{count}}W",
       "streakLoss": "{{count}}L",
@@ -107,9 +133,6 @@
       "ratingDown": "Rating down from last session",
       "ratingUnchanged": "Rating unchanged from last session"
     },
-    "tracker": {
-      "rate": "Rate"
-    },
     "formCurve": {
       "title": "Form Curve",
       "window": "Window",
@@ -124,11 +147,7 @@
       "title": "Previous Matches",
       "limit": "Limit",
       "limitAria": "Match limit",
-      "empty": "No matches recorded yet.",
-      "deleteAria": "Delete match",
-      "confirmTitle": "Delete this match?",
-      "deleted": "Match deleted!",
-      "deleteFailed": "Failed to delete match. Please try again."
+      "empty": "No matches recorded yet."
     },
     "stages": {
       "title": "Most-Played Stages",
@@ -341,6 +360,53 @@
       "mmrLabel": "Est. MMR (normalized)",
       "glickoLabel": "Glicko-2 (normalized)",
       "caption": "Your quickplay rating (estimated MMR for this fighter, community-reverse-engineered model) vs. your overall Glicko-2 rating (every fighter/session) — both normalized to 0-100 over this window since their raw scales are unrelated. Rating-vs-rating makes the shapes honestly comparable; divergence usually means your quickplay form differs from your overall form."
+    }
+  },
+  "matchData": {
+    "loading": "Loading match data...",
+    "title": "Match History",
+    "noMatches": "You have no matches, report a match and check back here to view match data!",
+    "goToDashboard": "Go to Dashboard",
+    "table": {
+      "columns": {
+        "date": "Date",
+        "fighter": "Fighter",
+        "opponentFighter": "Opponent",
+        "opponentName": "Opponent Name",
+        "stage": "Stage",
+        "matchType": "Type",
+        "win": "Result",
+        "tournament": "Tournament",
+        "notes": "Notes",
+        "manage": "Manage"
+      },
+      "editVod": "Edit VOD notes",
+      "addVod": "Add VOD notes",
+      "synced": "Synced",
+      "syncedTitle": "Synced from {{source}} — game data is managed by sync",
+      "editMatch": "Edit match",
+      "searchPlaceholder": "Search {{count}} records...",
+      "searchAria": "Filter matches",
+      "allOption": "All {{label}}",
+      "columnsButton": "Columns",
+      "toggleColumns": "Toggle columns",
+      "exportCsv": "Export CSV",
+      "noneFound": "No matches found.",
+      "pageOf": "Page {{page}} of {{total}}",
+      "rowsPerPage": "Rows per page",
+      "showN": "Show {{count}}"
+    },
+    "roster": {
+      "title": "Roster Usage",
+      "showAll": "Show all ({{count}} more)",
+      "showLess": "Show less"
+    },
+    "stages": {
+      "title": "Stage Breakdown",
+      "selectAria": "Select stage",
+      "noneOnStage": "No reported matches on this stage.",
+      "winsShort": "{{count}}W",
+      "lossesShort": "{{count}}L"
     }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -44,7 +44,11 @@
     "casual": "Casual",
     "competitive": "Competitivo",
     "unknown": "Desconocido",
-    "notAvailable": "n/d"
+    "notAvailable": "n/d",
+    "noMatchData": "Aún no hay datos de partidas.",
+    "rate": "Ratio",
+    "games_one": "{{count}} partida",
+    "games_other": "{{count}} partidas"
   },
   "filters": {
     "sourceAria": "Filtrar partidas por origen",
@@ -56,6 +60,37 @@
     "months12": "12 m"
   },
   "shared": {
+    "noFighters": {
+      "title": "¡Aún no has elegido ningún luchador!",
+      "subtitle": "Elige tus luchadores principal y secundarios para empezar a registrar partidas.",
+      "choosePrimary": "Elegir luchadores principales",
+      "chooseSecondary": "Elegir luchadores secundarios"
+    },
+    "matchDelete": {
+      "aria": "Eliminar partida",
+      "confirmTitle": "¿Eliminar esta partida?",
+      "deleted": "¡Partida eliminada!",
+      "deleteFailed": "No se pudo eliminar la partida. Inténtalo de nuevo."
+    },
+    "vod": {
+      "title": "Notas de VOD",
+      "description": "Adjunta un enlace al VOD y notas con marca de tiempo, p. ej. «2:41 — castigo fallado al escudo».",
+      "url": "URL del VOD",
+      "timestamps": "Marcas de tiempo",
+      "noTimestamps": "Aún no hay notas con marca de tiempo.",
+      "timestampsAria": "Notas con marca de tiempo",
+      "deleteTimestamp": "Eliminar marca de tiempo {{time}}",
+      "timePlaceholder": "m:ss",
+      "timeAria": "Tiempo de la marca",
+      "notePlaceholder": "Nota",
+      "noteAria": "Nota de la marca",
+      "addTimestamp": "Añadir marca de tiempo",
+      "timeFormatError": "Introduce un tiempo como m:ss o h:mm:ss",
+      "noteRequired": "Introduce una nota para esta marca de tiempo",
+      "timestampLimit": "Máximo {{max}} marcas de tiempo por partida",
+      "saved": "¡Notas de VOD guardadas!",
+      "saveFailed": "No se pudieron guardar las notas de VOD. Inténtalo de nuevo."
+    },
     "filteredNotice": {
       "message": "Ninguna partida coincide con los filtros actuales.",
       "clear": "Borrar filtros"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "Cargando tu panel...",
-    "empty": {
-      "title": "¡Aún no has elegido ningún luchador!",
-      "subtitle": "Elige tus luchadores principal y secundarios para empezar a registrar partidas.",
-      "choosePrimary": "Elegir luchadores principales",
-      "chooseSecondary": "Elegir luchadores secundarios"
-    },
     "hero": {
       "overallRecord": "Historial general",
       "winRate": "{{rate}}% de victorias",
-      "games_one": "{{count}} partida",
-      "games_other": "{{count}} partidas",
-      "noMatchData": "Aún no hay datos de partidas.",
       "form": "Forma",
       "streakWin": "{{count}}V",
       "streakLoss": "{{count}}D",
@@ -107,9 +133,6 @@
       "ratingDown": "Puntuación a la baja desde la última sesión",
       "ratingUnchanged": "Puntuación sin cambios desde la última sesión"
     },
-    "tracker": {
-      "rate": "Ratio"
-    },
     "formCurve": {
       "title": "Curva de forma",
       "window": "Ventana",
@@ -124,11 +147,7 @@
       "title": "Partidas anteriores",
       "limit": "Límite",
       "limitAria": "Límite de partidas",
-      "empty": "Aún no hay partidas registradas.",
-      "deleteAria": "Eliminar partida",
-      "confirmTitle": "¿Eliminar esta partida?",
-      "deleted": "¡Partida eliminada!",
-      "deleteFailed": "No se pudo eliminar la partida. Inténtalo de nuevo."
+      "empty": "Aún no hay partidas registradas."
     },
     "stages": {
       "title": "Escenarios más jugados",
@@ -341,6 +360,53 @@
       "mmrLabel": "MMR est. (normalizado)",
       "glickoLabel": "Glicko-2 (normalizado)",
       "caption": "Tu nivel en quickplay (MMR estimado de este luchador, modelo de ingeniería inversa de la comunidad) frente a tu Glicko-2 global (todos los luchadores/sesiones) — ambos normalizados a 0-100 en esta ventana porque sus escalas no están relacionadas. Comparar nivel contra nivel hace las formas honestamente comparables; una divergencia suele significar que tu forma en quickplay difiere de tu forma general."
+    }
+  },
+  "matchData": {
+    "loading": "Cargando datos de partidas...",
+    "title": "Historial de partidas",
+    "noMatches": "No tienes partidas; registra una y vuelve aquí para ver los datos.",
+    "goToDashboard": "Ir al Panel",
+    "table": {
+      "columns": {
+        "date": "Fecha",
+        "fighter": "Luchador",
+        "opponentFighter": "Rival",
+        "opponentName": "Nombre del rival",
+        "stage": "Escenario",
+        "matchType": "Tipo",
+        "win": "Resultado",
+        "tournament": "Torneo",
+        "notes": "Notas",
+        "manage": "Gestionar"
+      },
+      "editVod": "Editar notas de VOD",
+      "addVod": "Añadir notas de VOD",
+      "synced": "Sincronizada",
+      "syncedTitle": "Sincronizada desde {{source}} — los datos los gestiona la sincronización",
+      "editMatch": "Editar partida",
+      "searchPlaceholder": "Buscar en {{count}} registros...",
+      "searchAria": "Filtrar partidas",
+      "allOption": "Todos: {{label}}",
+      "columnsButton": "Columnas",
+      "toggleColumns": "Mostrar u ocultar columnas",
+      "exportCsv": "Exportar CSV",
+      "noneFound": "No se encontraron partidas.",
+      "pageOf": "Página {{page}} de {{total}}",
+      "rowsPerPage": "Filas por página",
+      "showN": "Mostrar {{count}}"
+    },
+    "roster": {
+      "title": "Uso del plantel",
+      "showAll": "Mostrar todos ({{count}} más)",
+      "showLess": "Mostrar menos"
+    },
+    "stages": {
+      "title": "Desglose por escenario",
+      "selectAria": "Seleccionar escenario",
+      "noneOnStage": "No hay partidas registradas en este escenario.",
+      "winsShort": "{{count}}V",
+      "lossesShort": "{{count}}D"
     }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -44,7 +44,11 @@
     "casual": "Casual",
     "competitive": "Compétitif",
     "unknown": "Inconnu",
-    "notAvailable": "n/d"
+    "notAvailable": "n/d",
+    "noMatchData": "Pas encore de données de match.",
+    "rate": "Taux",
+    "games_one": "{{count}} match",
+    "games_other": "{{count}} matchs"
   },
   "filters": {
     "sourceAria": "Filtrer les matchs par source",
@@ -56,6 +60,37 @@
     "months12": "12 m"
   },
   "shared": {
+    "noFighters": {
+      "title": "Vous n'avez pas encore choisi de combattant !",
+      "subtitle": "Choisissez vos combattants principaux et secondaires pour commencer à suivre vos matchs.",
+      "choosePrimary": "Choisir les combattants principaux",
+      "chooseSecondary": "Choisir les combattants secondaires"
+    },
+    "matchDelete": {
+      "aria": "Supprimer le match",
+      "confirmTitle": "Supprimer ce match ?",
+      "deleted": "Match supprimé !",
+      "deleteFailed": "Échec de la suppression du match. Veuillez réessayer."
+    },
+    "vod": {
+      "title": "Notes VOD",
+      "description": "Ajoutez un lien VOD et des notes horodatées, p. ex. « 2:41 — punition ratée sur le bouclier ».",
+      "url": "URL de la VOD",
+      "timestamps": "Horodatages",
+      "noTimestamps": "Pas encore de notes horodatées.",
+      "timestampsAria": "Notes horodatées",
+      "deleteTimestamp": "Supprimer l'horodatage {{time}}",
+      "timePlaceholder": "m:ss",
+      "timeAria": "Temps de l'horodatage",
+      "notePlaceholder": "Note",
+      "noteAria": "Note de l'horodatage",
+      "addTimestamp": "Ajouter un horodatage",
+      "timeFormatError": "Saisissez un temps au format m:ss ou h:mm:ss",
+      "noteRequired": "Saisissez une note pour cet horodatage",
+      "timestampLimit": "Limite de {{max}} horodatages par match",
+      "saved": "Notes VOD enregistrées !",
+      "saveFailed": "Échec de l'enregistrement des notes VOD. Veuillez réessayer."
+    },
     "filteredNotice": {
       "message": "Aucun match ne correspond aux filtres actuels.",
       "clear": "Effacer les filtres"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "Chargement de votre tableau de bord...",
-    "empty": {
-      "title": "Vous n'avez pas encore choisi de combattant !",
-      "subtitle": "Choisissez vos combattants principaux et secondaires pour commencer à suivre vos matchs.",
-      "choosePrimary": "Choisir les combattants principaux",
-      "chooseSecondary": "Choisir les combattants secondaires"
-    },
     "hero": {
       "overallRecord": "Bilan global",
       "winRate": "{{rate}}% de victoires",
-      "games_one": "{{count}} match",
-      "games_other": "{{count}} matchs",
-      "noMatchData": "Pas encore de données de match.",
       "form": "Forme",
       "streakWin": "{{count}}V",
       "streakLoss": "{{count}}D",
@@ -107,9 +133,6 @@
       "ratingDown": "Classement en baisse depuis la dernière session",
       "ratingUnchanged": "Classement inchangé depuis la dernière session"
     },
-    "tracker": {
-      "rate": "Taux"
-    },
     "formCurve": {
       "title": "Courbe de forme",
       "window": "Fenêtre",
@@ -124,11 +147,7 @@
       "title": "Matchs précédents",
       "limit": "Limite",
       "limitAria": "Nombre de matchs",
-      "empty": "Aucun match enregistré pour l'instant.",
-      "deleteAria": "Supprimer le match",
-      "confirmTitle": "Supprimer ce match ?",
-      "deleted": "Match supprimé !",
-      "deleteFailed": "Échec de la suppression du match. Veuillez réessayer."
+      "empty": "Aucun match enregistré pour l'instant."
     },
     "stages": {
       "title": "Stages les plus joués",
@@ -341,6 +360,53 @@
       "mmrLabel": "MMR est. (normalisé)",
       "glickoLabel": "Glicko-2 (normalisé)",
       "caption": "Votre niveau en quickplay (MMR estimé pour ce combattant, modèle communautaire par rétro-ingénierie) face à votre classement Glicko-2 global (tous combattants/sessions) — les deux normalisés de 0 à 100 sur cette fenêtre, leurs échelles brutes n'étant pas liées. Comparer classement contre classement rend les formes honnêtement comparables ; une divergence signifie généralement que votre forme en quickplay diffère de votre forme générale."
+    }
+  },
+  "matchData": {
+    "loading": "Chargement des données de matchs...",
+    "title": "Historique des matchs",
+    "noMatches": "Vous n'avez aucun match : enregistrez-en un puis revenez ici pour voir vos données.",
+    "goToDashboard": "Aller au tableau de bord",
+    "table": {
+      "columns": {
+        "date": "Date",
+        "fighter": "Combattant",
+        "opponentFighter": "Adversaire",
+        "opponentName": "Nom de l'adversaire",
+        "stage": "Stage",
+        "matchType": "Type",
+        "win": "Résultat",
+        "tournament": "Tournoi",
+        "notes": "Notes",
+        "manage": "Gérer"
+      },
+      "editVod": "Modifier les notes VOD",
+      "addVod": "Ajouter des notes VOD",
+      "synced": "Synchronisé",
+      "syncedTitle": "Synchronisé depuis {{source}} — les données sont gérées par la synchronisation",
+      "editMatch": "Modifier le match",
+      "searchPlaceholder": "Rechercher parmi {{count}} entrées...",
+      "searchAria": "Filtrer les matchs",
+      "allOption": "Tous : {{label}}",
+      "columnsButton": "Colonnes",
+      "toggleColumns": "Afficher/masquer les colonnes",
+      "exportCsv": "Exporter en CSV",
+      "noneFound": "Aucun match trouvé.",
+      "pageOf": "Page {{page}} sur {{total}}",
+      "rowsPerPage": "Lignes par page",
+      "showN": "Afficher {{count}}"
+    },
+    "roster": {
+      "title": "Utilisation du roster",
+      "showAll": "Tout afficher ({{count}} de plus)",
+      "showLess": "Afficher moins"
+    },
+    "stages": {
+      "title": "Détail par stage",
+      "selectAria": "Sélectionner un stage",
+      "noneOnStage": "Aucun match enregistré sur ce stage.",
+      "winsShort": "{{count}}V",
+      "lossesShort": "{{count}}D"
     }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -44,7 +44,11 @@
     "casual": "カジュアル",
     "competitive": "大会",
     "unknown": "不明",
-    "notAvailable": "—"
+    "notAvailable": "—",
+    "noMatchData": "まだ対戦データがありません。",
+    "rate": "勝率",
+    "games_one": "{{count}}戦",
+    "games_other": "{{count}}戦"
   },
   "filters": {
     "sourceAria": "対戦を種別で絞り込む",
@@ -56,6 +60,37 @@
     "months12": "12ヶ月"
   },
   "shared": {
+    "noFighters": {
+      "title": "まだファイターを選んでいません！",
+      "subtitle": "メインとサブのファイターを選んで、対戦の記録を始めましょう。",
+      "choosePrimary": "メインファイターを選ぶ",
+      "chooseSecondary": "サブファイターを選ぶ"
+    },
+    "matchDelete": {
+      "aria": "対戦を削除",
+      "confirmTitle": "この対戦を削除しますか？",
+      "deleted": "対戦を削除しました！",
+      "deleteFailed": "対戦を削除できませんでした。もう一度お試しください。"
+    },
+    "vod": {
+      "title": "VODメモ",
+      "description": "VODのリンクとタイムスタンプ付きメモを追加できます（例:「2:41 — ガードへの反撃ミス」）。",
+      "url": "VODのURL",
+      "timestamps": "タイムスタンプ",
+      "noTimestamps": "まだタイムスタンプ付きメモがありません。",
+      "timestampsAria": "タイムスタンプ付きメモ",
+      "deleteTimestamp": "タイムスタンプ{{time}}を削除",
+      "timePlaceholder": "m:ss",
+      "timeAria": "タイムスタンプの時間",
+      "notePlaceholder": "メモ",
+      "noteAria": "タイムスタンプのメモ",
+      "addTimestamp": "タイムスタンプを追加",
+      "timeFormatError": "時間は m:ss または h:mm:ss の形式で入力してください",
+      "noteRequired": "このタイムスタンプのメモを入力してください",
+      "timestampLimit": "タイムスタンプは1対戦につき{{max}}件までです",
+      "saved": "VODメモを保存しました！",
+      "saveFailed": "VODメモを保存できませんでした。もう一度お試しください。"
+    },
     "filteredNotice": {
       "message": "現在のフィルターに一致する対戦がありません。",
       "clear": "フィルターを解除"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "ダッシュボードを読み込み中...",
-    "empty": {
-      "title": "まだファイターを選んでいません！",
-      "subtitle": "メインとサブのファイターを選んで、対戦の記録を始めましょう。",
-      "choosePrimary": "メインファイターを選ぶ",
-      "chooseSecondary": "サブファイターを選ぶ"
-    },
     "hero": {
       "overallRecord": "通算戦績",
       "winRate": "勝率{{rate}}%",
-      "games_one": "{{count}}戦",
-      "games_other": "{{count}}戦",
-      "noMatchData": "まだ対戦データがありません。",
       "form": "調子",
       "streakWin": "{{count}}連勝",
       "streakLoss": "{{count}}連敗",
@@ -107,9 +133,6 @@
       "ratingDown": "前回セッションからレーティング下降",
       "ratingUnchanged": "前回セッションからレーティング変化なし"
     },
-    "tracker": {
-      "rate": "勝率"
-    },
     "formCurve": {
       "title": "調子の推移",
       "window": "集計範囲",
@@ -124,11 +147,7 @@
       "title": "最近の対戦",
       "limit": "表示数",
       "limitAria": "表示する対戦数",
-      "empty": "まだ対戦が記録されていません。",
-      "deleteAria": "対戦を削除",
-      "confirmTitle": "この対戦を削除しますか？",
-      "deleted": "対戦を削除しました！",
-      "deleteFailed": "対戦を削除できませんでした。もう一度お試しください。"
+      "empty": "まだ対戦が記録されていません。"
     },
     "stages": {
       "title": "よく遊ぶステージ",
@@ -341,6 +360,53 @@
       "mmrLabel": "推定MMR（正規化）",
       "glickoLabel": "Glicko-2（正規化）",
       "caption": "クイックプレイでのレート（このファイターの推定MMR、コミュニティ解析モデル）と、全体のGlicko-2レート（全ファイター・全セッション）の比較です。生のスケールに関連がないため、どちらもこの期間で0〜100に正規化しています。レート同士の比較なので形を公平に見比べられます。乖離がある場合は、クイックプレイでの調子が全体の調子と違うことを意味します。"
+    }
+  },
+  "matchData": {
+    "loading": "対戦データを読み込み中...",
+    "title": "対戦履歴",
+    "noMatches": "まだ対戦がありません。対戦を記録してから、ここでデータを確認しましょう！",
+    "goToDashboard": "ダッシュボードへ",
+    "table": {
+      "columns": {
+        "date": "日時",
+        "fighter": "ファイター",
+        "opponentFighter": "相手",
+        "opponentName": "相手の名前",
+        "stage": "ステージ",
+        "matchType": "種類",
+        "win": "結果",
+        "tournament": "大会",
+        "notes": "メモ",
+        "manage": "管理"
+      },
+      "editVod": "VODメモを編集",
+      "addVod": "VODメモを追加",
+      "synced": "同期済み",
+      "syncedTitle": "{{source}}から同期 — 対戦データは同期側が管理します",
+      "editMatch": "対戦を編集",
+      "searchPlaceholder": "{{count}}件から検索...",
+      "searchAria": "対戦を絞り込む",
+      "allOption": "すべての{{label}}",
+      "columnsButton": "列",
+      "toggleColumns": "列の表示切り替え",
+      "exportCsv": "CSVをエクスポート",
+      "noneFound": "対戦が見つかりません。",
+      "pageOf": "{{total}}ページ中{{page}}ページ",
+      "rowsPerPage": "1ページの行数",
+      "showN": "{{count}}件表示"
+    },
+    "roster": {
+      "title": "使用ファイター",
+      "showAll": "すべて表示（あと{{count}}体）",
+      "showLess": "少なく表示"
+    },
+    "stages": {
+      "title": "ステージ別集計",
+      "selectAria": "ステージを選択",
+      "noneOnStage": "このステージでの対戦記録はありません。",
+      "winsShort": "{{count}}勝",
+      "lossesShort": "{{count}}敗"
     }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -44,7 +44,11 @@
     "casual": "Casual",
     "competitive": "Competitivo",
     "unknown": "Desconhecido",
-    "notAvailable": "n/d"
+    "notAvailable": "n/d",
+    "noMatchData": "Ainda não há dados de partidas.",
+    "rate": "Taxa",
+    "games_one": "{{count}} partida",
+    "games_other": "{{count}} partidas"
   },
   "filters": {
     "sourceAria": "Filtrar partidas por origem",
@@ -56,6 +60,37 @@
     "months12": "12 m"
   },
   "shared": {
+    "noFighters": {
+      "title": "Você ainda não escolheu nenhum lutador!",
+      "subtitle": "Escolha seus lutadores principal e secundários para começar a registrar partidas.",
+      "choosePrimary": "Escolher lutadores principais",
+      "chooseSecondary": "Escolher lutadores secundários"
+    },
+    "matchDelete": {
+      "aria": "Excluir partida",
+      "confirmTitle": "Excluir esta partida?",
+      "deleted": "Partida excluída!",
+      "deleteFailed": "Falha ao excluir a partida. Tente novamente."
+    },
+    "vod": {
+      "title": "Notas de VOD",
+      "description": "Anexe um link de VOD e notas com marcação de tempo, ex.: \"2:41 — punição perdida no escudo\".",
+      "url": "URL do VOD",
+      "timestamps": "Marcações de tempo",
+      "noTimestamps": "Ainda não há notas com marcação de tempo.",
+      "timestampsAria": "Notas com marcação de tempo",
+      "deleteTimestamp": "Excluir marcação {{time}}",
+      "timePlaceholder": "m:ss",
+      "timeAria": "Tempo da marcação",
+      "notePlaceholder": "Nota",
+      "noteAria": "Nota da marcação",
+      "addTimestamp": "Adicionar marcação",
+      "timeFormatError": "Insira um tempo como m:ss ou h:mm:ss",
+      "noteRequired": "Insira uma nota para esta marcação",
+      "timestampLimit": "Máximo de {{max}} marcações por partida",
+      "saved": "Notas de VOD salvas!",
+      "saveFailed": "Falha ao salvar as notas de VOD. Tente novamente."
+    },
     "filteredNotice": {
       "message": "Nenhuma partida corresponde aos filtros atuais.",
       "clear": "Limpar filtros"
@@ -73,18 +108,9 @@
   },
   "dashboard": {
     "loading": "Carregando seu painel...",
-    "empty": {
-      "title": "Você ainda não escolheu nenhum lutador!",
-      "subtitle": "Escolha seus lutadores principal e secundários para começar a registrar partidas.",
-      "choosePrimary": "Escolher lutadores principais",
-      "chooseSecondary": "Escolher lutadores secundários"
-    },
     "hero": {
       "overallRecord": "Histórico geral",
       "winRate": "{{rate}}% de vitórias",
-      "games_one": "{{count}} partida",
-      "games_other": "{{count}} partidas",
-      "noMatchData": "Ainda não há dados de partidas.",
       "form": "Forma",
       "streakWin": "{{count}}V",
       "streakLoss": "{{count}}D",
@@ -107,9 +133,6 @@
       "ratingDown": "Pontuação em queda desde a última sessão",
       "ratingUnchanged": "Pontuação inalterada desde a última sessão"
     },
-    "tracker": {
-      "rate": "Taxa"
-    },
     "formCurve": {
       "title": "Curva de forma",
       "window": "Janela",
@@ -124,11 +147,7 @@
       "title": "Partidas anteriores",
       "limit": "Limite",
       "limitAria": "Limite de partidas",
-      "empty": "Nenhuma partida registrada ainda.",
-      "deleteAria": "Excluir partida",
-      "confirmTitle": "Excluir esta partida?",
-      "deleted": "Partida excluída!",
-      "deleteFailed": "Falha ao excluir a partida. Tente novamente."
+      "empty": "Nenhuma partida registrada ainda."
     },
     "stages": {
       "title": "Stages mais jogados",
@@ -341,6 +360,53 @@
       "mmrLabel": "MMR est. (normalizado)",
       "glickoLabel": "Glicko-2 (normalizado)",
       "caption": "Seu nível no quickplay (MMR estimado deste lutador, modelo de engenharia reversa da comunidade) contra seu Glicko-2 geral (todos os lutadores/sessões) — ambos normalizados de 0 a 100 nesta janela, já que as escalas brutas não têm relação. Comparar rating com rating torna as formas honestamente comparáveis; divergência normalmente significa que sua forma no quickplay difere da sua forma geral."
+    }
+  },
+  "matchData": {
+    "loading": "Carregando dados de partidas...",
+    "title": "Histórico de partidas",
+    "noMatches": "Você não tem partidas; registre uma e volte aqui para ver os dados!",
+    "goToDashboard": "Ir para o Painel",
+    "table": {
+      "columns": {
+        "date": "Data",
+        "fighter": "Lutador",
+        "opponentFighter": "Oponente",
+        "opponentName": "Nome do oponente",
+        "stage": "Stage",
+        "matchType": "Tipo",
+        "win": "Resultado",
+        "tournament": "Torneio",
+        "notes": "Notas",
+        "manage": "Gerenciar"
+      },
+      "editVod": "Editar notas de VOD",
+      "addVod": "Adicionar notas de VOD",
+      "synced": "Sincronizada",
+      "syncedTitle": "Sincronizada do {{source}} — os dados são gerenciados pela sincronização",
+      "editMatch": "Editar partida",
+      "searchPlaceholder": "Pesquisar {{count}} registros...",
+      "searchAria": "Filtrar partidas",
+      "allOption": "Todos: {{label}}",
+      "columnsButton": "Colunas",
+      "toggleColumns": "Alternar colunas",
+      "exportCsv": "Exportar CSV",
+      "noneFound": "Nenhuma partida encontrada.",
+      "pageOf": "Página {{page}} de {{total}}",
+      "rowsPerPage": "Linhas por página",
+      "showN": "Mostrar {{count}}"
+    },
+    "roster": {
+      "title": "Uso do elenco",
+      "showAll": "Mostrar todos ({{count}} a mais)",
+      "showLess": "Mostrar menos"
+    },
+    "stages": {
+      "title": "Detalhamento por stage",
+      "selectAria": "Selecionar stage",
+      "noneOnStage": "Nenhuma partida registrada neste stage.",
+      "winsShort": "{{count}}V",
+      "lossesShort": "{{count}}D"
     }
   }
 }

--- a/apps/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/Dashboard/DashboardPage.tsx
@@ -57,14 +57,14 @@ export function DashboardPage() {
   if (fighterSprites.length === 0) {
     return (
       <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">{t('dashboard.empty.title')}</h1>
-        <p className="max-w-md text-muted-foreground">{t('dashboard.empty.subtitle')}</p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('shared.noFighters.title')}</h1>
+        <p className="max-w-md text-muted-foreground">{t('shared.noFighters.subtitle')}</p>
         <div className="flex flex-wrap justify-center gap-2">
           <Button asChild>
-            <Link to="/choose-primary">{t('dashboard.empty.choosePrimary')}</Link>
+            <Link to="/choose-primary">{t('shared.noFighters.choosePrimary')}</Link>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/choose-secondary">{t('dashboard.empty.chooseSecondary')}</Link>
+            <Link to="/choose-secondary">{t('shared.noFighters.chooseSecondary')}</Link>
           </Button>
         </div>
       </div>

--- a/apps/web/src/pages/Dashboard/components/HeroStats.tsx
+++ b/apps/web/src/pages/Dashboard/components/HeroStats.tsx
@@ -61,11 +61,11 @@ function OverallRecordCard({ matches }: { matches: Match[] }) {
               </p>
             </div>
             <span className="text-sm text-muted-foreground">
-              {t('dashboard.hero.games', { count: total })}
+              {t('common.games', { count: total })}
             </span>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">{t('dashboard.hero.noMatchData')}</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         )}
       </CardContent>
     </Card>
@@ -180,7 +180,7 @@ function OnlineOfflineCard({ matches }: { matches: Match[] }) {
             <SplitStat label={t('dashboard.hero.offline')} record={offline} />
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">{t('dashboard.hero.noMatchData')}</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
+++ b/apps/web/src/pages/Dashboard/components/PreviousMatches.tsx
@@ -44,9 +44,9 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
     if (!pendingDelete) return;
     try {
       await deleteMatch.mutateAsync(pendingDelete.id);
-      toast.success(t('dashboard.previous.deleted'));
+      toast.success(t('shared.matchDelete.deleted'));
     } catch {
-      toast.error(t('dashboard.previous.deleteFailed'));
+      toast.error(t('shared.matchDelete.deleteFailed'));
     } finally {
       setPendingDelete(null);
     }
@@ -113,7 +113,7 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
                     <Button
                       variant="outline"
                       size="icon-sm"
-                      aria-label={t('dashboard.previous.deleteAria')}
+                      aria-label={t('shared.matchDelete.aria')}
                       onClick={() => setPendingDelete(match)}
                     >
                       <Trash2 />
@@ -132,7 +132,7 @@ export function PreviousMatches({ matches }: { matches: Match[] }) {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t('dashboard.previous.confirmTitle')}</AlertDialogTitle>
+            <AlertDialogTitle>{t('shared.matchDelete.confirmTitle')}</AlertDialogTitle>
             <AlertDialogDescription>{t('common.cannotBeUndone')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/pages/Dashboard/components/WinLossTracker.tsx
+++ b/apps/web/src/pages/Dashboard/components/WinLossTracker.tsx
@@ -20,13 +20,11 @@ export function WinLossTracker({ matches }: { matches: Match[] }) {
       </CardHeader>
       <CardContent className="flex justify-evenly">
         <Stat label={t('common.wins')} value={hasMatches ? wins : t('common.notAvailable')} />
-        {hasMatches && <Stat label={t('dashboard.tracker.rate')} value={`${winRate}%`} />}
+        {hasMatches && <Stat label={t('common.rate')} value={`${winRate}%`} />}
         <Stat label={t('common.losses')} value={hasMatches ? losses : t('common.notAvailable')} />
       </CardContent>
       {!hasMatches && (
-        <p className="pb-4 text-center text-sm text-muted-foreground">
-          {t('dashboard.hero.noMatchData')}
-        </p>
+        <p className="pb-4 text-center text-sm text-muted-foreground">{t('common.noMatchData')}</p>
       )}
     </Card>
   );

--- a/apps/web/src/pages/MatchData/MatchDataPage.tsx
+++ b/apps/web/src/pages/MatchData/MatchDataPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import type { Fighter } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -13,6 +14,7 @@ import { StageBreakdown } from './components/StageBreakdown';
 
 /** Ports legacy/src/screens/MatchData; the source/time filter is now global (see the topbar's AnalyticsFilterControls), not a per-page control. */
 export function MatchDataPage() {
+  const { t } = useTranslation();
   const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
   const { matches, allMatches, isLoading: matchesLoading, filterActive } = useFilteredMatches();
 
@@ -24,24 +26,20 @@ export function MatchDataPage() {
   }, [fighterSelection]);
 
   if (fightersLoading || matchesLoading) {
-    return <div className="text-muted-foreground">Loading match data...</div>;
+    return <div className="text-muted-foreground">{t('matchData.loading')}</div>;
   }
 
   if (fighterSprites.length === 0) {
     return (
       <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          You haven&apos;t picked any fighters yet!
-        </h1>
-        <p className="max-w-md text-muted-foreground">
-          Choose your primary and secondary fighters to start tracking matches.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('shared.noFighters.title')}</h1>
+        <p className="max-w-md text-muted-foreground">{t('shared.noFighters.subtitle')}</p>
         <div className="flex flex-wrap justify-center gap-2">
           <Button asChild>
-            <Link to="/choose-primary">Choose Primary Fighters</Link>
+            <Link to="/choose-primary">{t('shared.noFighters.choosePrimary')}</Link>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/choose-secondary">Choose Secondary Fighters</Link>
+            <Link to="/choose-secondary">{t('shared.noFighters.chooseSecondary')}</Link>
           </Button>
         </div>
       </div>
@@ -51,11 +49,9 @@ export function MatchDataPage() {
   if (allMatches.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-16 text-center">
-        <h2 className="text-xl font-semibold tracking-tight">
-          You have no matches, report a match and check back here to view match data!
-        </h2>
+        <h2 className="text-xl font-semibold tracking-tight">{t('matchData.noMatches')}</h2>
         <Button asChild className="mt-2">
-          <Link to="/dashboard">Go to Dashboard</Link>
+          <Link to="/dashboard">{t('matchData.goToDashboard')}</Link>
         </Button>
       </div>
     );
@@ -67,7 +63,7 @@ export function MatchDataPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Match History</CardTitle>
+          <CardTitle>{t('matchData.title')}</CardTitle>
         </CardHeader>
         <CardContent>
           <MatchTable matches={matches} fighterSprites={fighterSprites} />

--- a/apps/web/src/pages/MatchData/components/MatchTable.tsx
+++ b/apps/web/src/pages/MatchData/components/MatchTable.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { toast } from 'sonner';
 import { Download, Pencil, SlidersHorizontal, Trash2, Video } from 'lucide-react';
 import {
@@ -93,18 +95,23 @@ function toRow(match: Match): MatchRow {
   };
 }
 
-/** Column id -> friendly label, used by both the header cell and the visibility dropdown. */
-const COLUMN_LABELS: Record<string, string> = {
-  date: 'Date',
-  fighter: 'Fighter',
-  opponentFighter: 'Opponent',
-  opponentName: 'Opponent Name',
-  stage: 'Stage',
-  matchType: 'Type',
-  win: 'Result',
-  tournament: 'Tournament',
-  notes: 'Notes',
+/** Column id -> label key, used by both the header cell and the visibility dropdown. */
+const COLUMN_LABEL_KEYS: Record<string, string> = {
+  date: 'matchData.table.columns.date',
+  fighter: 'matchData.table.columns.fighter',
+  opponentFighter: 'matchData.table.columns.opponentFighter',
+  opponentName: 'matchData.table.columns.opponentName',
+  stage: 'matchData.table.columns.stage',
+  matchType: 'matchData.table.columns.matchType',
+  win: 'matchData.table.columns.win',
+  tournament: 'matchData.table.columns.tournament',
+  notes: 'matchData.table.columns.notes',
 };
+
+function columnLabel(t: TFunction, columnId: string): string {
+  const key = COLUMN_LABEL_KEYS[columnId];
+  return key ? t(key) : columnId;
+}
 
 /** Columns that are always shown and excluded from the visibility dropdown (row actions aren't real data). */
 const NON_TOGGLEABLE_COLUMNS = new Set(['actions']);
@@ -140,6 +147,7 @@ export function MatchTable({
   /** The signed-in user's primary+secondary fighter selections, passed through to EditMatchForm's "Your Fighter" picker. */
   fighterSprites: Fighter[];
 }) {
+  const { t } = useTranslation();
   const [sorting, setSorting] = useState<SortingState>([{ id: 'date', desc: true }]);
   const [globalFilter, setGlobalFilter] = useState('');
   const [columnFilters, setColumnFilters] = useState<MatchTableFilterState>(
@@ -169,27 +177,27 @@ export function MatchTable({
     () => [
       {
         id: 'date',
-        header: 'Date',
+        header: columnLabel(t, 'date'),
         accessorFn: (row) => row.match.time,
         cell: ({ row }) => row.original.date,
       },
       {
         id: 'fighter',
-        header: 'Fighter',
-        accessorFn: (row) => row.fighter?.name ?? 'Unknown',
+        header: columnLabel(t, 'fighter'),
+        accessorFn: (row) => row.fighter?.name ?? t('common.unknown'),
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
             {row.original.fighter && (
               <img src={row.original.fighter.url} alt="" className="size-6 object-contain" />
             )}
-            <span>{row.original.fighter?.name ?? 'Unknown'}</span>
+            <span>{row.original.fighter?.name ?? t('common.unknown')}</span>
           </div>
         ),
       },
       {
         id: 'opponentFighter',
-        header: 'Opponent',
-        accessorFn: (row) => row.opponentFighter?.name ?? 'Unknown',
+        header: columnLabel(t, 'opponentFighter'),
+        accessorFn: (row) => row.opponentFighter?.name ?? t('common.unknown'),
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
             {row.original.opponentFighter && (
@@ -199,43 +207,43 @@ export function MatchTable({
                 className="size-6 object-contain"
               />
             )}
-            <span>{row.original.opponentFighter?.name ?? 'Unknown'}</span>
+            <span>{row.original.opponentFighter?.name ?? t('common.unknown')}</span>
           </div>
         ),
       },
       {
         id: 'opponentName',
-        header: 'Opponent Name',
+        header: columnLabel(t, 'opponentName'),
         accessorFn: (row) => row.opponentName,
       },
       {
         id: 'stage',
-        header: 'Stage',
+        header: columnLabel(t, 'stage'),
         accessorFn: (row) => row.stage,
       },
       {
         id: 'matchType',
-        header: 'Type',
+        header: columnLabel(t, 'matchType'),
         accessorFn: (row) => row.matchType,
       },
       {
         id: 'win',
-        header: 'Result',
-        accessorFn: (row) => (row.match.win ? 'Win' : 'Loss'),
+        header: columnLabel(t, 'win'),
+        accessorFn: (row) => (row.match.win ? t('common.win') : t('common.loss')),
         cell: ({ row }) => (
           <Badge variant={row.original.match.win ? 'success' : 'destructive'}>
-            {row.original.match.win ? 'Win' : 'Loss'}
+            {row.original.match.win ? t('common.win') : t('common.loss')}
           </Badge>
         ),
       },
       {
         id: 'tournament',
-        header: 'Tournament',
+        header: columnLabel(t, 'tournament'),
         accessorFn: (row) => row.tournament,
       },
       {
         id: 'notes',
-        header: 'Notes',
+        header: columnLabel(t, 'notes'),
         accessorFn: (row) => row.notes,
         cell: ({ row }) => (
           <span className="line-clamp-1 max-w-[16ch]" title={row.original.notes}>
@@ -245,7 +253,7 @@ export function MatchTable({
       },
       {
         id: 'actions',
-        header: 'Manage',
+        header: t('matchData.table.columns.manage'),
         enableSorting: false,
         enableHiding: false,
         cell: ({ row }) => {
@@ -256,7 +264,7 @@ export function MatchTable({
               <Button
                 variant="outline"
                 size="icon-sm"
-                aria-label={hasVod ? 'Edit VOD notes' : 'Add VOD notes'}
+                aria-label={hasVod ? t('matchData.table.editVod') : t('matchData.table.addVod')}
                 className={cn(hasVod && 'border-primary text-primary')}
                 onClick={() => setVodMatch(row.original.match)}
               >
@@ -268,16 +276,18 @@ export function MatchTable({
                 // stay editable.
                 <Badge
                   variant="outline"
-                  title={`Synced from ${source === 'startgg' ? 'start.gg' : 'parry.gg'} — game data is managed by sync`}
+                  title={t('matchData.table.syncedTitle', {
+                    source: source === 'startgg' ? 'start.gg' : 'parry.gg',
+                  })}
                 >
-                  Synced
+                  {t('matchData.table.synced')}
                 </Badge>
               ) : (
                 <>
                   <Button
                     variant="outline"
                     size="icon-sm"
-                    aria-label="Edit match"
+                    aria-label={t('matchData.table.editMatch')}
                     onClick={() => setEditingMatch(row.original.match)}
                   >
                     <Pencil />
@@ -285,7 +295,7 @@ export function MatchTable({
                   <Button
                     variant="outline"
                     size="icon-sm"
-                    aria-label="Delete match"
+                    aria-label={t('shared.matchDelete.aria')}
                     onClick={() => setPendingDelete(row.original.match)}
                   >
                     <Trash2 />
@@ -297,7 +307,7 @@ export function MatchTable({
         },
       },
     ],
-    [],
+    [t],
   );
 
   const table = useReactTable({
@@ -318,9 +328,9 @@ export function MatchTable({
     if (!pendingDelete) return;
     try {
       await deleteMatch.mutateAsync(pendingDelete.id);
-      toast.success('Match deleted!');
+      toast.success(t('shared.matchDelete.deleted'));
     } catch {
-      toast.error('Failed to delete match. Please try again.');
+      toast.error(t('shared.matchDelete.deleteFailed'));
     } finally {
       setPendingDelete(null);
     }
@@ -335,11 +345,7 @@ export function MatchTable({
   }
 
   if (matches.length === 0) {
-    return (
-      <p className="text-center text-sm text-muted-foreground">
-        You have no matches, report a match and check back here to view match data!
-      </p>
-    );
+    return <p className="text-center text-sm text-muted-foreground">{t('matchData.noMatches')}</p>;
   }
 
   return (
@@ -348,37 +354,37 @@ export function MatchTable({
         <Input
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}
-          placeholder={`Search ${data.length} records...`}
+          placeholder={t('matchData.table.searchPlaceholder', { count: data.length })}
           className="max-w-xs"
-          aria-label="Filter matches"
+          aria-label={t('matchData.table.searchAria')}
         />
 
         <ColumnFilterSelect
-          label="Your Fighter"
+          label={t('matchForm.yourFighter')}
           value={columnFilters.fighter}
           options={filterOptions.fighters}
           onChange={(value) => setColumnFilters((prev) => ({ ...prev, fighter: value }))}
         />
         <ColumnFilterSelect
-          label="Opponent Fighter"
+          label={t('matchForm.opponentFighter')}
           value={columnFilters.opponentFighter}
           options={filterOptions.opponentFighters}
           onChange={(value) => setColumnFilters((prev) => ({ ...prev, opponentFighter: value }))}
         />
         <ColumnFilterSelect
-          label="Stage"
+          label={t('matchData.table.columns.stage')}
           value={columnFilters.stage}
           options={filterOptions.stages}
           onChange={(value) => setColumnFilters((prev) => ({ ...prev, stage: value }))}
         />
         <ColumnFilterSelect
-          label="Type"
+          label={t('matchData.table.columns.matchType')}
           value={columnFilters.matchType}
           options={filterOptions.matchTypes}
           onChange={(value) => setColumnFilters((prev) => ({ ...prev, matchType: value }))}
         />
         <ColumnFilterSelect
-          label="Tournament"
+          label={t('matchData.table.columns.tournament')}
           value={columnFilters.tournament}
           options={filterOptions.tournaments}
           onChange={(value) => setColumnFilters((prev) => ({ ...prev, tournament: value }))}
@@ -389,11 +395,11 @@ export function MatchTable({
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm">
                 <SlidersHorizontal />
-                Columns
+                {t('matchData.table.columnsButton')}
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+              <DropdownMenuLabel>{t('matchData.table.toggleColumns')}</DropdownMenuLabel>
               <DropdownMenuSeparator />
               {table
                 .getAllColumns()
@@ -405,7 +411,7 @@ export function MatchTable({
                     onCheckedChange={(value) => column.toggleVisibility(!!value)}
                     onSelect={(e) => e.preventDefault()}
                   >
-                    {COLUMN_LABELS[column.id] ?? column.id}
+                    {columnLabel(t, column.id)}
                   </DropdownMenuCheckboxItem>
                 ))}
             </DropdownMenuContent>
@@ -413,7 +419,7 @@ export function MatchTable({
 
           <Button variant="outline" size="sm" onClick={handleExportCsv}>
             <Download />
-            Export CSV
+            {t('matchData.table.exportCsv')}
           </Button>
         </div>
       </div>
@@ -446,7 +452,7 @@ export function MatchTable({
                   colSpan={table.getVisibleFlatColumns().length}
                   className="text-center text-muted-foreground"
                 >
-                  No matches found.
+                  {t('matchData.table.noneFound')}
                 </TableCell>
               </TableRow>
             ) : (
@@ -500,19 +506,22 @@ export function MatchTable({
           </Button>
         </div>
         <span className="text-sm text-muted-foreground">
-          Page {table.getState().pagination.pageIndex + 1} of {Math.max(1, table.getPageCount())}
+          {t('matchData.table.pageOf', {
+            page: table.getState().pagination.pageIndex + 1,
+            total: Math.max(1, table.getPageCount()),
+          })}
         </span>
         <Select
           value={String(table.getState().pagination.pageSize)}
           onValueChange={(value) => table.setPageSize(Number(value))}
         >
-          <SelectTrigger className="w-[110px]" aria-label="Rows per page">
+          <SelectTrigger className="w-[110px]" aria-label={t('matchData.table.rowsPerPage')}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             {PAGE_SIZE_OPTIONS.map((size) => (
               <SelectItem key={size} value={String(size)}>
-                Show {size}
+                {t('matchData.table.showN', { count: size })}
               </SelectItem>
             ))}
           </SelectContent>
@@ -546,12 +555,12 @@ export function MatchTable({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete this match?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+            <AlertDialogTitle>{t('shared.matchDelete.confirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('common.cannotBeUndone')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>{t('common.delete')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -571,13 +580,16 @@ function ColumnFilterSelect({
   options: string[];
   onChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <Select value={value} onValueChange={onChange}>
       <SelectTrigger className="w-[150px]" aria-label={label}>
         <SelectValue placeholder={label} />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value={ALL_FILTER_VALUE}>All {label}</SelectItem>
+        <SelectItem value={ALL_FILTER_VALUE}>
+          {t('matchData.table.allOption', { label })}
+        </SelectItem>
         {options.map((option) => (
           <SelectItem key={option} value={option}>
             {option}

--- a/apps/web/src/pages/MatchData/components/RosterUsage.tsx
+++ b/apps/web/src/pages/MatchData/components/RosterUsage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Fighter, Match } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -37,6 +38,7 @@ export function RosterUsage({
   matches: Match[];
   fighterSprites: Fighter[];
 }) {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
 
   const rows = useMemo(() => buildRosterUsage(matches, fighterSprites), [matches, fighterSprites]);
@@ -45,10 +47,10 @@ export function RosterUsage({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Roster Usage</CardTitle>
+          <CardTitle>{t('matchData.roster.title')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         </CardContent>
       </Card>
     );
@@ -60,7 +62,7 @@ export function RosterUsage({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Roster Usage</CardTitle>
+        <CardTitle>{t('matchData.roster.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <ul className="flex flex-col gap-2">
@@ -76,7 +78,7 @@ export function RosterUsage({
             className="self-start"
             onClick={() => setExpanded(true)}
           >
-            Show all ({hiddenCount} more)
+            {t('matchData.roster.showAll', { count: hiddenCount })}
           </Button>
         )}
         {expanded && rows.length > VISIBLE_CAP && (
@@ -86,7 +88,7 @@ export function RosterUsage({
             className="self-start"
             onClick={() => setExpanded(false)}
           >
-            Show less
+            {t('matchData.roster.showLess')}
           </Button>
         )}
       </CardContent>
@@ -95,6 +97,7 @@ export function RosterUsage({
 }
 
 function RosterUsageItem({ row, colorIndex }: { row: RosterUsageRow; colorIndex: number }) {
+  const { t } = useTranslation();
   const { fighter, games, usagePercent, wins, losses, winRate } = row;
   const tone = winRateTone(winRate);
   const barColor = BAR_COLOR_CLASSES[colorIndex % BAR_COLOR_CLASSES.length];
@@ -105,7 +108,9 @@ function RosterUsageItem({ row, colorIndex }: { row: RosterUsageRow; colorIndex:
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center justify-between gap-2">
           <span className="truncate text-sm font-medium">{fighter.name}</span>
-          <span className="shrink-0 text-xs text-muted-foreground">{games} games</span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {t('common.games', { count: games })}
+          </span>
         </div>
         <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
           <div

--- a/apps/web/src/pages/MatchData/components/StageBreakdown.tsx
+++ b/apps/web/src/pages/MatchData/components/StageBreakdown.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -29,6 +30,7 @@ export function StageBreakdown({
   /** Unfiltered matches used to compute "Most played" ordering; defaults to `matches` when omitted. */
   usageMatches?: Match[];
 }) {
+  const { t } = useTranslation();
   const [stageId, setStageId] = useState<number>(NO_SELECTION_STAGE.id);
   const { mostPlayed, all: allStages } = useMemo(
     () => getGroupedStageOptions(usageMatches ?? matches),
@@ -39,10 +41,10 @@ export function StageBreakdown({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Stage Breakdown</CardTitle>
+          <CardTitle>{t('matchData.stages.title')}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         </CardContent>
       </Card>
     );
@@ -66,18 +68,18 @@ export function StageBreakdown({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Stage Breakdown</CardTitle>
+        <CardTitle>{t('matchData.stages.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <Select value={String(stageId)} onValueChange={(v) => setStageId(Number(v))}>
-          <SelectTrigger className="w-full max-w-xs" aria-label="Select stage">
+          <SelectTrigger className="w-full max-w-xs" aria-label={t('matchData.stages.selectAria')}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={String(NO_SELECTION_STAGE.id)}>{NO_SELECTION_STAGE.name}</SelectItem>
             {mostPlayed.length > 0 && (
               <SelectGroup>
-                <SelectLabel>Most played</SelectLabel>
+                <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
                 {mostPlayed.map((s) => (
                   <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
                     <StageOption stage={s} />
@@ -86,7 +88,7 @@ export function StageBreakdown({
               </SelectGroup>
             )}
             <SelectGroup>
-              <SelectLabel>All stages</SelectLabel>
+              <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
               {allStages.map((s) => (
                 <SelectItem key={`all-${s.id}`} value={String(s.id)}>
                   <StageOption stage={s} />
@@ -115,12 +117,12 @@ export function StageBreakdown({
             ))}
           <h3 className="text-lg font-medium">{selectedStage.name}</h3>
           {!record || record.total === 0 ? (
-            <p className="text-sm text-muted-foreground">No reported matches on this stage.</p>
+            <p className="text-sm text-muted-foreground">{t('matchData.stages.noneOnStage')}</p>
           ) : (
             <div className="flex justify-evenly pt-2">
-              <Stat label="Rate" value={`${record.winRate}%`} />
-              <Stat label="Wins" value={record.wins} />
-              <Stat label="Losses" value={record.losses} />
+              <Stat label={t('common.rate')} value={`${record.winRate}%`} />
+              <Stat label={t('common.wins')} value={record.wins} />
+              <Stat label={t('common.losses')} value={record.losses} />
             </div>
           )}
         </div>
@@ -133,8 +135,8 @@ export function StageBreakdown({
                 <span className="flex-1 font-medium">{fighter.name}</span>
                 <div className="flex gap-4 text-sm text-muted-foreground">
                   <span>{winRate}%</span>
-                  <span>{wins}W</span>
-                  <span>{losses}L</span>
+                  <span>{t('matchData.stages.winsShort', { count: wins })}</span>
+                  <span>{t('matchData.stages.lossesShort', { count: losses })}</span>
                 </div>
               </li>
             ))}


### PR DESCRIPTION
## Summary

Stacked on #144 (chain: #142 ← #143 ← #144 ← this). Localizes `pages/MatchData/` into `matchData.*` and the shared `VodNotesDialog` (used here and by Tournaments' SetTimeline) into `shared.vod.*`, translated into es/fr/de/pt/ja:

- Page loading/empty states, Match History card.
- Match table: column headers + the visibility dropdown (one key set via `columnLabel(t, id)`), per-column filter selects (reusing `matchForm.yourFighter`/`opponentFighter`), global search placeholder/aria, synced-badge text + tooltip, row-action aria labels, CSV export button, empty row state, and pagination ("Page X of Y", "Show N", rows-per-page aria).
- Roster usage (title, show all/less) and stage breakdown (title, stage select aria, per-stage record labels, W/L shorthand — 勝/敗 in ja).
- VOD dialog: labels, placeholders, timestamp validation errors, delete-timestamp aria, toasts.

## Key promotions (de-duplication)

MatchData repeats several Dashboard strings verbatim, so instead of duplicating them across locales this PR promotes them and updates the Dashboard components:

- `dashboard.empty.*` → `shared.noFighters.*` (identical no-fighters hero on both pages)
- `dashboard.previous.{deleteAria,confirmTitle,deleted,deleteFailed}` → `shared.matchDelete.*` (same confirm dialog + toasts in PreviousMatches and MatchTable)
- `dashboard.hero.noMatchData` → `common.noMatchData`, `dashboard.hero.games_*` → `common.games_*`, `dashboard.tracker.rate` → `common.rate` (used by RosterUsage/StageBreakdown too)

Rendered English is unchanged everywhere, so all existing test assertions pass untouched.

## Implementation notes

- The table's Win/Loss `accessorFn` localizes alongside the badge, so the global text search matches the rendered language.
- The `columns` useMemo now depends on `[t]`, rebuilding headers on language switch.

## Testing

- `pnpm --filter @smash-tracker/web lint` ✅ (0 errors)
- `pnpm --filter @smash-tracker/web typecheck` ✅
- `pnpm --filter @smash-tracker/web test` ✅ 926/926 (key-parity test covers all six locales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)