### PR TITLE
Favorite stages pinned to the top of stage pickers

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import opponentsRoutes from './routes/opponents.js';
 import opponentAliasesRoutes from './routes/opponentAliases.js';
 import opponentNotesRoutes from './routes/opponentNotes.js';
 import gspSettingsRoutes from './routes/gspSettings.js';
+import stageFavoritesRoutes from './routes/stageFavorites.js';
 import startggRoutes from './routes/startgg.js';
 import parryggRoutes from './routes/parrygg.js';
 import parryggAuthRoutes from './routes/parryggAuth.js';
@@ -149,6 +150,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(opponentAliasesRoutes);
       await api.register(opponentNotesRoutes);
       await api.register(gspSettingsRoutes);
+      await api.register(stageFavoritesRoutes);
       await api.register(tournamentsRoutes);
       await api.register(groupsRoutes);
       await api.register(startggRoutes, {

--- a/apps/api/src/routes/stageFavorites.test.ts
+++ b/apps/api/src/routes/stageFavorites.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+describe('GET /api/stage-favorites', () => {
+  it('returns an empty default when the user has never saved favorites', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ stageIds: [], updatedAt: 0 });
+  });
+
+  it('returns the saved favorites when present', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`stageFavorites/${TEST_UID}`, { stageIds: [113, 1, 1000, 1001], updatedAt: 555 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ stageIds: [113, 1, 1000, 1001], updatedAt: 555 });
+  });
+
+  it('tolerates a record whose stageIds key was dropped by RTDB (empty array write)', async () => {
+    const { app, database } = buildTestApp();
+    // RTDB silently drops empty arrays on write, so a user who removed their
+    // last favorite reads back as { updatedAt } only.
+    database.seed(`stageFavorites/${TEST_UID}`, { updatedAt: 777 });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ stageIds: [], updatedAt: 777 });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'GET', url: '/api/stage-favorites' });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/stage-favorites', () => {
+  it('saves favorites in the given order and stamps updatedAt server-side', async () => {
+    const { app, database } = buildTestApp();
+    const before = Date.now();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [113, 1, 1000, 1001] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.stageIds).toEqual([113, 1, 1000, 1001]);
+    expect(body.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(database.dump()).toMatchObject({
+      stageFavorites: { [TEST_UID]: { stageIds: [113, 1, 1000, 1001] } },
+    });
+  });
+
+  it('overwrites previously-saved favorites', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`stageFavorites/${TEST_UID}`, { stageIds: [3], updatedAt: 1 });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [1, 113] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().stageIds).toEqual([1, 113]);
+  });
+
+  it('dedupes repeated ids, keeping the first occurrence', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [113, 1, 113, 3, 1] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().stageIds).toEqual([113, 1, 3]);
+  });
+
+  it('accepts an empty list (removing the last favorite)', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().stageIds).toEqual([]);
+  });
+
+  it('rejects unknown stage ids', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [1, 99999] },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects the id-0 no-selection sentinel', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: { stageIds: [0] },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects a missing body', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/stage-favorites',
+      payload: { stageIds: [1] },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/apps/api/src/routes/stageFavorites.ts
+++ b/apps/api/src/routes/stageFavorites.ts
@@ -1,0 +1,52 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { stageFavoritesSchema, upsertStageFavoritesInputSchema } from '@smash-tracker/shared';
+import { RtdbService } from '../services/rtdb.js';
+
+/**
+ * `stageFavorites/{uid}` — the user's favorited stages, pinned to the top of
+ * every stage picker (match forms, set wizard, stage breakdown filter) so
+ * frequent stages don't have to be scrolled to on every match log.
+ *
+ * GET returns a synthesized empty default rather than 404ing when the user
+ * hasn't favorited anything yet — same convention as gsp-settings. PUT
+ * replaces the whole list (favorites are a small ordered set, not an
+ * append-only log).
+ */
+const stageFavoritesRoutes: FastifyPluginAsyncZod = async (app) => {
+  const rtdb = new RtdbService(app.firebase.database);
+
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/stage-favorites
+  app.get(
+    '/stage-favorites',
+    {
+      schema: {
+        response: {
+          200: stageFavoritesSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.getStageFavorites(request.uid);
+    },
+  );
+
+  // PUT /api/stage-favorites
+  app.put(
+    '/stage-favorites',
+    {
+      schema: {
+        body: upsertStageFavoritesInputSchema,
+        response: {
+          200: stageFavoritesSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.setStageFavorites(request.uid, request.body);
+    },
+  );
+};
+
+export default stageFavoritesRoutes;

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -7,10 +7,12 @@ import {
   opponentMapSchema,
   opponentNoteMapSchema,
   opponentNoteSchema,
+  stageFavoritesSchema,
   userSchema,
   type CreateMatchInput,
   type FighterSelectionInput,
   type GspSettings,
+  type StageFavorites,
   type Match,
   type MatchRecord,
   type OpponentAliasMap,
@@ -19,6 +21,7 @@ import {
   type UpdateMatchInput,
   type UpsertGspSettingsInput,
   type UpsertOpponentNoteInput,
+  type UpsertStageFavoritesInput,
   type User,
 } from '@smash-tracker/shared';
 
@@ -381,5 +384,36 @@ export class RtdbService {
     };
     await this.database.ref(`gspSettings/${uid}`).set(gspSettingsSchema.parse(settings));
     return settings;
+  }
+
+  // ---- stageFavorites/{uid} -----------------------------------------------
+
+  /**
+   * Returns the user's favorited stage ids, synthesizing an empty default
+   * (`stageIds: [], updatedAt: 0`) when they've never saved any — same
+   * no-404 convention as `getGspSettings`. The schema's `stageIds` default
+   * also covers the record RTDB leaves behind after the last favorite is
+   * removed (RTDB drops empty arrays on write, so only `updatedAt` survives).
+   */
+  async getStageFavorites(uid: string): Promise<StageFavorites> {
+    const snapshot = await this.database.ref(`stageFavorites/${uid}`).get();
+    if (!snapshot.exists()) {
+      return { stageIds: [], updatedAt: 0 };
+    }
+    return stageFavoritesSchema.parse(snapshot.val());
+  }
+
+  /**
+   * Writes (fully replaces) the user's favorite-stage list, deduping ids
+   * (first-occurrence-wins, preserving the user's chosen order) and stamping
+   * `updatedAt` server-side.
+   */
+  async setStageFavorites(uid: string, input: UpsertStageFavoritesInput): Promise<StageFavorites> {
+    const favorites: StageFavorites = {
+      stageIds: [...new Set(input.stageIds)],
+      updatedAt: Date.now(),
+    };
+    await this.database.ref(`stageFavorites/${uid}`).set(stageFavoritesSchema.parse(favorites));
+    return favorites;
   }
 }

--- a/apps/web/src/components/StageSelectGroups.tsx
+++ b/apps/web/src/components/StageSelectGroups.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import { SelectGroup, SelectItem, SelectLabel } from '@/components/ui/select';
+import { NO_SELECTION_STAGE } from '@/data/stages';
+import { StageOption } from '@/components/StageOption';
+import type { GroupedStageOptions } from '@/lib/stageOptions';
+
+/**
+ * The option list every stage `<Select>` renders (match forms, set wizard,
+ * stage breakdown filter): the "no selection" sentinel first, then the
+ * user's pinned Favorites, then Most played, then All stages. Groups repeat
+ * stages on purpose — see `getGroupedStageOptions`. Must be rendered inside
+ * a `<SelectContent>`.
+ */
+export function StageSelectGroups({ groups }: { groups: GroupedStageOptions }) {
+  const { t } = useTranslation();
+  const { favorites, mostPlayed, all } = groups;
+  return (
+    <>
+      <SelectItem value={String(NO_SELECTION_STAGE.id)}>{NO_SELECTION_STAGE.name}</SelectItem>
+      {favorites.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>{t('matchForm.favorites')}</SelectLabel>
+          {favorites.map((s) => (
+            <SelectItem key={`favorite-${s.id}`} value={String(s.id)}>
+              <StageOption stage={s} />
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      )}
+      {mostPlayed.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
+          {mostPlayed.map((s) => (
+            <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
+              <StageOption stage={s} />
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      )}
+      <SelectGroup>
+        <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
+        {all.map((s) => (
+          <SelectItem key={`all-${s.id}`} value={String(s.id)}>
+            <StageOption stage={s} />
+          </SelectItem>
+        ))}
+      </SelectGroup>
+    </>
+  );
+}

--- a/apps/web/src/components/match-form/MatchForm.tsx
+++ b/apps/web/src/components/match-form/MatchForm.tsx
@@ -19,9 +19,7 @@ import {
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -41,9 +39,10 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { cn } from '@/lib/utils';
 import { SpriteList } from '@/data/sprites';
 import { NO_SELECTION_STAGE } from '@/data/stages';
-import { StageOption } from '@/components/StageOption';
+import { StageSelectGroups } from '@/components/StageSelectGroups';
 import { useOpponents } from '@/hooks/useOpponents';
 import { useMatches } from '@/hooks/useMatches';
+import { useStageFavorites } from '@/hooks/useStageFavorites';
 import { getGroupedStageOptions, stageOptions } from '@/lib/stageOptions';
 import { parseGspNumber } from '@/pages/Gsp/lib/parseGspNumber';
 
@@ -306,11 +305,13 @@ export function MatchFormFields({
   const { t } = useTranslation();
   const { data: opponents = [] } = useOpponents();
   const { data: allMatches = [] } = useMatches();
+  const { data: stageFavorites } = useStageFavorites();
   const [opponentPopoverOpen, setOpponentPopoverOpen] = useState(false);
 
-  const { mostPlayed, all: allStages } = useMemo(
-    () => getGroupedStageOptions(allMatches),
-    [allMatches],
+  const favoriteStageIds = stageFavorites?.stageIds;
+  const stageGroups = useMemo(
+    () => getGroupedStageOptions(allMatches, favoriteStageIds),
+    [allMatches, favoriteStageIds],
   );
 
   return (
@@ -416,27 +417,7 @@ export function MatchFormFields({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value={String(NO_SELECTION_STAGE.id)}>
-                    {NO_SELECTION_STAGE.name}
-                  </SelectItem>
-                  {mostPlayed.length > 0 && (
-                    <SelectGroup>
-                      <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
-                      {mostPlayed.map((s) => (
-                        <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
-                          <StageOption stage={s} />
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  )}
-                  <SelectGroup>
-                    <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
-                    {allStages.map((s) => (
-                      <SelectItem key={`all-${s.id}`} value={String(s.id)}>
-                        <StageOption stage={s} />
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
+                  <StageSelectGroups groups={stageGroups} />
                 </SelectContent>
               </Select>
               <StageArtPreview stageId={field.value} />

--- a/apps/web/src/components/match-form/SetWizard.tsx
+++ b/apps/web/src/components/match-form/SetWizard.tsx
@@ -20,9 +20,7 @@ import {
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -37,10 +35,10 @@ import {
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import { NO_SELECTION_STAGE } from '@/data/stages';
-import { StageOption } from '@/components/StageOption';
+import { StageSelectGroups } from '@/components/StageSelectGroups';
 import { useOpponents } from '@/hooks/useOpponents';
 import { useMatches } from '@/hooks/useMatches';
+import { useStageFavorites } from '@/hooks/useStageFavorites';
 import { getGroupedStageOptions } from '@/lib/stageOptions';
 import { alphaSpriteList, TournamentFields, matchTypeLabel } from './MatchForm';
 import {
@@ -202,9 +200,11 @@ export function SetWizard({
     await onSubmit(payloads);
   }
 
-  const { mostPlayed, all: allStages } = useMemo(
-    () => getGroupedStageOptions(allMatches),
-    [allMatches],
+  const { data: stageFavorites } = useStageFavorites();
+  const favoriteStageIds = stageFavorites?.stageIds;
+  const stageGroups = useMemo(
+    () => getGroupedStageOptions(allMatches, favoriteStageIds),
+    [allMatches, favoriteStageIds],
   );
 
   return (
@@ -435,27 +435,7 @@ export function SetWizard({
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value={String(NO_SELECTION_STAGE.id)}>
-                          {NO_SELECTION_STAGE.name}
-                        </SelectItem>
-                        {mostPlayed.length > 0 && (
-                          <SelectGroup>
-                            <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
-                            {mostPlayed.map((s) => (
-                              <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
-                                <StageOption stage={s} />
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        )}
-                        <SelectGroup>
-                          <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
-                          {allStages.map((s) => (
-                            <SelectItem key={`all-${s.id}`} value={String(s.id)}>
-                              <StageOption stage={s} />
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
+                        <StageSelectGroups groups={stageGroups} />
                       </SelectContent>
                     </Select>
                   </FormItem>

--- a/apps/web/src/hooks/useStageFavorites.test.tsx
+++ b/apps/web/src/hooks/useStageFavorites.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useStageFavorites, useUpdateStageFavorites } from './useStageFavorites';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+import { AuthProvider } from '@/context/AuthContext';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [queryClient] = [new QueryClient({ defaultOptions: { queries: { retry: false } } })];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function FavoritesProbe() {
+  const { data, isSuccess } = useStageFavorites();
+  const update = useUpdateStageFavorites();
+  if (!isSuccess) {
+    return <div>loading</div>;
+  }
+  return (
+    <div>
+      <div>stageIds: {data.stageIds.join(',') || 'none'}</div>
+      <button onClick={() => update.mutate({ stageIds: [113, 1] })}>Update</button>
+    </div>
+  );
+}
+
+describe('useStageFavorites', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches favorites with a Bearer auth header and validates against the shared schema', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ stageIds: [113], updatedAt: 0 }),
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <FavoritesProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('stageIds: 113')).toBeInTheDocument());
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(fetch).mock.calls[0];
+    if (!call) {
+      throw new Error('expected fetch to have been called');
+    }
+    const [url, init] = call;
+    expect(String(url)).toContain('/api/stage-favorites');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer mock-id-token');
+  });
+
+  it('PUTs the update and invalidates the favorites query', async () => {
+    let stored: { stageIds: number[]; updatedAt: number } = { stageIds: [], updatedAt: 0 };
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        stored = { stageIds: [113, 1], updatedAt: 999 };
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify(stored),
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <Wrapper>
+        <FavoritesProbe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByText('stageIds: none')).toBeInTheDocument());
+
+    screen.getByRole('button', { name: 'Update' }).click();
+
+    await waitFor(() => expect(screen.getByText('stageIds: 113,1')).toBeInTheDocument());
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(putCall).toBeDefined();
+    expect(JSON.parse((putCall![1] as RequestInit).body as string)).toEqual({
+      stageIds: [113, 1],
+    });
+  });
+});

--- a/apps/web/src/hooks/useStageFavorites.ts
+++ b/apps/web/src/hooks/useStageFavorites.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UpsertStageFavoritesInput } from '@smash-tracker/shared';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const stageFavoritesQueryKey = ['stageFavorites'] as const;
+
+/**
+ * GET /api/stage-favorites — the signed-in user's favorited stages, pinned
+ * to the top of every stage picker. The API always returns a value (an empty
+ * list when nothing's been favorited yet), so callers never need to handle a
+ * missing-favorites case themselves.
+ */
+export function useStageFavorites() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: stageFavoritesQueryKey,
+    queryFn: () => api.stageFavorites.get(),
+    enabled: Boolean(user),
+  });
+}
+
+/** PUT /api/stage-favorites — replaces the whole list. Invalidates the favorites query on success. */
+export function useUpdateStageFavorites() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpsertStageFavoritesInput) => api.stageFavorites.update(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: stageFavoritesQueryKey });
+    },
+  });
+}

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -166,6 +166,7 @@
     "opponentFighter": "Gegnerischer Kämpfer",
     "result": "Ergebnis",
     "map": "Stage",
+    "favorites": "Favoriten",
     "mostPlayed": "Meistgespielt",
     "allStages": "Alle Stages",
     "stocksLeft": "Verbleibende Stocks (Sieger)",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -166,6 +166,7 @@
     "opponentFighter": "Opponent Fighter",
     "result": "Result",
     "map": "Map",
+    "favorites": "Favorites",
     "mostPlayed": "Most played",
     "allStages": "All stages",
     "stocksLeft": "Stocks Left (winner)",

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -166,6 +166,7 @@
     "opponentFighter": "Luchador del rival",
     "result": "Resultado",
     "map": "Escenario",
+    "favorites": "Favoritos",
     "mostPlayed": "Más jugados",
     "allStages": "Todos los escenarios",
     "stocksLeft": "Vidas restantes (ganador)",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -166,6 +166,7 @@
     "opponentFighter": "Combattant adverse",
     "result": "Résultat",
     "map": "Stage",
+    "favorites": "Favoris",
     "mostPlayed": "Les plus joués",
     "allStages": "Tous les stages",
     "stocksLeft": "Stocks restants (vainqueur)",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -166,6 +166,7 @@
     "opponentFighter": "相手のファイター",
     "result": "結果",
     "map": "ステージ",
+    "favorites": "お気に入り",
     "mostPlayed": "よく遊ぶステージ",
     "allStages": "すべてのステージ",
     "stocksLeft": "残ストック（勝者）",

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -166,6 +166,7 @@
     "opponentFighter": "Lutador do oponente",
     "result": "Resultado",
     "map": "Stage",
+    "favorites": "Favoritos",
     "mostPlayed": "Mais jogados",
     "allStages": "Todos os stages",
     "stocksLeft": "Vidas restantes (vencedor)",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -32,6 +32,7 @@ import {
   reportsConfigSchema,
   scoutReportDataSchema,
   scoutReportRecordSchema,
+  stageFavoritesSchema,
   startggAuthorizeResponseSchema,
   startggStatusSchema,
   startggSyncSummarySchema,
@@ -51,6 +52,7 @@ import {
   type UpsertGspSettingsInput,
   type UpsertOpponentAliasInput,
   type UpsertOpponentNoteInput,
+  type UpsertStageFavoritesInput,
 } from '@smash-tracker/shared';
 import { getFirebaseAuth } from './firebase';
 
@@ -409,6 +411,16 @@ export const api = {
     /** PUT /api/gsp-settings */
     update: (input: UpsertGspSettingsInput) =>
       apiRequestParsed('/api/gsp-settings', gspSettingsSchema, { method: 'PUT', body: input }),
+  },
+  stageFavorites: {
+    /** GET /api/stage-favorites — the signed-in user's favorited stage ids (an empty default is synthesized server-side, never 404s). */
+    get: () => apiRequestParsed('/api/stage-favorites', stageFavoritesSchema),
+    /** PUT /api/stage-favorites — replaces the whole favorites list. */
+    update: (input: UpsertStageFavoritesInput) =>
+      apiRequestParsed('/api/stage-favorites', stageFavoritesSchema, {
+        method: 'PUT',
+        body: input,
+      }),
   },
 };
 

--- a/apps/web/src/lib/stageOptions.test.ts
+++ b/apps/web/src/lib/stageOptions.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { Match } from '@smash-tracker/shared';
+import { alphaStageList, getGroupedStageOptions } from './stageOptions';
+
+function makeMatch(mapId: number, mapName: string, id: string): Match {
+  return {
+    id,
+    fighter_id: 1,
+    opponent_id: 10,
+    time: 1_700_000_000_000,
+    map: { id: mapId, name: mapName },
+    opponent: 'rival',
+    notes: '',
+    matchType: 'none',
+    win: true,
+  };
+}
+
+// Battlefield played 3x, Final Destination 2x, Small Battlefield 1x.
+const matches: Match[] = [
+  makeMatch(1, 'Battlefield', 'm1'),
+  makeMatch(1, 'Battlefield', 'm2'),
+  makeMatch(1, 'Battlefield', 'm3'),
+  makeMatch(3, 'Final Destination', 'm4'),
+  makeMatch(3, 'Final Destination', 'm5'),
+  makeMatch(113, 'Small Battlefield', 'm6'),
+];
+
+describe('getGroupedStageOptions', () => {
+  it('returns no favorites and usage-ordered most played when no favorites are given', () => {
+    const groups = getGroupedStageOptions(matches);
+
+    expect(groups.favorites).toEqual([]);
+    expect(groups.mostPlayed.map((s) => s.name)).toEqual([
+      'Battlefield',
+      'Final Destination',
+      'Small Battlefield',
+    ]);
+    expect(groups.all).toBe(alphaStageList);
+  });
+
+  it('returns favorites in the saved order, not alphabetical or usage order', () => {
+    const groups = getGroupedStageOptions(matches, [113, 1, 1000]);
+
+    expect(groups.favorites.map((s) => s.name)).toEqual([
+      'Small Battlefield',
+      'Battlefield',
+      '(Gen. Battlefield)',
+    ]);
+  });
+
+  it('excludes favorited stages from most played (they are already pinned)', () => {
+    const groups = getGroupedStageOptions(matches, [1]);
+
+    expect(groups.mostPlayed.map((s) => s.name)).toEqual([
+      'Final Destination',
+      'Small Battlefield',
+    ]);
+  });
+
+  it('skips unknown favorite ids instead of throwing', () => {
+    const groups = getGroupedStageOptions(matches, [99999, 1]);
+
+    expect(groups.favorites.map((s) => s.name)).toEqual(['Battlefield']);
+  });
+
+  it('keeps the full alphabetical list even when stages are favorited', () => {
+    const groups = getGroupedStageOptions(matches, [1, 3]);
+
+    expect(groups.all).toBe(alphaStageList);
+  });
+});

--- a/apps/web/src/lib/stageOptions.ts
+++ b/apps/web/src/lib/stageOptions.ts
@@ -13,26 +13,38 @@ export const stageOptions = [NO_SELECTION_STAGE, ...alphaStageList];
 const MOST_PLAYED_LIMIT = 8;
 
 export interface GroupedStageOptions {
-  /** Top stages by usage (count > 0), most-used first, capped at `MOST_PLAYED_LIMIT`. */
+  /** The user's favorited stages, in the order they favorited them — pinned above everything else. */
+  favorites: Stage[];
+  /** Top stages by usage (count > 0, favorites excluded — they're already pinned), most-used first, capped at `MOST_PLAYED_LIMIT`. */
   mostPlayed: Stage[];
-  /** Every real stage, alphabetical — intentionally repeats entries already in `mostPlayed` for scannability. */
+  /** Every real stage, alphabetical — intentionally repeats entries already in `favorites`/`mostPlayed` for scannability. */
   all: Stage[];
 }
 
 /**
- * Builds the "Most played" (usage-ordered, from the user's unfiltered
- * matches) + "All stages" (alphabetical) grouping shown in stage pickers.
- * `matches` should be the user's full, unfiltered match history — usage
- * ordering isn't meant to react to the global analytics filter.
+ * Builds the "Favorites" (user-pinned, saved order) + "Most played"
+ * (usage-ordered, from the user's unfiltered matches) + "All stages"
+ * (alphabetical) grouping shown in stage pickers. `matches` should be the
+ * user's full, unfiltered match history — usage ordering isn't meant to
+ * react to the global analytics filter. Unknown ids in `favoriteStageIds`
+ * are skipped rather than thrown on (stale data can't break the picker).
  */
-export function getGroupedStageOptions(matches: Match[]): GroupedStageOptions {
+export function getGroupedStageOptions(
+  matches: Match[],
+  favoriteStageIds: number[] = [],
+): GroupedStageOptions {
+  const favorites = favoriteStageIds
+    .map((id) => stagesById.get(id))
+    .filter((stage): stage is Stage => stage != null);
+  const favoriteIds = new Set(favorites.map((stage) => stage.id));
+
   const usage = getStageUsage(matches);
   const mostPlayed = alphaStageList
     .map((stage) => ({ stage, count: usage.get(stage.id) ?? 0 }))
-    .filter((entry) => entry.count > 0)
+    .filter((entry) => entry.count > 0 && !favoriteIds.has(entry.stage.id))
     .sort((a, b) => b.count - a.count)
     .slice(0, MOST_PLAYED_LIMIT)
     .map((entry) => entry.stage);
 
-  return { mostPlayed, all: alphaStageList };
+  return { favorites, mostPlayed, all: alphaStageList };
 }

--- a/apps/web/src/pages/Dashboard/components/AddMatchForm.test.tsx
+++ b/apps/web/src/pages/Dashboard/components/AddMatchForm.test.tsx
@@ -30,6 +30,7 @@ const createMatch = vi.fn();
 const listMatches = vi.fn();
 const listOpponents = vi.fn();
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+const getStageFavorites = vi.fn().mockResolvedValue({ stageIds: [], updatedAt: 0 });
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -42,6 +43,9 @@ vi.mock('@/lib/api', () => ({
     },
     opponents: {
       list: (...args: unknown[]) => listOpponents(...args),
+    },
+    stageFavorites: {
+      get: (...args: unknown[]) => getStageFavorites(...args),
     },
   },
 }));

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -43,6 +43,7 @@ const createMatch = vi.fn();
 const getGspSettings = vi.fn();
 const updateGspSettings = vi.fn();
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+const getStageFavorites = vi.fn().mockResolvedValue({ stageIds: [], updatedAt: 0 });
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -57,6 +58,9 @@ vi.mock('@/lib/api', () => ({
     gspSettings: {
       get: (...args: unknown[]) => getGspSettings(...args),
       update: (...args: unknown[]) => updateGspSettings(...args),
+    },
+    stageFavorites: {
+      get: (...args: unknown[]) => getStageFavorites(...args),
     },
   },
 }));

--- a/apps/web/src/pages/MatchData/MatchDataPage.test.tsx
+++ b/apps/web/src/pages/MatchData/MatchDataPage.test.tsx
@@ -36,6 +36,7 @@ const listOpponents = vi.fn();
 const updateMatch = vi.fn();
 const deleteMatch = vi.fn();
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+const getStageFavorites = vi.fn().mockResolvedValue({ stageIds: [], updatedAt: 0 });
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -50,6 +51,9 @@ vi.mock('@/lib/api', () => ({
     },
     opponents: {
       list: (...args: unknown[]) => listOpponents(...args),
+    },
+    stageFavorites: {
+      get: (...args: unknown[]) => getStageFavorites(...args),
     },
   },
 }));

--- a/apps/web/src/pages/Profile/ProfilePage.test.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage.test.tsx
@@ -49,6 +49,8 @@ const reportsConfig = vi.fn().mockResolvedValue({ enabled: false });
 const reportsList = vi.fn().mockResolvedValue([]);
 const billingCredits = vi.fn().mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
 const billingCheckout = vi.fn();
+const stageFavoritesGet = vi.fn().mockResolvedValue({ stageIds: [], updatedAt: 0 });
+const stageFavoritesUpdate = vi.fn();
 
 vi.mock('@/lib/api', () => {
   class MockApiError extends Error {
@@ -76,6 +78,10 @@ vi.mock('@/lib/api', () => {
       billing: {
         credits: (...args: unknown[]) => billingCredits(...args),
         checkout: (...args: unknown[]) => billingCheckout(...args),
+      },
+      stageFavorites: {
+        get: (...args: unknown[]) => stageFavoritesGet(...args),
+        update: (...args: unknown[]) => stageFavoritesUpdate(...args),
       },
     },
     ApiError: MockApiError,

--- a/apps/web/src/pages/Profile/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { AccountCard } from './components/AccountCard';
 import { SecurityCard } from './components/SecurityCard';
 import { ConnectedAccountsCard } from './components/ConnectedAccountsCard';
 import { FightersCard } from './components/FightersCard';
+import { FavoriteStagesCard } from './components/FavoriteStagesCard';
 import { BillingCard } from './components/BillingCard';
 import { YourDataCard } from './components/YourDataCard';
 
@@ -39,6 +40,7 @@ export function ProfilePage() {
       <SecurityCard user={user} />
       <ConnectedAccountsCard />
       <FightersCard />
+      <FavoriteStagesCard />
       <BillingCard />
       <YourDataCard />
     </div>

--- a/apps/web/src/pages/Profile/components/FavoriteStagesCard.test.tsx
+++ b/apps/web/src/pages/Profile/components/FavoriteStagesCard.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const getFavorites = vi.fn();
+const updateFavorites = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    stageFavorites: {
+      get: (...args: unknown[]) => getFavorites(...args),
+      update: (...args: unknown[]) => updateFavorites(...args),
+    },
+  },
+}));
+
+import { AuthProvider } from '@/context/AuthContext';
+import { FavoriteStagesCard } from './FavoriteStagesCard';
+
+function renderCard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <FavoriteStagesCard />
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('FavoriteStagesCard', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    setMockUser(makeMockUser());
+  });
+
+  it('shows an empty state when nothing is favorited yet', async () => {
+    getFavorites.mockResolvedValue({ stageIds: [], updatedAt: 0 });
+
+    renderCard();
+
+    expect(await screen.findByText('No favorite stages yet.')).toBeInTheDocument();
+  });
+
+  it('lists favorites in their saved order', async () => {
+    getFavorites.mockResolvedValue({ stageIds: [113, 1], updatedAt: 5 });
+
+    renderCard();
+
+    expect(await screen.findByText('Small Battlefield')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((li) => li.textContent)).toEqual(['Small Battlefield', 'Battlefield']);
+  });
+
+  it('removing a favorite PUTs the list without it', async () => {
+    const user = userEvent.setup();
+    getFavorites.mockResolvedValue({ stageIds: [113, 1], updatedAt: 5 });
+    updateFavorites.mockResolvedValue({ stageIds: [1], updatedAt: 6 });
+
+    renderCard();
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Remove Small Battlefield from favorites' }),
+    );
+
+    await waitFor(() => expect(updateFavorites).toHaveBeenCalledWith({ stageIds: [1] }));
+  });
+
+  it('adding a stage through the combobox PUTs the list with it appended', async () => {
+    const user = userEvent.setup();
+    getFavorites.mockResolvedValue({ stageIds: [1], updatedAt: 5 });
+    updateFavorites.mockResolvedValue({ stageIds: [1, 113], updatedAt: 6 });
+
+    renderCard();
+
+    await user.click(await screen.findByRole('combobox', { name: /Add a favorite stage/ }));
+    await user.type(screen.getByPlaceholderText('Search stages...'), 'Small Battlefield');
+    await user.click(await screen.findByRole('option', { name: /Small Battlefield/ }));
+
+    await waitFor(() => expect(updateFavorites).toHaveBeenCalledWith({ stageIds: [1, 113] }));
+  });
+
+  it('already-favorited stages are not offered in the combobox', async () => {
+    const user = userEvent.setup();
+    getFavorites.mockResolvedValue({ stageIds: [113], updatedAt: 5 });
+
+    renderCard();
+
+    await user.click(await screen.findByRole('combobox', { name: /Add a favorite stage/ }));
+    await user.type(screen.getByPlaceholderText('Search stages...'), 'Small Battlefield');
+
+    expect(screen.queryByRole('option', { name: /Small Battlefield/ })).not.toBeInTheDocument();
+  });
+
+  it('shows an error toast when saving fails', async () => {
+    const user = userEvent.setup();
+    getFavorites.mockResolvedValue({ stageIds: [1], updatedAt: 5 });
+    updateFavorites.mockRejectedValue(new Error('nope'));
+
+    renderCard();
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Remove Battlefield from favorites' }),
+    );
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/pages/Profile/components/FavoriteStagesCard.tsx
+++ b/apps/web/src/pages/Profile/components/FavoriteStagesCard.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { ChevronsUpDown, X } from 'lucide-react';
+import type { Stage } from '@smash-tracker/shared';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { StageOption } from '@/components/StageOption';
+import { getStageById } from '@/data/stages';
+import { alphaStageList } from '@/lib/stageOptions';
+import { useStageFavorites, useUpdateStageFavorites } from '@/hooks/useStageFavorites';
+
+/**
+ * Profile > Favorite Stages: manage the stages pinned to the top of every
+ * stage picker (Add/Edit Match, set wizard, stage breakdown filter) — the
+ * quickplay/Elite Smash rotation is a handful of stages, so pinning them
+ * beats scrolling the full ~120-stage list on every log. Favorites keep the
+ * order they were added in, which is the order pickers show them.
+ */
+export function FavoriteStagesCard() {
+  const { data: favorites, isLoading } = useStageFavorites();
+  const update = useUpdateStageFavorites();
+  const [addOpen, setAddOpen] = useState(false);
+
+  const stageIds = favorites?.stageIds ?? [];
+  const favoriteStages = stageIds
+    .map((id) => getStageById(id))
+    .filter((stage): stage is Stage => stage != null);
+  const addableStages = alphaStageList.filter((stage) => !stageIds.includes(stage.id));
+
+  function save(nextIds: number[]) {
+    update.mutate(
+      { stageIds: nextIds },
+      {
+        onError: () => toast.error('Could not save your favorite stages. Please try again.'),
+      },
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Favorite Stages</CardTitle>
+        <CardDescription>
+          Pinned to the top of stage pickers when logging matches — handy for the usual
+          quickplay/Elite Smash rotation.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading your favorite stages...</p>
+        ) : favoriteStages.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No favorite stages yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {favoriteStages.map((stage) => (
+              <li
+                key={stage.id}
+                className="flex items-center justify-between gap-2 rounded-md border p-2"
+              >
+                <StageOption stage={stage} />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove ${stage.name} from favorites`}
+                  disabled={update.isPending}
+                  onClick={() => save(stageIds.filter((id) => id !== stage.id))}
+                >
+                  <X />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <Popover open={addOpen} onOpenChange={setAddOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              role="combobox"
+              // Combobox is not a name-from-content role, so the visible
+              // text doesn't become the accessible name on its own.
+              aria-label="Add a favorite stage"
+              aria-expanded={addOpen}
+              disabled={isLoading || update.isPending}
+              className="justify-between font-normal"
+            >
+              Add a favorite stage...
+              <ChevronsUpDown className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+            <Command>
+              <CommandInput placeholder="Search stages..." />
+              <CommandList>
+                <CommandEmpty>No stage found.</CommandEmpty>
+                <CommandGroup>
+                  {addableStages.map((stage) => (
+                    <CommandItem
+                      key={stage.id}
+                      // Two stage names exist under two distinct ids each
+                      // (Yggdrasil's Altar, Spiral Mountain), and cmdk values
+                      // must be unique — suffix the id; name-typed search
+                      // still matches.
+                      value={`${stage.name} ${stage.id}`}
+                      onSelect={() => {
+                        save([...stageIds, stage.id]);
+                        setAddOpen(false);
+                      }}
+                    >
+                      <StageOption stage={stage} />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from './startgg.js';
 export * from './parrygg.js';
 export * from './fighterData.js';
 export * from './stageData.js';
+export * from './stageFavorites.js';
 export * from './reports.js';
 export * from './glicko.js';
 export * from './groups.js';

--- a/packages/shared/src/stageFavorites.ts
+++ b/packages/shared/src/stageFavorites.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { StageList, stagesById } from './stageData.js';
+
+/**
+ * `stageFavorites/{uid}` — the user's favorited stages, pinned to the top of
+ * every stage picker so the handful of stages they actually play on (e.g.
+ * Small Battlefield / Battlefield / the generic hazardless forms for Elite
+ * Smash grinders) don't have to be scrolled to on every match log.
+ *
+ * `stageIds` preserves the order the user favorited them in — that order is
+ * what pickers render, so it doubles as a user-chosen priority order.
+ * `.default([])` matters for reads: RTDB silently drops empty arrays on
+ * write, so a user who removed their last favorite reads back as
+ * `{ updatedAt }` with no `stageIds` key at all.
+ */
+export const stageFavoritesSchema = z.object({
+  /** Favorited stage ids in user-chosen (insertion) order. */
+  stageIds: z.array(z.number().int().positive()).default([]),
+  /** Epoch ms this was last saved — server-stamped, same convention as `gspSettingsSchema`. */
+  updatedAt: z.number(),
+});
+export type StageFavorites = z.infer<typeof stageFavoritesSchema>;
+
+/**
+ * PUT /api/stage-favorites body — the full replacement list (`updatedAt` is
+ * server-stamped). Ids must be real stages from `StageList`; the id-0
+ * "no selection" sentinel is not favoritable (it's already pinned first in
+ * every picker). Duplicates are tolerated and deduped server-side
+ * (first-occurrence-wins) rather than rejected.
+ */
+export const upsertStageFavoritesInputSchema = z.object({
+  stageIds: z
+    .array(z.number().int().positive())
+    .max(StageList.length, 'Too many favorites')
+    .refine((ids) => ids.every((id) => stagesById.has(id)), {
+      message: 'Unknown stage id',
+    }),
+});
+export type UpsertStageFavoritesInput = z.infer<typeof upsertStageFavoritesInputSchema>;


### PR DESCRIPTION
## What

Community request: most quickplay/Elite Smash matches happen on a handful of stages (Small Battlefield, Battlefield, Gen. Battlefield, Gen. FD), so scrolling the full ~120-stage list on every match log is friction. This adds **favorite stages**: manage them in **Profile → Favorite Stages**, and they appear in a pinned **Favorites** group at the very top of every stage picker — Add/Edit Match, the set wizard's per-game rows, and the Match Data Stage Breakdown filter.

## How

- **Shared**: `stageFavoritesSchema` / `upsertStageFavoritesInputSchema` in `packages/shared/src/stageFavorites.ts`. Input ids must be real `StageList` stages (the id-0 sentinel is rejected); `stageIds` defaults to `[]` on read because RTDB drops empty arrays on write.
- **API**: `GET`/`PUT /api/stage-favorites` → `stageFavorites/{uid}`, mirroring the gsp-settings conventions: synthesized empty default instead of 404, server-stamped `updatedAt`, dedupe first-occurrence-wins. No new `buildApp` options, no null writes, RTDB stays deny-all.
- **Web**: `useStageFavorites`/`useUpdateStageFavorites` hooks; `getGroupedStageOptions(matches, favoriteStageIds)` returns a `favorites` group (saved order = the order pickers render) and excludes favorited stages from "Most played" since they're already pinned. The previously-triplicated picker markup is consolidated into a shared `StageSelectGroups` component.
- **Profile card**: current favorites as rows with remove buttons + a searchable combobox to add stages (already-favorited stages aren't offered).

## Tests

- 13 API route tests (defaults, RTDB empty-array read-back, order preservation, dedupe, unknown/sentinel id rejection, auth)
- 5 grouping unit tests, 2 hook tests (auth header + PUT/invalidate), 6 FavoriteStagesCard component tests (add/remove/error toast/order)
- Full suite: shared 174 ✓, api 425 ✓, web 938 ✓ (the one failing web test, `LanguageSelect` full-suite flake, fails identically on clean master — pre-existing, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)