### PR TITLE
Localization phase 2f: Trends + Tournaments pages

### DIFF
--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -97,6 +97,10 @@
       "saved": "VOD-Notizen gespeichert!",
       "saveFailed": "VOD-Notizen konnten nicht gespeichert werden. Bitte erneut versuchen."
     },
+    "startgg": {
+      "view": "Auf start.gg ansehen",
+      "viewName": "{{name}} auf start.gg ansehen"
+    },
     "filteredNotice": {
       "message": "Keine Matches entsprechen den aktuellen Filtern.",
       "clear": "Filter zurücksetzen"
@@ -529,6 +533,148 @@
       "title": "Gegner",
       "empty": "Noch keine benannten Gegner erfasst.",
       "matches": "Matches"
+    }
+  },
+  "trends": {
+    "loading": "Trends werden geladen...",
+    "noMatches": "Du hast noch keine Matches — erfasse eins und schau hier wieder vorbei, um deine Trends zu sehen!",
+    "hero": {
+      "currentRating": "Aktuelle Wertung",
+      "glickoRating": "Glicko-2-Wertung",
+      "notEnoughGames": "Noch nicht genug Matches",
+      "peakRating": "Höchste Wertung",
+      "bestSessionRating": "Beste Sitzungswertung",
+      "bestMonth": "Bester Monat",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}} ({{count}} Matches)",
+      "bestMonthNeeds": "Braucht einen Monat mit {{count}}+ Matches",
+      "currentForm": "Aktuelle Form",
+      "formCaption": "Letzte {{played}} von {{window}} Matches"
+    },
+    "monthly": {
+      "title": "Monatliche Leistung",
+      "winRateLabel": "Winrate",
+      "caption": "Blasse Balken markieren Monate mit weniger als {{count}} Matches — kleine Stichprobe, mit Vorsicht lesen.",
+      "tooltipRate": "Winrate: {{value}} %",
+      "tooltipGames": "Gespielte Matches: {{count}}",
+      "month": "Monat",
+      "wl": "S-N",
+      "games": "Matches"
+    },
+    "ratingCurve": {
+      "title": "Wertungskurve",
+      "current": "aktuelle Wertung",
+      "ratingLabel": "Wertung",
+      "caption": "Glicko-2, sitzungsbasiert · inoffiziell. Gestrichelte Linien zeigen das ±RD-Unsicherheitsband.",
+      "locked": "Die Kurve wird ab {{count}} Matches freigeschaltet",
+      "progress": "Bisher {{played}}/{{threshold}} Matches",
+      "tooltipGames_one": "{{count}} Match in dieser Sitzung",
+      "tooltipGames_other": "{{count}} Matches in dieser Sitzung"
+    },
+    "sessions": {
+      "title": "Sitzungen & Tilt",
+      "total": "Sitzungen gesamt",
+      "avgGames": "Ø Matches / Sitzung",
+      "best": "Beste Sitzung",
+      "worstTilt": "Schlimmster Tilt",
+      "tiltRun": "{{count}}N-Serie",
+      "date": "Datum",
+      "duration": "Dauer",
+      "lossRun": "Längste Niederlagenserie",
+      "durationUnderMin": "< 1 Min.",
+      "durationMin": "{{count}} Min.",
+      "durationHM": "{{hours}} Std. {{minutes}} Min.",
+      "durationH": "{{hours}} Std."
+    },
+    "setting": {
+      "title": "Umgebungsvergleich",
+      "online": "Online",
+      "offline": "Offline",
+      "unspecified": "Nicht angegeben",
+      "noData": "keine Daten",
+      "even": "Du gewinnst online und offline etwa gleich oft.",
+      "youWin": "Du gewinnst",
+      "moreOnline": "häufiger online als offline.",
+      "moreOffline": "häufiger offline als online.",
+      "smallSample": "Für einen verlässlichen Vergleich braucht es mindestens {{count}} Matches online und offline."
+    },
+    "tournaments": {
+      "title": "Turniere",
+      "loading": "Turniere werden geladen...",
+      "resyncPrefix": "Turnier-Einträge kommen mit deinem nächsten start.gg-Sync — geh zu",
+      "resyncSuffix": "und starte den Sync.",
+      "tournament": "Turnier",
+      "event": "Event",
+      "dates": "Daten"
+    },
+    "mix": {
+      "title": "Match-Typ-Mix im Zeitverlauf",
+      "tourney": "Turnier",
+      "friendly": "Friendly",
+      "quickplay": "Quickplay",
+      "unspecified": "Nicht angegeben"
+    }
+  },
+  "tournaments": {
+    "loading": "Turnier wird geladen...",
+    "won": "Gewonnen",
+    "lost": "Verloren",
+    "notFound": {
+      "title": "Turnier nicht gefunden",
+      "body": "Wir konnten keinen Turnier-Eintrag zu diesem Link finden. Er wurde vielleicht unter einem anderen Konto synchronisiert, oder der Link ist veraltet.",
+      "back": "Zurück zu Trends"
+    },
+    "header": {
+      "entrants": "{{count}} Teilnehmer",
+      "setsPlayed_one": "{{count}} Set gespielt",
+      "setsPlayed_other": "{{count}} Sets gespielt",
+      "outperformed": "Seed übertroffen: {{seed}} → {{placement}}",
+      "underperformed": "Seed verfehlt: {{seed}} → {{placement}}",
+      "matched": "Seed getroffen: {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "Event-Ergebnisse",
+      "resync": "Die vollständigen Ergebnisse kommen mit deinem nächsten start.gg-Sync.",
+      "winner": "{{name}} hat dieses Event gewonnen",
+      "place": "Platz",
+      "entrant": "Teilnehmer",
+      "playedTooltip": "Gegen diese Person hast du bei diesem Event gespielt"
+    },
+    "timeline": {
+      "title": "Set-Verlauf",
+      "empty": "Für dieses Event sind noch keine Matches erfasst.",
+      "setsAria": "Sets",
+      "setFallback": "Set {{id}}",
+      "yourFighters": "Deine Kämpfer",
+      "opponentFighters": "Gegnerische Kämpfer",
+      "watchVod": "VOD ansehen",
+      "watchVodAria": "VOD zu {{set}} ansehen",
+      "editVodAria": "VOD-Notizen zu {{set}} bearbeiten",
+      "otherMatches": "Weitere Matches während dieses Events"
+    },
+    "charStages": {
+      "yourCharacters": "Deine Charaktere",
+      "opponentsCharacters": "Charaktere der Gegner",
+      "stagesPlayed": "Gespielte Stages",
+      "noGames": "Keine Matches erfasst.",
+      "noStageData": "Keine Stage-Daten erfasst."
+    },
+    "retro": {
+      "title": "Berater-Rückblick",
+      "description": "Jeder Pick wird daran gemessen, was der Counterpick-Berater empfohlen hätte — nur mit Daten von vor Turnierbeginn.",
+      "noGames": "Für dieses Event sind noch keine Matches erfasst.",
+      "notEnough": "Nicht genug Vor-Turnier-Daten, um diese Picks zu bewerten.",
+      "adherence": "Berater-Befolgung: {{rate}} % der bewertbaren Picks",
+      "followedWon": "befolgte Picks gewannen {{rate}} %",
+      "againstWon": "{{rate}} % bei Picks dagegen",
+      "setsAria": "Sets im Berater-Rückblick",
+      "unknownStage": "unbekannte Stage",
+      "noDataTooltip": "Nicht genug Vor-Turnier-Daten, um diesen Pick zu bewerten. Du hast {{stage}} gespielt. Ergebnis: {{result}}",
+      "advisorTooltip": "Der Berater hätte gesagt: {{advice}} — du hast {{stage}} gespielt ({{verdict}}). Ergebnis: {{result}}",
+      "advicePick": "{{stages}} picken",
+      "adviceNone": "kein klarer Pick",
+      "verdictFollowed": "befolgt",
+      "verdictAgainst": "dagegen",
+      "verdictNeutral": "neutral zu"
     }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -97,6 +97,10 @@
       "saved": "VOD notes saved!",
       "saveFailed": "Failed to save VOD notes. Please try again."
     },
+    "startgg": {
+      "view": "View on start.gg",
+      "viewName": "View {{name}} on start.gg"
+    },
     "filteredNotice": {
       "message": "No matches match the current filters.",
       "clear": "Clear filters"
@@ -529,6 +533,148 @@
       "title": "Opponents",
       "empty": "No named opponents recorded yet.",
       "matches": "Matches"
+    }
+  },
+  "trends": {
+    "loading": "Loading trends...",
+    "noMatches": "You have no matches, report a match and check back here to view trends!",
+    "hero": {
+      "currentRating": "Current Rating",
+      "glickoRating": "Glicko-2 rating",
+      "notEnoughGames": "Not enough games yet",
+      "peakRating": "Peak Rating",
+      "bestSessionRating": "Best session rating",
+      "bestMonth": "Best Month",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}} ({{count}} games)",
+      "bestMonthNeeds": "Needs a month with {{count}}+ games",
+      "currentForm": "Current Form",
+      "formCaption": "Last {{played}} of {{window}} games"
+    },
+    "monthly": {
+      "title": "Monthly Performance",
+      "winRateLabel": "Win Rate",
+      "caption": "Faded bars mark months with fewer than {{count}} games — small sample, read with caution.",
+      "tooltipRate": "Win rate: {{value}}%",
+      "tooltipGames": "Games played: {{count}}",
+      "month": "Month",
+      "wl": "W-L",
+      "games": "Games"
+    },
+    "ratingCurve": {
+      "title": "Rating Curve",
+      "current": "current rating",
+      "ratingLabel": "Rating",
+      "caption": "Glicko-2, session-based · unofficial. Dashed lines show the +/-RD uncertainty band.",
+      "locked": "Rating curve unlocks at {{count}} games",
+      "progress": "{{played}}/{{threshold}} games so far",
+      "tooltipGames_one": "{{count}} game this session",
+      "tooltipGames_other": "{{count}} games this session"
+    },
+    "sessions": {
+      "title": "Sessions & Tilt",
+      "total": "Total Sessions",
+      "avgGames": "Avg Games / Session",
+      "best": "Best Session",
+      "worstTilt": "Worst Tilt",
+      "tiltRun": "{{count}}L run",
+      "date": "Date",
+      "duration": "Duration",
+      "lossRun": "Longest Loss Run",
+      "durationUnderMin": "< 1 min",
+      "durationMin": "{{count}} min",
+      "durationHM": "{{hours}}h {{minutes}}m",
+      "durationH": "{{hours}}h"
+    },
+    "setting": {
+      "title": "Setting Comparison",
+      "online": "Online",
+      "offline": "Offline",
+      "unspecified": "Unspecified",
+      "noData": "no data",
+      "even": "You win about the same rate online and offline.",
+      "youWin": "You win",
+      "moreOnline": "more online than offline.",
+      "moreOffline": "more offline than online.",
+      "smallSample": "Need at least {{count}} games both online and offline for a reliable comparison."
+    },
+    "tournaments": {
+      "title": "Tournaments",
+      "loading": "Loading tournaments...",
+      "resyncPrefix": "Tournament entries attach on your next start.gg sync — head to",
+      "resyncSuffix": "and hit Sync now.",
+      "tournament": "Tournament",
+      "event": "Event",
+      "dates": "Dates"
+    },
+    "mix": {
+      "title": "Match-Type Mix Over Time",
+      "tourney": "Tourney",
+      "friendly": "Friendly",
+      "quickplay": "Quickplay",
+      "unspecified": "Unspecified"
+    }
+  },
+  "tournaments": {
+    "loading": "Loading tournament...",
+    "won": "Won",
+    "lost": "Lost",
+    "notFound": {
+      "title": "Tournament not found",
+      "body": "We couldn't find a tournament entry for that link. It may have been synced under a different account, or you followed a stale link.",
+      "back": "Back to Trends"
+    },
+    "header": {
+      "entrants": "{{count}} entrants",
+      "setsPlayed_one": "{{count}} set played",
+      "setsPlayed_other": "{{count}} sets played",
+      "outperformed": "Outperformed seed: {{seed}} → {{placement}}",
+      "underperformed": "Underperformed seed: {{seed}} → {{placement}}",
+      "matched": "Matched seed: {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "Event Results",
+      "resync": "Full results attach on your next start.gg sync.",
+      "winner": "{{name}} won this event",
+      "place": "Place",
+      "entrant": "Entrant",
+      "playedTooltip": "You played them at this event"
+    },
+    "timeline": {
+      "title": "Set Timeline",
+      "empty": "No matches recorded for this event yet.",
+      "setsAria": "Sets",
+      "setFallback": "Set {{id}}",
+      "yourFighters": "Your fighters",
+      "opponentFighters": "Opponent fighters",
+      "watchVod": "Watch VOD",
+      "watchVodAria": "Watch VOD for {{set}}",
+      "editVodAria": "Edit VOD notes for {{set}}",
+      "otherMatches": "Other matches during this event"
+    },
+    "charStages": {
+      "yourCharacters": "Your Characters",
+      "opponentsCharacters": "Opponents' Characters",
+      "stagesPlayed": "Stages Played",
+      "noGames": "No games recorded.",
+      "noStageData": "No stage data recorded."
+    },
+    "retro": {
+      "title": "Advisor Retrospective",
+      "description": "Grading each pick against what the Counterpick Advisor would have recommended, using only data from before this tournament started.",
+      "noGames": "No games recorded for this event yet.",
+      "notEnough": "Not enough pre-tournament data to grade these picks.",
+      "adherence": "Advisor adherence: {{rate}}% of classifiable picks",
+      "followedWon": "followed picks won {{rate}}%",
+      "againstWon": "{{rate}}% when against",
+      "setsAria": "Advisor retrospective sets",
+      "unknownStage": "unknown stage",
+      "noDataTooltip": "Not enough pre-tournament data to grade this pick. You played {{stage}}. Result: {{result}}",
+      "advisorTooltip": "Advisor would have said: {{advice}} — you played {{stage}} ({{verdict}}). Result: {{result}}",
+      "advicePick": "pick {{stages}}",
+      "adviceNone": "no clear pick",
+      "verdictFollowed": "followed",
+      "verdictAgainst": "against",
+      "verdictNeutral": "neutral on"
     }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -97,6 +97,10 @@
       "saved": "¡Notas de VOD guardadas!",
       "saveFailed": "No se pudieron guardar las notas de VOD. Inténtalo de nuevo."
     },
+    "startgg": {
+      "view": "Ver en start.gg",
+      "viewName": "Ver a {{name}} en start.gg"
+    },
     "filteredNotice": {
       "message": "Ninguna partida coincide con los filtros actuales.",
       "clear": "Borrar filtros"
@@ -529,6 +533,148 @@
       "title": "Rivales",
       "empty": "Aún no hay rivales con nombre registrados.",
       "matches": "Partidas"
+    }
+  },
+  "trends": {
+    "loading": "Cargando tendencias...",
+    "noMatches": "No tienes partidas; registra una y vuelve aquí para ver tus tendencias.",
+    "hero": {
+      "currentRating": "Puntuación actual",
+      "glickoRating": "Puntuación Glicko-2",
+      "notEnoughGames": "Aún no hay suficientes partidas",
+      "peakRating": "Puntuación máxima",
+      "bestSessionRating": "Mejor puntuación de sesión",
+      "bestMonth": "Mejor mes",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}} ({{count}} partidas)",
+      "bestMonthNeeds": "Necesita un mes con {{count}}+ partidas",
+      "currentForm": "Forma actual",
+      "formCaption": "Últimas {{played}} de {{window}} partidas"
+    },
+    "monthly": {
+      "title": "Rendimiento mensual",
+      "winRateLabel": "% de victorias",
+      "caption": "Las barras atenuadas marcan meses con menos de {{count}} partidas — muestra pequeña, interprétala con cautela.",
+      "tooltipRate": "Victorias: {{value}}%",
+      "tooltipGames": "Partidas jugadas: {{count}}",
+      "month": "Mes",
+      "wl": "V-D",
+      "games": "Partidas"
+    },
+    "ratingCurve": {
+      "title": "Curva de puntuación",
+      "current": "puntuación actual",
+      "ratingLabel": "Puntuación",
+      "caption": "Glicko-2, por sesiones · no oficial. Las líneas discontinuas muestran la banda de incertidumbre ±RD.",
+      "locked": "La curva se desbloquea a las {{count}} partidas",
+      "progress": "{{played}}/{{threshold}} partidas hasta ahora",
+      "tooltipGames_one": "{{count}} partida en esta sesión",
+      "tooltipGames_other": "{{count}} partidas en esta sesión"
+    },
+    "sessions": {
+      "title": "Sesiones y tilt",
+      "total": "Sesiones totales",
+      "avgGames": "Partidas medias / sesión",
+      "best": "Mejor sesión",
+      "worstTilt": "Peor tilt",
+      "tiltRun": "Racha de {{count}}D",
+      "date": "Fecha",
+      "duration": "Duración",
+      "lossRun": "Mayor racha de derrotas",
+      "durationUnderMin": "< 1 min",
+      "durationMin": "{{count}} min",
+      "durationHM": "{{hours}}h {{minutes}}m",
+      "durationH": "{{hours}}h"
+    },
+    "setting": {
+      "title": "Comparativa por entorno",
+      "online": "Online",
+      "offline": "Offline",
+      "unspecified": "Sin especificar",
+      "noData": "sin datos",
+      "even": "Ganas más o menos al mismo ritmo online y offline.",
+      "youWin": "Ganas un",
+      "moreOnline": "más online que offline.",
+      "moreOffline": "más offline que online.",
+      "smallSample": "Se necesitan al menos {{count}} partidas online y offline para una comparación fiable."
+    },
+    "tournaments": {
+      "title": "Torneos",
+      "loading": "Cargando torneos...",
+      "resyncPrefix": "Las entradas de torneo se añaden en tu próxima sincronización con start.gg — ve a",
+      "resyncSuffix": "y pulsa Sincronizar ahora.",
+      "tournament": "Torneo",
+      "event": "Evento",
+      "dates": "Fechas"
+    },
+    "mix": {
+      "title": "Mezcla de tipos de partida en el tiempo",
+      "tourney": "Torneo",
+      "friendly": "Amistoso",
+      "quickplay": "Quickplay",
+      "unspecified": "Sin especificar"
+    }
+  },
+  "tournaments": {
+    "loading": "Cargando torneo...",
+    "won": "Ganado",
+    "lost": "Perdido",
+    "notFound": {
+      "title": "Torneo no encontrado",
+      "body": "No encontramos una entrada de torneo para ese enlace. Puede que se sincronizara con otra cuenta o que el enlace esté obsoleto.",
+      "back": "Volver a Tendencias"
+    },
+    "header": {
+      "entrants": "{{count}} participantes",
+      "setsPlayed_one": "{{count}} set jugado",
+      "setsPlayed_other": "{{count}} sets jugados",
+      "outperformed": "Superó el seed: {{seed}} → {{placement}}",
+      "underperformed": "Por debajo del seed: {{seed}} → {{placement}}",
+      "matched": "Igualó el seed: {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "Resultados del evento",
+      "resync": "Los resultados completos se añaden en tu próxima sincronización con start.gg.",
+      "winner": "{{name}} ganó este evento",
+      "place": "Puesto",
+      "entrant": "Participante",
+      "playedTooltip": "Jugaste contra esta persona en este evento"
+    },
+    "timeline": {
+      "title": "Cronología de sets",
+      "empty": "Aún no hay partidas registradas para este evento.",
+      "setsAria": "Sets",
+      "setFallback": "Set {{id}}",
+      "yourFighters": "Tus luchadores",
+      "opponentFighters": "Luchadores del rival",
+      "watchVod": "Ver VOD",
+      "watchVodAria": "Ver VOD de {{set}}",
+      "editVodAria": "Editar notas de VOD de {{set}}",
+      "otherMatches": "Otras partidas durante este evento"
+    },
+    "charStages": {
+      "yourCharacters": "Tus personajes",
+      "opponentsCharacters": "Personajes de los rivales",
+      "stagesPlayed": "Escenarios jugados",
+      "noGames": "No hay partidas registradas.",
+      "noStageData": "No hay datos de escenarios registrados."
+    },
+    "retro": {
+      "title": "Retrospectiva del asesor",
+      "description": "Evalúa cada elección frente a lo que habría recomendado el Asesor de counterpicks, usando solo datos anteriores al inicio de este torneo.",
+      "noGames": "Aún no hay partidas registradas para este evento.",
+      "notEnough": "No hay suficientes datos previos al torneo para evaluar estas elecciones.",
+      "adherence": "Adhesión al asesor: {{rate}}% de las elecciones evaluables",
+      "followedWon": "las elecciones seguidas ganaron el {{rate}}%",
+      "againstWon": "{{rate}}% cuando fue en contra",
+      "setsAria": "Sets de la retrospectiva del asesor",
+      "unknownStage": "escenario desconocido",
+      "noDataTooltip": "No hay suficientes datos previos al torneo para evaluar esta elección. Jugaste en {{stage}}. Resultado: {{result}}",
+      "advisorTooltip": "El asesor habría dicho: {{advice}} — jugaste en {{stage}} ({{verdict}}). Resultado: {{result}}",
+      "advicePick": "elige {{stages}}",
+      "adviceNone": "sin elección clara",
+      "verdictFollowed": "seguida",
+      "verdictAgainst": "en contra",
+      "verdictNeutral": "neutral sobre"
     }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -97,6 +97,10 @@
       "saved": "Notes VOD enregistrées !",
       "saveFailed": "Échec de l'enregistrement des notes VOD. Veuillez réessayer."
     },
+    "startgg": {
+      "view": "Voir sur start.gg",
+      "viewName": "Voir {{name}} sur start.gg"
+    },
     "filteredNotice": {
       "message": "Aucun match ne correspond aux filtres actuels.",
       "clear": "Effacer les filtres"
@@ -529,6 +533,148 @@
       "title": "Adversaires",
       "empty": "Aucun adversaire nommé enregistré pour l'instant.",
       "matches": "Matchs"
+    }
+  },
+  "trends": {
+    "loading": "Chargement des tendances...",
+    "noMatches": "Vous n'avez aucun match : enregistrez-en un puis revenez ici pour voir vos tendances.",
+    "hero": {
+      "currentRating": "Classement actuel",
+      "glickoRating": "Classement Glicko-2",
+      "notEnoughGames": "Pas encore assez de matchs",
+      "peakRating": "Meilleur classement",
+      "bestSessionRating": "Meilleur classement de session",
+      "bestMonth": "Meilleur mois",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}} ({{count}} matchs)",
+      "bestMonthNeeds": "Nécessite un mois avec {{count}}+ matchs",
+      "currentForm": "Forme actuelle",
+      "formCaption": "{{played}} derniers sur {{window}} matchs"
+    },
+    "monthly": {
+      "title": "Performance mensuelle",
+      "winRateLabel": "Taux de victoire",
+      "caption": "Les barres estompées marquent les mois à moins de {{count}} matchs — petit échantillon, à interpréter avec prudence.",
+      "tooltipRate": "Taux de victoire : {{value}}%",
+      "tooltipGames": "Matchs joués : {{count}}",
+      "month": "Mois",
+      "wl": "V-D",
+      "games": "Matchs"
+    },
+    "ratingCurve": {
+      "title": "Courbe de classement",
+      "current": "classement actuel",
+      "ratingLabel": "Classement",
+      "caption": "Glicko-2, par session · non officiel. Les lignes pointillées montrent la bande d'incertitude ±RD.",
+      "locked": "La courbe se débloque à {{count}} matchs",
+      "progress": "{{played}}/{{threshold}} matchs pour l'instant",
+      "tooltipGames_one": "{{count}} match dans cette session",
+      "tooltipGames_other": "{{count}} matchs dans cette session"
+    },
+    "sessions": {
+      "title": "Sessions et tilt",
+      "total": "Sessions au total",
+      "avgGames": "Matchs moyens / session",
+      "best": "Meilleure session",
+      "worstTilt": "Pire tilt",
+      "tiltRun": "Série de {{count}}D",
+      "date": "Date",
+      "duration": "Durée",
+      "lossRun": "Plus longue série de défaites",
+      "durationUnderMin": "< 1 min",
+      "durationMin": "{{count}} min",
+      "durationHM": "{{hours}} h {{minutes}} min",
+      "durationH": "{{hours}} h"
+    },
+    "setting": {
+      "title": "Comparaison des cadres de jeu",
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "unspecified": "Non précisé",
+      "noData": "aucune donnée",
+      "even": "Vous gagnez à peu près au même rythme en ligne et hors ligne.",
+      "youWin": "Vous gagnez",
+      "moreOnline": "de plus en ligne que hors ligne.",
+      "moreOffline": "de plus hors ligne qu'en ligne.",
+      "smallSample": "Il faut au moins {{count}} matchs en ligne et hors ligne pour une comparaison fiable."
+    },
+    "tournaments": {
+      "title": "Tournois",
+      "loading": "Chargement des tournois...",
+      "resyncPrefix": "Les entrées de tournoi s'ajoutent à votre prochaine synchronisation start.gg — allez dans",
+      "resyncSuffix": "et lancez la synchronisation.",
+      "tournament": "Tournoi",
+      "event": "Évènement",
+      "dates": "Dates"
+    },
+    "mix": {
+      "title": "Répartition des types de match dans le temps",
+      "tourney": "Tournoi",
+      "friendly": "Amical",
+      "quickplay": "Quickplay",
+      "unspecified": "Non précisé"
+    }
+  },
+  "tournaments": {
+    "loading": "Chargement du tournoi...",
+    "won": "Gagné",
+    "lost": "Perdu",
+    "notFound": {
+      "title": "Tournoi introuvable",
+      "body": "Nous n'avons pas trouvé d'entrée de tournoi pour ce lien. Elle a peut-être été synchronisée sous un autre compte, ou le lien est obsolète.",
+      "back": "Retour aux Tendances"
+    },
+    "header": {
+      "entrants": "{{count}} participants",
+      "setsPlayed_one": "{{count}} set joué",
+      "setsPlayed_other": "{{count}} sets joués",
+      "outperformed": "Seed dépassé : {{seed}} → {{placement}}",
+      "underperformed": "Sous le seed : {{seed}} → {{placement}}",
+      "matched": "Seed respecté : {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "Résultats de l'évènement",
+      "resync": "Les résultats complets s'ajoutent à votre prochaine synchronisation start.gg.",
+      "winner": "{{name}} a remporté cet évènement",
+      "place": "Place",
+      "entrant": "Participant",
+      "playedTooltip": "Vous l'avez affronté lors de cet évènement"
+    },
+    "timeline": {
+      "title": "Chronologie des sets",
+      "empty": "Aucun match enregistré pour cet évènement pour l'instant.",
+      "setsAria": "Sets",
+      "setFallback": "Set {{id}}",
+      "yourFighters": "Vos combattants",
+      "opponentFighters": "Combattants adverses",
+      "watchVod": "Voir la VOD",
+      "watchVodAria": "Voir la VOD de {{set}}",
+      "editVodAria": "Modifier les notes VOD de {{set}}",
+      "otherMatches": "Autres matchs pendant cet évènement"
+    },
+    "charStages": {
+      "yourCharacters": "Vos personnages",
+      "opponentsCharacters": "Personnages des adversaires",
+      "stagesPlayed": "Stages joués",
+      "noGames": "Aucun match enregistré.",
+      "noStageData": "Aucune donnée de stage enregistrée."
+    },
+    "retro": {
+      "title": "Rétrospective du conseiller",
+      "description": "Chaque pick est comparé à ce que le Conseiller de counterpick aurait recommandé, en utilisant uniquement les données antérieures au début du tournoi.",
+      "noGames": "Aucun match enregistré pour cet évènement pour l'instant.",
+      "notEnough": "Pas assez de données pré-tournoi pour évaluer ces picks.",
+      "adherence": "Adhésion au conseiller : {{rate}}% des picks évaluables",
+      "followedWon": "les picks suivis ont gagné {{rate}}%",
+      "againstWon": "{{rate}}% quand à l'encontre",
+      "setsAria": "Sets de la rétrospective du conseiller",
+      "unknownStage": "stage inconnu",
+      "noDataTooltip": "Pas assez de données pré-tournoi pour évaluer ce pick. Vous avez joué {{stage}}. Résultat : {{result}}",
+      "advisorTooltip": "Le conseiller aurait dit : {{advice}} — vous avez joué {{stage}} ({{verdict}}). Résultat : {{result}}",
+      "advicePick": "prendre {{stages}}",
+      "adviceNone": "pas de pick évident",
+      "verdictFollowed": "suivi",
+      "verdictAgainst": "à l'encontre",
+      "verdictNeutral": "neutre sur"
     }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -97,6 +97,10 @@
       "saved": "VODメモを保存しました！",
       "saveFailed": "VODメモを保存できませんでした。もう一度お試しください。"
     },
+    "startgg": {
+      "view": "start.ggで見る",
+      "viewName": "{{name}}をstart.ggで見る"
+    },
     "filteredNotice": {
       "message": "現在のフィルターに一致する対戦がありません。",
       "clear": "フィルターを解除"
@@ -529,6 +533,148 @@
       "title": "相手プレイヤー",
       "empty": "名前付きの相手はまだ記録されていません。",
       "matches": "対戦数"
+    }
+  },
+  "trends": {
+    "loading": "トレンドを読み込み中...",
+    "noMatches": "まだ対戦がありません。対戦を記録してから、ここでトレンドを確認しましょう！",
+    "hero": {
+      "currentRating": "現在のレーティング",
+      "glickoRating": "Glicko-2レーティング",
+      "notEnoughGames": "まだ対戦数が足りません",
+      "peakRating": "最高レーティング",
+      "bestSessionRating": "セッション最高値",
+      "bestMonth": "ベストな月",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}}（{{count}}戦）",
+      "bestMonthNeeds": "{{count}}戦以上の月が必要です",
+      "currentForm": "現在の調子",
+      "formCaption": "直近{{window}}戦のうち{{played}}戦"
+    },
+    "monthly": {
+      "title": "月別パフォーマンス",
+      "winRateLabel": "勝率",
+      "caption": "薄いバーは{{count}}戦未満の月です — サンプルが少ないため参考程度に。",
+      "tooltipRate": "勝率: {{value}}%",
+      "tooltipGames": "対戦数: {{count}}",
+      "month": "月",
+      "wl": "勝-敗",
+      "games": "対戦数"
+    },
+    "ratingCurve": {
+      "title": "レーティング推移",
+      "current": "現在のレーティング",
+      "ratingLabel": "レーティング",
+      "caption": "Glicko-2・セッション制・非公式。点線は±RDの不確実性の帯を示します。",
+      "locked": "推移は{{count}}戦で解放されます",
+      "progress": "現在{{played}}/{{threshold}}戦",
+      "tooltipGames_one": "このセッションで{{count}}戦",
+      "tooltipGames_other": "このセッションで{{count}}戦"
+    },
+    "sessions": {
+      "title": "セッションとティルト",
+      "total": "総セッション数",
+      "avgGames": "セッション平均対戦数",
+      "best": "ベストセッション",
+      "worstTilt": "最悪のティルト",
+      "tiltRun": "{{count}}連敗",
+      "date": "日付",
+      "duration": "時間",
+      "lossRun": "最長連敗",
+      "durationUnderMin": "1分未満",
+      "durationMin": "{{count}}分",
+      "durationHM": "{{hours}}時間{{minutes}}分",
+      "durationH": "{{hours}}時間"
+    },
+    "setting": {
+      "title": "オン/オフ環境の比較",
+      "online": "オンライン",
+      "offline": "オフライン",
+      "unspecified": "未指定",
+      "noData": "データなし",
+      "even": "オンラインとオフラインの勝率はほぼ同じです。",
+      "youWin": "勝率の差:",
+      "moreOnline": "オンラインの方が高い。",
+      "moreOffline": "オフラインの方が高い。",
+      "smallSample": "信頼できる比較には、オンライン・オフラインそれぞれ{{count}}戦以上が必要です。"
+    },
+    "tournaments": {
+      "title": "大会",
+      "loading": "大会を読み込み中...",
+      "resyncPrefix": "大会エントリーは次回のstart.gg同期で追加されます —",
+      "resyncSuffix": "から同期を実行してください。",
+      "tournament": "大会",
+      "event": "種目",
+      "dates": "日程"
+    },
+    "mix": {
+      "title": "対戦タイプの推移",
+      "tourney": "大会",
+      "friendly": "フリー",
+      "quickplay": "クイックプレイ",
+      "unspecified": "未指定"
+    }
+  },
+  "tournaments": {
+    "loading": "大会を読み込み中...",
+    "won": "勝利",
+    "lost": "敗北",
+    "notFound": {
+      "title": "大会が見つかりません",
+      "body": "このリンクに対応する大会エントリーが見つかりませんでした。別のアカウントで同期されたか、古いリンクの可能性があります。",
+      "back": "トレンドに戻る"
+    },
+    "header": {
+      "entrants": "参加者{{count}}名",
+      "setsPlayed_one": "{{count}}セットプレイ",
+      "setsPlayed_other": "{{count}}セットプレイ",
+      "outperformed": "シード超え: {{seed}} → {{placement}}",
+      "underperformed": "シード未達: {{seed}} → {{placement}}",
+      "matched": "シード通り: {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "大会結果",
+      "resync": "完全な結果は次回のstart.gg同期で追加されます。",
+      "winner": "{{name}}がこの大会で優勝",
+      "place": "順位",
+      "entrant": "参加者",
+      "playedTooltip": "この大会で対戦した相手です"
+    },
+    "timeline": {
+      "title": "セットの流れ",
+      "empty": "この大会の対戦はまだ記録されていません。",
+      "setsAria": "セット",
+      "setFallback": "セット{{id}}",
+      "yourFighters": "自分のファイター",
+      "opponentFighters": "相手のファイター",
+      "watchVod": "VODを見る",
+      "watchVodAria": "{{set}}のVODを見る",
+      "editVodAria": "{{set}}のVODメモを編集",
+      "otherMatches": "この大会中のその他の対戦"
+    },
+    "charStages": {
+      "yourCharacters": "自分の使用キャラ",
+      "opponentsCharacters": "相手の使用キャラ",
+      "stagesPlayed": "プレイしたステージ",
+      "noGames": "対戦の記録がありません。",
+      "noStageData": "ステージのデータがありません。"
+    },
+    "retro": {
+      "title": "アドバイザー振り返り",
+      "description": "各ステージ選択を、この大会開始前のデータのみを使ってカウンターピック指南が推奨したであろう内容と照らし合わせて評価します。",
+      "noGames": "この大会の対戦はまだ記録されていません。",
+      "notEnough": "評価に必要な大会前のデータが足りません。",
+      "adherence": "アドバイザー遵守率: 評価可能な選択の{{rate}}%",
+      "followedWon": "推奨に従った選択の勝率{{rate}}%",
+      "againstWon": "逆らった場合は{{rate}}%",
+      "setsAria": "アドバイザー振り返りのセット",
+      "unknownStage": "不明なステージ",
+      "noDataTooltip": "この選択を評価するには大会前のデータが足りません。プレイしたのは{{stage}}。結果: {{result}}",
+      "advisorTooltip": "アドバイザーの推奨: {{advice}} — 実際にプレイしたのは{{stage}}（{{verdict}}）。結果: {{result}}",
+      "advicePick": "{{stages}}を選ぶ",
+      "adviceNone": "明確な推奨なし",
+      "verdictFollowed": "従った",
+      "verdictAgainst": "逆らった",
+      "verdictNeutral": "どちらでもない"
     }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -97,6 +97,10 @@
       "saved": "Notas de VOD salvas!",
       "saveFailed": "Falha ao salvar as notas de VOD. Tente novamente."
     },
+    "startgg": {
+      "view": "Ver no start.gg",
+      "viewName": "Ver {{name}} no start.gg"
+    },
     "filteredNotice": {
       "message": "Nenhuma partida corresponde aos filtros atuais.",
       "clear": "Limpar filtros"
@@ -529,6 +533,148 @@
       "title": "Oponentes",
       "empty": "Nenhum oponente nomeado registrado ainda.",
       "matches": "Partidas"
+    }
+  },
+  "trends": {
+    "loading": "Carregando tendências...",
+    "noMatches": "Você não tem partidas; registre uma e volte aqui para ver as tendências!",
+    "hero": {
+      "currentRating": "Pontuação atual",
+      "glickoRating": "Pontuação Glicko-2",
+      "notEnoughGames": "Ainda não há partidas suficientes",
+      "peakRating": "Pontuação máxima",
+      "bestSessionRating": "Melhor pontuação de sessão",
+      "bestMonth": "Melhor mês",
+      "bestMonthCaption": "{{month}} · {{wins}}-{{losses}} ({{count}} partidas)",
+      "bestMonthNeeds": "Precisa de um mês com {{count}}+ partidas",
+      "currentForm": "Forma atual",
+      "formCaption": "Últimas {{played}} de {{window}} partidas"
+    },
+    "monthly": {
+      "title": "Desempenho mensal",
+      "winRateLabel": "Taxa de vitórias",
+      "caption": "As barras esmaecidas marcam meses com menos de {{count}} partidas — amostra pequena, interprete com cautela.",
+      "tooltipRate": "Taxa de vitórias: {{value}}%",
+      "tooltipGames": "Partidas jogadas: {{count}}",
+      "month": "Mês",
+      "wl": "V-D",
+      "games": "Partidas"
+    },
+    "ratingCurve": {
+      "title": "Curva de pontuação",
+      "current": "pontuação atual",
+      "ratingLabel": "Pontuação",
+      "caption": "Glicko-2, por sessão · não oficial. As linhas tracejadas mostram a faixa de incerteza ±RD.",
+      "locked": "A curva desbloqueia com {{count}} partidas",
+      "progress": "{{played}}/{{threshold}} partidas até agora",
+      "tooltipGames_one": "{{count}} partida nesta sessão",
+      "tooltipGames_other": "{{count}} partidas nesta sessão"
+    },
+    "sessions": {
+      "title": "Sessões e tilt",
+      "total": "Sessões no total",
+      "avgGames": "Média de partidas / sessão",
+      "best": "Melhor sessão",
+      "worstTilt": "Pior tilt",
+      "tiltRun": "Sequência de {{count}}D",
+      "date": "Data",
+      "duration": "Duração",
+      "lossRun": "Maior sequência de derrotas",
+      "durationUnderMin": "< 1 min",
+      "durationMin": "{{count}} min",
+      "durationHM": "{{hours}}h {{minutes}}m",
+      "durationH": "{{hours}}h"
+    },
+    "setting": {
+      "title": "Comparação de ambiente",
+      "online": "Online",
+      "offline": "Offline",
+      "unspecified": "Não especificado",
+      "noData": "sem dados",
+      "even": "Você vence mais ou menos na mesma proporção online e offline.",
+      "youWin": "Você vence",
+      "moreOnline": "a mais online do que offline.",
+      "moreOffline": "a mais offline do que online.",
+      "smallSample": "São necessárias pelo menos {{count}} partidas online e offline para uma comparação confiável."
+    },
+    "tournaments": {
+      "title": "Torneios",
+      "loading": "Carregando torneios...",
+      "resyncPrefix": "As entradas de torneio chegam na sua próxima sincronização com o start.gg — vá em",
+      "resyncSuffix": "e clique em Sincronizar agora.",
+      "tournament": "Torneio",
+      "event": "Evento",
+      "dates": "Datas"
+    },
+    "mix": {
+      "title": "Mix de tipos de partida ao longo do tempo",
+      "tourney": "Torneio",
+      "friendly": "Amistoso",
+      "quickplay": "Quickplay",
+      "unspecified": "Não especificado"
+    }
+  },
+  "tournaments": {
+    "loading": "Carregando torneio...",
+    "won": "Vitória",
+    "lost": "Derrota",
+    "notFound": {
+      "title": "Torneio não encontrado",
+      "body": "Não encontramos uma entrada de torneio para esse link. Ela pode ter sido sincronizada em outra conta, ou o link está desatualizado.",
+      "back": "Voltar para Tendências"
+    },
+    "header": {
+      "entrants": "{{count}} participantes",
+      "setsPlayed_one": "{{count}} set jogado",
+      "setsPlayed_other": "{{count}} sets jogados",
+      "outperformed": "Superou o seed: {{seed}} → {{placement}}",
+      "underperformed": "Abaixo do seed: {{seed}} → {{placement}}",
+      "matched": "Igualou o seed: {{seed}} → {{placement}}"
+    },
+    "results": {
+      "title": "Resultados do evento",
+      "resync": "Os resultados completos chegam na sua próxima sincronização com o start.gg.",
+      "winner": "{{name}} venceu este evento",
+      "place": "Colocação",
+      "entrant": "Participante",
+      "playedTooltip": "Você jogou contra essa pessoa neste evento"
+    },
+    "timeline": {
+      "title": "Linha do tempo dos sets",
+      "empty": "Nenhuma partida registrada para este evento ainda.",
+      "setsAria": "Sets",
+      "setFallback": "Set {{id}}",
+      "yourFighters": "Seus lutadores",
+      "opponentFighters": "Lutadores do oponente",
+      "watchVod": "Assistir VOD",
+      "watchVodAria": "Assistir VOD de {{set}}",
+      "editVodAria": "Editar notas de VOD de {{set}}",
+      "otherMatches": "Outras partidas durante este evento"
+    },
+    "charStages": {
+      "yourCharacters": "Seus personagens",
+      "opponentsCharacters": "Personagens dos oponentes",
+      "stagesPlayed": "Stages jogados",
+      "noGames": "Nenhuma partida registrada.",
+      "noStageData": "Nenhum dado de stage registrado."
+    },
+    "retro": {
+      "title": "Retrospectiva do conselheiro",
+      "description": "Avalia cada escolha em relação ao que o Conselheiro de counterpick teria recomendado, usando apenas dados anteriores ao início deste torneio.",
+      "noGames": "Nenhuma partida registrada para este evento ainda.",
+      "notEnough": "Não há dados pré-torneio suficientes para avaliar essas escolhas.",
+      "adherence": "Adesão ao conselheiro: {{rate}}% das escolhas avaliáveis",
+      "followedWon": "escolhas seguidas venceram {{rate}}%",
+      "againstWon": "{{rate}}% quando contra",
+      "setsAria": "Sets da retrospectiva do conselheiro",
+      "unknownStage": "stage desconhecido",
+      "noDataTooltip": "Não há dados pré-torneio suficientes para avaliar esta escolha. Você jogou em {{stage}}. Resultado: {{result}}",
+      "advisorTooltip": "O conselheiro teria dito: {{advice}} — você jogou em {{stage}} ({{verdict}}). Resultado: {{result}}",
+      "advicePick": "escolha {{stages}}",
+      "adviceNone": "sem escolha clara",
+      "verdictFollowed": "seguiu",
+      "verdictAgainst": "contra",
+      "verdictNeutral": "neutro sobre"
     }
   }
 }

--- a/apps/web/src/pages/Tournaments/TournamentDetailPage.tsx
+++ b/apps/web/src/pages/Tournaments/TournamentDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useParams, Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useTournamentEntries } from '@/hooks/useTournamentEntries';
 import { useMatches } from '@/hooks/useMatches';
@@ -13,15 +14,13 @@ import { buildSetTimeline } from './lib/setTimeline';
 import { buildRetrospective } from './lib/retrospective';
 
 function NotFoundState() {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center gap-4 py-16 text-center">
-      <h1 className="text-2xl font-semibold tracking-tight">Tournament not found</h1>
-      <p className="max-w-md text-muted-foreground">
-        We couldn&apos;t find a tournament entry for that link. It may have been synced under a
-        different account, or you followed a stale link.
-      </p>
+      <h1 className="text-2xl font-semibold tracking-tight">{t('tournaments.notFound.title')}</h1>
+      <p className="max-w-md text-muted-foreground">{t('tournaments.notFound.body')}</p>
       <Button asChild className="mt-2">
-        <Link to="/trends">Back to Trends</Link>
+        <Link to="/trends">{t('tournaments.notFound.back')}</Link>
       </Button>
     </div>
   );
@@ -37,6 +36,7 @@ function NotFoundState() {
  * entry.
  */
 export function TournamentDetailPage() {
+  const { t } = useTranslation();
   const { eventId } = useParams<{ eventId: string }>();
   const { data: entries, isLoading: entriesLoading } = useTournamentEntries();
   const { data: allMatches = [], isLoading: matchesLoading } = useMatches();
@@ -66,7 +66,7 @@ export function TournamentDetailPage() {
   }, [allMatches, entryMatches, entry]);
 
   if (entriesLoading || matchesLoading) {
-    return <div className="text-muted-foreground">Loading tournament...</div>;
+    return <div className="text-muted-foreground">{t('tournaments.loading')}</div>;
   }
 
   if (!entry) {

--- a/apps/web/src/pages/Tournaments/components/AdvisorRetrospective.tsx
+++ b/apps/web/src/pages/Tournaments/components/AdvisorRetrospective.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -19,31 +21,42 @@ const CLASSIFICATION_STYLE: Record<ClassifiedGame['classification'], string> = {
   'no-data': 'border border-dashed text-muted-foreground',
 };
 
-function stageLabel(stageId: number): string {
-  return stagesById.get(stageId)?.name ?? 'Unknown';
+function stageLabel(stageId: number, t: TFunction): string {
+  return stagesById.get(stageId)?.name ?? t('common.unknown');
 }
 
-function tooltipText(game: ClassifiedGame): string {
+function tooltipText(game: ClassifiedGame, t: TFunction): string {
   const playedStage =
-    game.match.map && game.match.map.id !== 0 ? stageLabel(game.match.map.id) : 'unknown stage';
+    game.match.map && game.match.map.id !== 0
+      ? stageLabel(game.match.map.id, t)
+      : t('tournaments.retro.unknownStage');
   const result = game.match.win ? 'W' : 'L';
 
   if (game.classification === 'no-data') {
-    return `Not enough pre-tournament data to grade this pick. You played ${playedStage}. Result: ${result}`;
+    return t('tournaments.retro.noDataTooltip', { stage: playedStage, result });
   }
 
-  const picks = game.recommendedStageIds.map(stageLabel).join('/');
-  const advisorText = picks.length > 0 ? `pick ${picks}` : 'no clear pick';
+  const picks = game.recommendedStageIds.map((id) => stageLabel(id, t)).join('/');
+  const advisorText =
+    picks.length > 0
+      ? t('tournaments.retro.advicePick', { stages: picks })
+      : t('tournaments.retro.adviceNone');
   const verdict =
     game.classification === 'followed'
-      ? 'followed'
+      ? t('tournaments.retro.verdictFollowed')
       : game.classification === 'against'
-        ? 'against'
-        : 'neutral on';
-  return `Advisor would have said: ${advisorText} — you played ${playedStage} (${verdict}). Result: ${result}`;
+        ? t('tournaments.retro.verdictAgainst')
+        : t('tournaments.retro.verdictNeutral');
+  return t('tournaments.retro.advisorTooltip', {
+    advice: advisorText,
+    stage: playedStage,
+    verdict,
+    result,
+  });
 }
 
 function GameIcon({ game }: { game: ClassifiedGame }) {
+  const { t } = useTranslation();
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -57,30 +70,27 @@ function GameIcon({ game }: { game: ClassifiedGame }) {
           {CLASSIFICATION_ICON[game.classification]}
         </span>
       </TooltipTrigger>
-      <TooltipContent className="max-w-64 text-center">{tooltipText(game)}</TooltipContent>
+      <TooltipContent className="max-w-64 text-center">{tooltipText(game, t)}</TooltipContent>
     </Tooltip>
   );
 }
 
 function AdherenceSummaryCard({ summary }: { summary: Retrospective['summary'] }) {
+  const { t } = useTranslation();
   if (summary.classifiable === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Not enough pre-tournament data to grade these picks.
-      </p>
-    );
+    return <p className="text-sm text-muted-foreground">{t('tournaments.retro.notEnough')}</p>;
   }
 
-  const parts: string[] = [`Advisor adherence: ${summary.adherenceRate}% of classifiable picks`];
+  const parts: string[] = [t('tournaments.retro.adherence', { rate: summary.adherenceRate })];
   const winRateParts: string[] = [];
   if (summary.followedWinRate != null) {
-    winRateParts.push(`followed picks won ${summary.followedWinRate}%`);
+    winRateParts.push(t('tournaments.retro.followedWon', { rate: summary.followedWinRate }));
   }
   if (summary.againstWinRate != null) {
-    winRateParts.push(`${summary.againstWinRate}% when against`);
+    winRateParts.push(t('tournaments.retro.againstWon', { rate: summary.againstWinRate }));
   }
   if (winRateParts.length > 0) {
-    parts.push(winRateParts.join(' vs '));
+    parts.push(winRateParts.join(` ${t('matchups.vs')} `));
   }
 
   return <p className="text-sm">{parts.join(' · ')}</p>;
@@ -94,35 +104,33 @@ function AdherenceSummaryCard({ summary }: { summary: Retrospective['summary'] }
  * lives in `lib/retrospective.ts`.
  */
 export function AdvisorRetrospective({ retrospective }: { retrospective: Retrospective }) {
+  const { t } = useTranslation();
   const { rows, otherGames, summary } = retrospective;
   const hasAnyGames = rows.some((r) => r.games.length > 0) || otherGames.length > 0;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Advisor Retrospective</CardTitle>
-        <CardDescription>
-          Grading each pick against what the Counterpick Advisor would have recommended, using only
-          data from before this tournament started.
-        </CardDescription>
+        <CardTitle>{t('tournaments.retro.title')}</CardTitle>
+        <CardDescription>{t('tournaments.retro.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {!hasAnyGames ? (
-          <p className="text-sm text-muted-foreground">No games recorded for this event yet.</p>
+          <p className="text-sm text-muted-foreground">{t('tournaments.retro.noGames')}</p>
         ) : (
           <>
             <div className="rounded-md border bg-muted/30 p-3">
               <AdherenceSummaryCard summary={summary} />
             </div>
 
-            <ul className="flex flex-col gap-2" aria-label="Advisor retrospective sets">
+            <ul className="flex flex-col gap-2" aria-label={t('tournaments.retro.setsAria')}>
               {rows.map(({ set, games }) => (
                 <li
                   key={set.setId}
                   className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3"
                 >
                   <span className="min-w-32 text-sm font-medium">
-                    {set.roundText ?? `Set ${set.setId}`}
+                    {set.roundText ?? t('tournaments.timeline.setFallback', { id: set.setId })}
                   </span>
                   <div className="flex items-center gap-1.5">
                     {games.map((game) => (
@@ -130,7 +138,7 @@ export function AdvisorRetrospective({ retrospective }: { retrospective: Retrosp
                     ))}
                   </div>
                   <Badge variant={set.won ? 'success' : 'destructive'}>
-                    {set.won ? 'Won' : 'Lost'}
+                    {set.won ? t('tournaments.won') : t('tournaments.lost')}
                   </Badge>
                 </li>
               ))}
@@ -139,7 +147,7 @@ export function AdvisorRetrospective({ retrospective }: { retrospective: Retrosp
             {otherGames.length > 0 && (
               <div>
                 <h3 className="mb-2 text-sm font-medium text-muted-foreground">
-                  Other matches during this event
+                  {t('tournaments.timeline.otherMatches')}
                 </h3>
                 <div className="flex flex-wrap items-center gap-1.5">
                   {otherGames.map((game) => (

--- a/apps/web/src/pages/Tournaments/components/CharactersAndStages.tsx
+++ b/apps/web/src/pages/Tournaments/components/CharactersAndStages.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getFighterById } from '@/data/sprites';
 import { stagesById } from '@/data/stages';
@@ -5,15 +6,16 @@ import { getRecordsByFighter, getStageRecords, type FighterRecord } from '@/lib/
 import type { Match } from '@smash-tracker/shared';
 
 function FighterRow({ record }: { record: FighterRecord }) {
+  const { t } = useTranslation();
   const sprite = getFighterById(record.fighterId);
   return (
     <li className="flex items-center justify-between gap-2">
       <div className="flex items-center gap-2">
         {sprite && <img src={sprite.url} alt="" className="size-7 object-contain" />}
-        <span className="text-sm">{sprite?.name ?? 'Unknown'}</span>
+        <span className="text-sm">{sprite?.name ?? t('common.unknown')}</span>
       </div>
       <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
-        {record.wins}-{record.losses} · {record.total} game{record.total === 1 ? '' : 's'}
+        {record.wins}-{record.losses} · {t('common.games', { count: record.total })}
       </span>
     </li>
   );
@@ -28,6 +30,7 @@ function FighterCard({
   matches: Match[];
   keyFn?: (match: Match) => number;
 }) {
+  const { t } = useTranslation();
   const records = getRecordsByFighter(matches, keyFn).sort((a, b) => b.total - a.total);
 
   return (
@@ -37,7 +40,7 @@ function FighterCard({
       </CardHeader>
       <CardContent>
         {records.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No games recorded.</p>
+          <p className="text-sm text-muted-foreground">{t('tournaments.charStages.noGames')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {records.map((record) => (
@@ -51,6 +54,7 @@ function FighterCard({
 }
 
 function StagesCard({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const records = getStageRecords(matches)
     .filter((r) => r.stageId !== 0)
     .sort((a, b) => b.total - a.total);
@@ -58,11 +62,11 @@ function StagesCard({ matches }: { matches: Match[] }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Stages Played</CardTitle>
+        <CardTitle className="text-base">{t('tournaments.charStages.stagesPlayed')}</CardTitle>
       </CardHeader>
       <CardContent>
         {records.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No stage data recorded.</p>
+          <p className="text-sm text-muted-foreground">{t('tournaments.charStages.noStageData')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {records.map((record) => {
@@ -77,11 +81,10 @@ function StagesCard({ matches }: { matches: Match[] }) {
                         {stage ? stage.name.slice(0, 3).toUpperCase() : '??'}
                       </span>
                     )}
-                    <span className="text-sm">{stage?.name ?? 'Unknown'}</span>
+                    <span className="text-sm">{stage?.name ?? t('common.unknown')}</span>
                   </div>
                   <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
-                    {record.wins}-{record.losses} · {record.total} game
-                    {record.total === 1 ? '' : 's'}
+                    {record.wins}-{record.losses} · {t('common.games', { count: record.total })}
                   </span>
                 </li>
               );
@@ -99,10 +102,15 @@ function StagesCard({ matches }: { matches: Match[] }) {
  * stages played — all derived from the same entry-scoped match list.
  */
 export function CharactersAndStages({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      <FighterCard title="Your Characters" matches={matches} />
-      <FighterCard title="Opponents' Characters" matches={matches} keyFn={(m) => m.opponent_id} />
+      <FighterCard title={t('tournaments.charStages.yourCharacters')} matches={matches} />
+      <FighterCard
+        title={t('tournaments.charStages.opponentsCharacters')}
+        matches={matches}
+        keyFn={(m) => m.opponent_id}
+      />
       <StagesCard matches={matches} />
     </div>
   );

--- a/apps/web/src/pages/Tournaments/components/EventResults.tsx
+++ b/apps/web/src/pages/Tournaments/components/EventResults.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ExternalLink, Trophy } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -14,6 +15,7 @@ import type { Match, TournamentEntry } from '@smash-tracker/shared';
 import { buildEventResultRows, type EventResultRow } from '../lib/eventResults';
 
 function ProfileLink({ row }: { row: EventResultRow }) {
+  const { t } = useTranslation();
   if (!row.profileUrl) {
     return null;
   }
@@ -22,7 +24,7 @@ function ProfileLink({ row }: { row: EventResultRow }) {
       href={row.profileUrl}
       target="_blank"
       rel="noreferrer"
-      aria-label={`View ${row.displayName} on start.gg`}
+      aria-label={t('shared.startgg.viewName', { name: row.displayName })}
       className="inline-flex text-muted-foreground hover:text-foreground"
     >
       <ExternalLink className="size-3.5" />
@@ -31,6 +33,7 @@ function ProfileLink({ row }: { row: EventResultRow }) {
 }
 
 function ResultRow({ row }: { row: EventResultRow }) {
+  const { t } = useTranslation();
   const nameCell = (
     <span className="inline-flex items-center gap-2">
       {row.standing.placement === 1 && <Trophy className="size-4 text-amber-500" />}
@@ -55,7 +58,7 @@ function ResultRow({ row }: { row: EventResultRow }) {
                 {nameCell}
               </span>
             </TooltipTrigger>
-            <TooltipContent>You played them at this event</TooltipContent>
+            <TooltipContent>{t('tournaments.results.playedTooltip')}</TooltipContent>
           </Tooltip>
         ) : (
           nameCell
@@ -82,33 +85,34 @@ export function EventResults({
   entry: TournamentEntry;
   entryMatches: Match[];
 }) {
+  const { t } = useTranslation();
   const rows = buildEventResultRows(entry, entryMatches);
   const winner = rows.find((row) => row.standing.placement === 1);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Event Results</CardTitle>
+        <CardTitle>{t('tournaments.results.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Full results attach on your next start.gg sync.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('tournaments.results.resync')}</p>
         ) : (
           <>
             {winner && (
               <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
                 <Trophy className="size-5 text-amber-500" />
-                <span className="text-sm font-medium">{winner.displayName} won this event</span>
+                <span className="text-sm font-medium">
+                  {t('tournaments.results.winner', { name: winner.displayName })}
+                </span>
                 <ProfileLink row={winner} />
               </div>
             )}
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="w-16">Place</TableHead>
-                  <TableHead>Entrant</TableHead>
+                  <TableHead className="w-16">{t('tournaments.results.place')}</TableHead>
+                  <TableHead>{t('tournaments.results.entrant')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
+++ b/apps/web/src/pages/Tournaments/components/SetTimeline.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ExternalLink, Pencil } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -16,6 +17,7 @@ import { formatTimestamp, vodDeepLink } from '@/lib/vod';
 import { VodNotesDialog } from '@/components/vod/VodNotesDialog';
 
 function GameChip({ match }: { match: Match }) {
+  const { t } = useTranslation();
   const stageId = match.map?.id ?? 0;
   const stage = stageId !== 0 ? stagesById.get(stageId) : undefined;
   const stageName = stage?.name ?? match.map?.name ?? 'unknown';
@@ -38,7 +40,7 @@ function GameChip({ match }: { match: Match }) {
         </span>
       </TooltipTrigger>
       <TooltipContent>
-        {stageName} — {match.win ? 'Win' : 'Loss'}
+        {stageName} — {match.win ? t('common.win') : t('common.loss')}
         {matchup}
       </TooltipContent>
     </Tooltip>
@@ -106,6 +108,7 @@ function VodTimestampChips({ vodUrl, match }: { vodUrl: string; match: Match }) 
  * VOD can be attached even for sets that never got one from start.gg.
  */
 function VodLink({ set }: { set: TournamentSet }) {
+  const { t } = useTranslation();
   const [dialogOpen, setDialogOpen] = useState(false);
   const vodMatch =
     set.games.map((g) => g.match).find((m) => m.vodUrl != null) ?? set.games[0]?.match;
@@ -115,6 +118,8 @@ function VodLink({ set }: { set: TournamentSet }) {
     return null;
   }
 
+  const setLabel = set.roundText ?? t('tournaments.timeline.setFallback', { id: set.setId });
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       {vodUrl && (
@@ -123,10 +128,10 @@ function VodLink({ set }: { set: TournamentSet }) {
             href={vodUrl}
             target="_blank"
             rel="noreferrer"
-            aria-label={`Watch VOD for ${set.roundText ?? `Set ${set.setId}`}`}
+            aria-label={t('tournaments.timeline.watchVodAria', { set: setLabel })}
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
-            Watch VOD
+            {t('tournaments.timeline.watchVod')}
             <ExternalLink className="size-3.5" />
           </a>
           <VodTimestampChips vodUrl={vodUrl} match={vodMatch} />
@@ -136,7 +141,7 @@ function VodLink({ set }: { set: TournamentSet }) {
         type="button"
         variant="ghost"
         size="icon-sm"
-        aria-label={`Edit VOD notes for ${set.roundText ?? `Set ${set.setId}`}`}
+        aria-label={t('tournaments.timeline.editVodAria', { set: setLabel })}
         onClick={() => setDialogOpen(true)}
       >
         <Pencil className="size-3.5" />
@@ -149,6 +154,7 @@ function VodLink({ set }: { set: TournamentSet }) {
 }
 
 function OpponentLabel({ set }: { set: TournamentSet }) {
+  const { t } = useTranslation();
   if (!set.opponentName) {
     return null;
   }
@@ -167,7 +173,7 @@ function OpponentLabel({ set }: { set: TournamentSet }) {
             href={profileUrl}
             target="_blank"
             rel="noreferrer"
-            aria-label={`View ${set.opponentName} on start.gg`}
+            aria-label={t('shared.startgg.viewName', { name: set.opponentName })}
             className="inline-flex text-muted-foreground hover:text-foreground"
           >
             <ExternalLink className="size-3.5" />
@@ -180,6 +186,7 @@ function OpponentLabel({ set }: { set: TournamentSet }) {
 }
 
 function SetRow({ set }: { set: TournamentSet }) {
+  const { t } = useTranslation();
   const isLosersSide = set.bracketRound != null && set.bracketRound < 0;
 
   return (
@@ -190,11 +197,19 @@ function SetRow({ set }: { set: TournamentSet }) {
       )}
     >
       <div className="flex flex-wrap items-center gap-3">
-        <span className="min-w-32 text-sm font-medium">{set.roundText ?? `Set ${set.setId}`}</span>
+        <span className="min-w-32 text-sm font-medium">
+          {set.roundText ?? t('tournaments.timeline.setFallback', { id: set.setId })}
+        </span>
         <div className="flex items-center gap-1.5">
-          <FighterTags fighterIds={set.userFighterIds} label="Your fighters" />
-          <span className="text-xs text-muted-foreground">vs</span>
-          <FighterTags fighterIds={set.opponentFighterIds} label="Opponent fighters" />
+          <FighterTags
+            fighterIds={set.userFighterIds}
+            label={t('tournaments.timeline.yourFighters')}
+          />
+          <span className="text-xs text-muted-foreground">{t('matchups.vs')}</span>
+          <FighterTags
+            fighterIds={set.opponentFighterIds}
+            label={t('tournaments.timeline.opponentFighters')}
+          />
         </div>
         <OpponentLabel set={set} />
         <div className="flex items-center gap-1">
@@ -208,7 +223,9 @@ function SetRow({ set }: { set: TournamentSet }) {
         <span className="text-sm text-muted-foreground">
           {set.gamesWon}-{set.gamesLost}
         </span>
-        <Badge variant={set.won ? 'success' : 'destructive'}>{set.won ? 'Won' : 'Lost'}</Badge>
+        <Badge variant={set.won ? 'success' : 'destructive'}>
+          {set.won ? t('tournaments.won') : t('tournaments.lost')}
+        </Badge>
       </div>
     </li>
   );
@@ -233,18 +250,19 @@ export function SetTimeline({
   sets: TournamentSet[];
   otherMatches: Match[];
 }) {
+  const { t, i18n } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Set Timeline</CardTitle>
+        <CardTitle>{t('tournaments.timeline.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {sets.length === 0 && otherMatches.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No matches recorded for this event yet.</p>
+          <p className="text-sm text-muted-foreground">{t('tournaments.timeline.empty')}</p>
         ) : (
           <>
             {sets.length > 0 && (
-              <ul className="flex flex-col gap-2" aria-label="Sets">
+              <ul className="flex flex-col gap-2" aria-label={t('tournaments.timeline.setsAria')}>
                 {sets.map((set) => (
                   <SetRow key={set.setId} set={set} />
                 ))}
@@ -253,9 +271,12 @@ export function SetTimeline({
             {otherMatches.length > 0 && (
               <div>
                 <h3 className="mb-2 text-sm font-medium text-muted-foreground">
-                  Other matches during this event
+                  {t('tournaments.timeline.otherMatches')}
                 </h3>
-                <ul className="flex flex-col gap-2" aria-label="Other matches during this event">
+                <ul
+                  className="flex flex-col gap-2"
+                  aria-label={t('tournaments.timeline.otherMatches')}
+                >
                   {otherMatches.map((match) => {
                     const userSprite = getFighterById(match.fighter_id);
                     const opponentSprite = getFighterById(match.opponent_id);
@@ -266,7 +287,7 @@ export function SetTimeline({
                       >
                         <div className="flex items-center gap-3">
                           <span className="text-sm text-muted-foreground">
-                            {new Date(match.time).toLocaleDateString()}
+                            {new Date(match.time).toLocaleDateString(i18n.language)}
                           </span>
                           <span className="flex items-center gap-1.5">
                             {userSprite && (
@@ -278,7 +299,9 @@ export function SetTimeline({
                               />
                             )}
                             {(userSprite || opponentSprite) && (
-                              <span className="text-xs text-muted-foreground">vs</span>
+                              <span className="text-xs text-muted-foreground">
+                                {t('matchups.vs')}
+                              </span>
                             )}
                             {opponentSprite && (
                               <img
@@ -292,7 +315,7 @@ export function SetTimeline({
                           <GameChip match={match} />
                         </div>
                         <Badge variant={match.win ? 'success' : 'destructive'}>
-                          {match.win ? 'Win' : 'Loss'}
+                          {match.win ? t('common.win') : t('common.loss')}
                         </Badge>
                       </li>
                     );

--- a/apps/web/src/pages/Tournaments/components/TournamentHeader.test.tsx
+++ b/apps/web/src/pages/Tournaments/components/TournamentHeader.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import i18n from '@/i18n';
 import { render, screen } from '@testing-library/react';
 import type { TournamentEntry } from '@smash-tracker/shared';
 import { TournamentHeader, buildSeedPlacementBadge } from './TournamentHeader';
@@ -16,25 +17,25 @@ function makeEntry(overrides: Partial<TournamentEntry> = {}): TournamentEntry {
 
 describe('buildSeedPlacementBadge', () => {
   it('returns null when seed is absent', () => {
-    expect(buildSeedPlacementBadge(makeEntry({ placement: 5 }))).toBeNull();
+    expect(buildSeedPlacementBadge(makeEntry({ placement: 5 }), i18n.t)).toBeNull();
   });
 
   it('returns null when placement is absent', () => {
-    expect(buildSeedPlacementBadge(makeEntry({ seed: 5 }))).toBeNull();
+    expect(buildSeedPlacementBadge(makeEntry({ seed: 5 }), i18n.t)).toBeNull();
   });
 
   it('returns a success-toned badge when placement beats seed', () => {
-    const badge = buildSeedPlacementBadge(makeEntry({ seed: 408, placement: 257 }));
+    const badge = buildSeedPlacementBadge(makeEntry({ seed: 408, placement: 257 }), i18n.t);
     expect(badge).toEqual({ tone: 'success', label: 'Outperformed seed: 408 → 257' });
   });
 
   it('returns a destructive-toned badge when placement is worse than seed', () => {
-    const badge = buildSeedPlacementBadge(makeEntry({ seed: 32, placement: 65 }));
+    const badge = buildSeedPlacementBadge(makeEntry({ seed: 32, placement: 65 }), i18n.t);
     expect(badge).toEqual({ tone: 'destructive', label: 'Underperformed seed: 32 → 65' });
   });
 
   it('returns a neutral badge when placement matches seed exactly', () => {
-    const badge = buildSeedPlacementBadge(makeEntry({ seed: 16, placement: 16 }));
+    const badge = buildSeedPlacementBadge(makeEntry({ seed: 16, placement: 16 }), i18n.t);
     expect(badge).toEqual({ tone: 'secondary', label: 'Matched seed: 16 → 16' });
   });
 });

--- a/apps/web/src/pages/Tournaments/components/TournamentHeader.tsx
+++ b/apps/web/src/pages/Tournaments/components/TournamentHeader.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { ExternalLink } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -5,17 +7,17 @@ import { Button } from '@/components/ui/button';
 import type { TournamentEntry } from '@smash-tracker/shared';
 import { buildEventStartggUrl } from '../lib/startggLinks';
 
-function formatDate(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', {
+function formatDate(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
 }
 
-function formatDateRange(entry: TournamentEntry): string {
-  const start = formatDate(entry.firstSetAt);
-  const end = formatDate(entry.lastSetAt);
+function formatDateRange(entry: TournamentEntry, locale: string): string {
+  const start = formatDate(entry.firstSetAt, locale);
+  const end = formatDate(entry.lastSetAt, locale);
   return start === end ? start : `${start} – ${end}`;
 }
 
@@ -31,18 +33,24 @@ export interface SeedPlacementBadge {
  * (destructive-toned), and an exact match is neutral. Returns `null` when
  * either field is absent — callers must omit the badge cleanly.
  */
-export function buildSeedPlacementBadge(entry: TournamentEntry): SeedPlacementBadge | null {
+export function buildSeedPlacementBadge(
+  entry: TournamentEntry,
+  t: TFunction,
+): SeedPlacementBadge | null {
   if (entry.seed == null || entry.placement == null) {
     return null;
   }
   const { seed, placement } = entry;
   if (placement < seed) {
-    return { tone: 'success', label: `Outperformed seed: ${seed} → ${placement}` };
+    return { tone: 'success', label: t('tournaments.header.outperformed', { seed, placement }) };
   }
   if (placement > seed) {
-    return { tone: 'destructive', label: `Underperformed seed: ${seed} → ${placement}` };
+    return {
+      tone: 'destructive',
+      label: t('tournaments.header.underperformed', { seed, placement }),
+    };
   }
-  return { tone: 'secondary', label: `Matched seed: ${seed} → ${placement}` };
+  return { tone: 'secondary', label: t('tournaments.header.matched', { seed, placement }) };
 }
 
 /**
@@ -54,9 +62,10 @@ export function buildSeedPlacementBadge(entry: TournamentEntry): SeedPlacementBa
  * yet; hidden entirely when neither is present).
  */
 export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
+  const { t, i18n } = useTranslation();
   const title = entry.tournamentName ?? entry.eventName;
   const showEventSubline = entry.tournamentName != null && entry.tournamentName !== entry.eventName;
-  const badge = buildSeedPlacementBadge(entry);
+  const badge = buildSeedPlacementBadge(entry, t);
   const startggUrl = buildEventStartggUrl(entry);
 
   return (
@@ -67,11 +76,15 @@ export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
           {showEventSubline && (
             <p className="mt-1 text-sm text-muted-foreground">{entry.eventName}</p>
           )}
-          <p className="mt-1 text-sm text-muted-foreground">{formatDateRange(entry)}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {formatDateRange(entry, i18n.language)}
+          </p>
         </div>
         <div className="flex flex-col items-end gap-2 text-right">
           {entry.numEntrants != null && (
-            <p className="text-sm text-muted-foreground">{entry.numEntrants} entrants</p>
+            <p className="text-sm text-muted-foreground">
+              {t('tournaments.header.entrants', { count: entry.numEntrants })}
+            </p>
           )}
           {badge && (
             <Badge variant={badge.tone === 'secondary' ? 'secondary' : badge.tone}>
@@ -81,7 +94,7 @@ export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
           {startggUrl && (
             <Button variant="outline" size="sm" asChild>
               <a href={startggUrl} target="_blank" rel="noreferrer">
-                View on start.gg
+                {t('shared.startgg.view')}
                 <ExternalLink className="size-3.5" />
               </a>
             </Button>
@@ -89,7 +102,9 @@ export function TournamentHeader({ entry }: { entry: TournamentEntry }) {
         </div>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-muted-foreground">{entry.setsPlayed} sets played</p>
+        <p className="text-sm text-muted-foreground">
+          {t('tournaments.header.setsPlayed', { count: entry.setsPlayed })}
+        </p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/pages/Trends/TrendsPage.tsx
+++ b/apps/web/src/pages/Trends/TrendsPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useFilteredMatches } from '@/hooks/useFilteredMatches';
 import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
@@ -18,20 +19,19 @@ import { RatingCurve } from './components/RatingCurve';
  * other analytics pages.
  */
 export function TrendsPage() {
+  const { t } = useTranslation();
   const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
 
   if (isLoading) {
-    return <div className="text-muted-foreground">Loading trends...</div>;
+    return <div className="text-muted-foreground">{t('trends.loading')}</div>;
   }
 
   if (allMatches.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-16 text-center">
-        <h2 className="text-xl font-semibold tracking-tight">
-          You have no matches, report a match and check back here to view trends!
-        </h2>
+        <h2 className="text-xl font-semibold tracking-tight">{t('trends.noMatches')}</h2>
         <Button asChild className="mt-2">
-          <Link to="/dashboard">Go to Dashboard</Link>
+          <Link to="/dashboard">{t('common.goToDashboard')}</Link>
         </Button>
       </div>
     );

--- a/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
+++ b/apps/web/src/pages/Trends/components/MatchTypeMix.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   BarElement,
   CategoryScale,
@@ -26,11 +28,11 @@ const BUCKET_COLORS: Record<MatchTypeBucket, string> = {
   unspecified: '#71717a',
 };
 
-const BUCKET_LABELS: Record<MatchTypeBucket, string> = {
-  tourney: 'Tourney',
-  friendly: 'Friendly',
-  quickplay: 'Quickplay',
-  unspecified: 'Unspecified',
+const BUCKET_LABEL_KEYS: Record<MatchTypeBucket, string> = {
+  tourney: 'trends.mix.tourney',
+  friendly: 'trends.mix.friendly',
+  quickplay: 'trends.mix.quickplay',
+  unspecified: 'trends.mix.unspecified',
 };
 
 /** Buckets a stored `matchType` literal into one of the four mix categories. */
@@ -73,11 +75,11 @@ export function buildMonthlyMatchTypeMix(matches: Match[]): MonthlyMatchTypeMix[
     .sort((a, b) => a.month.localeCompare(b.month));
 }
 
-function buildChartData(mix: MonthlyMatchTypeMix[]) {
+function buildChartData(mix: MonthlyMatchTypeMix[], t: TFunction, locale: string) {
   return {
-    labels: mix.map((m) => formatMonthLabel(m.month)),
+    labels: mix.map((m) => formatMonthLabel(m.month, locale)),
     datasets: MATCH_TYPE_BUCKETS.map((bucket) => ({
-      label: BUCKET_LABELS[bucket],
+      label: t(BUCKET_LABEL_KEYS[bucket]),
       data: mix.map((m) => m.counts[bucket]),
       backgroundColor: BUCKET_COLORS[bucket],
       stack: 'games',
@@ -111,19 +113,20 @@ function buildChartOptions(): ChartOptions<'bar'> {
  * interactivity beyond the chart.js default tooltip.
  */
 export function MatchTypeMix({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const mix = buildMonthlyMatchTypeMix(matches);
 
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle>Match-Type Mix Over Time</CardTitle>
+        <CardTitle>{t('trends.mix.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {mix.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         ) : (
           <div className="h-56">
-            <Bar data={buildChartData(mix)} options={buildChartOptions()} />
+            <Bar data={buildChartData(mix, t, i18n.language)} options={buildChartOptions()} />
           </div>
         )}
       </CardContent>

--- a/apps/web/src/pages/Trends/components/MonthlyPerformance.test.tsx
+++ b/apps/web/src/pages/Trends/components/MonthlyPerformance.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import i18n from '@/i18n';
 import { render, screen } from '@testing-library/react';
 import type { Match } from '@smash-tracker/shared';
 import {
@@ -23,12 +24,12 @@ function makeMatch(overrides: Partial<Match> & Pick<Match, 'id' | 'time' | 'win'
 
 describe('formatMonthLabel', () => {
   it('formats a YYYY-MM key as a short month/year label', () => {
-    expect(formatMonthLabel('2021-01')).toBe('Jan 2021');
-    expect(formatMonthLabel('2021-12')).toBe('Dec 2021');
+    expect(formatMonthLabel('2021-01', 'en')).toBe('Jan 2021');
+    expect(formatMonthLabel('2021-12', 'en')).toBe('Dec 2021');
   });
 
   it('falls back to the raw key for malformed input', () => {
-    expect(formatMonthLabel('garbage')).toBe('garbage');
+    expect(formatMonthLabel('garbage', 'en')).toBe('garbage');
   });
 });
 
@@ -44,7 +45,7 @@ describe('buildMonthlyChartData', () => {
       makeMatch({ id: '5', time: Date.UTC(2021, 1, 3), win: false }),
     ];
     const records = getMonthlyRecords(matches);
-    const data = buildMonthlyChartData(records);
+    const data = buildMonthlyChartData(records, i18n.t, 'en');
 
     expect(records[0]?.total).toBe(2);
     expect(records[1]?.total).toBe(3);
@@ -60,7 +61,7 @@ describe('buildMonthlyChartData', () => {
       makeMatch({ id: '3', time: Date.UTC(2021, 0, 3), win: false }),
     ];
     const records = getMonthlyRecords(matches);
-    const data = buildMonthlyChartData(records);
+    const data = buildMonthlyChartData(records, i18n.t, 'en');
 
     expect(data.labels).toEqual(['Jan 2021']);
     expect(data.datasets[0]?.data).toEqual([67]);
@@ -68,7 +69,7 @@ describe('buildMonthlyChartData', () => {
   });
 
   it('returns an empty dataset for no matches', () => {
-    const data = buildMonthlyChartData(getMonthlyRecords([]));
+    const data = buildMonthlyChartData(getMonthlyRecords([]), i18n.t, 'en');
     expect(data.labels).toEqual([]);
     expect(data.datasets[0]?.data).toEqual([]);
   });

--- a/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
+++ b/apps/web/src/pages/Trends/components/MonthlyPerformance.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   BarElement,
   CategoryScale,
@@ -26,12 +28,12 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 /** Below this many games in a month, the bar renders at reduced opacity as a small-sample cue. */
 export const SMALL_SAMPLE_THRESHOLD = 3;
 
-/** Formats a `YYYY-MM` month key as a short human label, e.g. '2021-01' -> 'Jan 2021'. */
-export function formatMonthLabel(month: string): string {
+/** Formats a `YYYY-MM` month key as a short human label in the given locale, e.g. '2021-01' -> 'Jan 2021'. */
+export function formatMonthLabel(month: string, locale: string): string {
   const [year, monthNum] = month.split('-').map(Number);
   if (!year || !monthNum) return month;
   const date = new Date(Date.UTC(year, monthNum - 1, 1));
-  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+  return date.toLocaleDateString(locale, { month: 'short', year: 'numeric', timeZone: 'UTC' });
 }
 
 /**
@@ -40,12 +42,12 @@ export function formatMonthLabel(month: string): string {
  * rendering chart.js. Bars for months under `SMALL_SAMPLE_THRESHOLD` games
  * get a reduced-opacity fill as a small-sample visual cue.
  */
-export function buildMonthlyChartData(records: MonthlyRecord[]) {
+export function buildMonthlyChartData(records: MonthlyRecord[], t: TFunction, locale: string) {
   return {
-    labels: records.map((r) => formatMonthLabel(r.month)),
+    labels: records.map((r) => formatMonthLabel(r.month, locale)),
     datasets: [
       {
-        label: 'Win Rate',
+        label: t('trends.monthly.winRateLabel'),
         data: records.map((r) => r.winRate),
         backgroundColor: records.map((r) =>
           r.total < SMALL_SAMPLE_THRESHOLD ? chartColors.redSoft : chartColors.red,
@@ -60,7 +62,7 @@ export function buildMonthlyChartData(records: MonthlyRecord[]) {
   };
 }
 
-function buildMonthlyChartOptions(records: MonthlyRecord[]): ChartOptions<'bar'> {
+function buildMonthlyChartOptions(records: MonthlyRecord[], t: TFunction): ChartOptions<'bar'> {
   const theme = darkChartOptions();
   return {
     responsive: theme.responsive,
@@ -80,10 +82,10 @@ function buildMonthlyChartOptions(records: MonthlyRecord[]): ChartOptions<'bar'>
         borderColor: chartColors.tooltipBorder,
         borderWidth: 1,
         callbacks: {
-          label: (item) => `Win rate: ${item.formattedValue}%`,
+          label: (item) => t('trends.monthly.tooltipRate', { value: item.formattedValue }),
           afterLabel: (item) => {
             const record = records[item.dataIndex];
-            return record ? `Games played: ${record.total}` : '';
+            return record ? t('trends.monthly.tooltipGames', { count: record.total }) : '';
           },
         },
       },
@@ -97,44 +99,44 @@ function buildMonthlyChartOptions(records: MonthlyRecord[]): ChartOptions<'bar'>
  * at reduced opacity, called out in a caption.
  */
 export function MonthlyPerformance({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const records = getMonthlyRecords(matches);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Monthly Performance</CardTitle>
+        <CardTitle>{t('trends.monthly.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {records.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         ) : (
           <div className="flex flex-col gap-4 lg:flex-row">
             <div className="flex flex-col gap-2 lg:w-3/5">
               <div className="h-64">
                 <Bar
-                  data={buildMonthlyChartData(records)}
-                  options={buildMonthlyChartOptions(records)}
+                  data={buildMonthlyChartData(records, t, i18n.language)}
+                  options={buildMonthlyChartOptions(records, t)}
                 />
               </div>
               <p className="text-xs text-muted-foreground">
-                Faded bars mark months with fewer than {SMALL_SAMPLE_THRESHOLD} games — small
-                sample, read with caution.
+                {t('trends.monthly.caption', { count: SMALL_SAMPLE_THRESHOLD })}
               </p>
             </div>
             <div className="max-h-72 overflow-y-auto lg:w-2/5">
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Month</TableHead>
-                    <TableHead>W-L</TableHead>
-                    <TableHead>Rate</TableHead>
-                    <TableHead>Games</TableHead>
+                    <TableHead>{t('trends.monthly.month')}</TableHead>
+                    <TableHead>{t('trends.monthly.wl')}</TableHead>
+                    <TableHead>{t('common.rate')}</TableHead>
+                    <TableHead>{t('trends.monthly.games')}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {[...records].reverse().map((record) => (
                     <TableRow key={record.month}>
-                      <TableCell>{formatMonthLabel(record.month)}</TableCell>
+                      <TableCell>{formatMonthLabel(record.month, i18n.language)}</TableCell>
                       <TableCell>
                         {record.wins}-{record.losses}
                       </TableCell>

--- a/apps/web/src/pages/Trends/components/RatingCurve.test.tsx
+++ b/apps/web/src/pages/Trends/components/RatingCurve.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import i18n from '@/i18n';
 import { render, screen } from '@testing-library/react';
 import type { Match } from '@smash-tracker/shared';
 import {
@@ -31,7 +32,7 @@ describe('formatPeriodLabel', () => {
       rd: 300,
       volatility: 0.06,
     };
-    expect(formatPeriodLabel(period)).toBe('Jan 5');
+    expect(formatPeriodLabel(period, 'en')).toBe('Jan 5');
   });
 });
 
@@ -41,7 +42,7 @@ describe('buildRatingCurveData', () => {
       makeMatch({ id: `${i}`, time: i * 1000, win: true }),
     );
     const { periods } = computeRatingHistory(matches);
-    const data = buildRatingCurveData(periods);
+    const data = buildRatingCurveData(periods, i18n.t, 'en');
 
     expect(data.datasets).toHaveLength(3);
     expect(data.datasets[0]?.label).toBe('Rating');
@@ -54,7 +55,7 @@ describe('buildRatingCurveData', () => {
   });
 
   it('returns empty series for no periods', () => {
-    const data = buildRatingCurveData([]);
+    const data = buildRatingCurveData([], i18n.t, 'en');
     expect(data.labels).toEqual([]);
     expect(data.datasets[0]?.data).toEqual([]);
   });

--- a/apps/web/src/pages/Trends/components/RatingCurve.tsx
+++ b/apps/web/src/pages/Trends/components/RatingCurve.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -20,9 +22,9 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip,
 /** Minimum total games before the curve renders instead of the locked state — mirrors the Dashboard Rating card's `RATING_UNLOCK_THRESHOLD`. */
 export const RATING_CURVE_UNLOCK_THRESHOLD = 5;
 
-/** Formats a rating period's end date as a short x-axis label, e.g. "Jan 5". */
-export function formatPeriodLabel(period: RatingPeriodResult): string {
-  return new Date(period.end).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+/** Formats a rating period's end date as a short x-axis label in the given locale, e.g. "Jan 5". */
+export function formatPeriodLabel(period: RatingPeriodResult, locale: string): string {
+  return new Date(period.end).toLocaleDateString(locale, { month: 'short', day: 'numeric' });
 }
 
 /**
@@ -33,13 +35,13 @@ export function formatPeriodLabel(period: RatingPeriodResult): string {
  * as an uncertainty envelope around the rating line). Exported as a pure
  * builder so the series math can be unit-tested without rendering chart.js.
  */
-export function buildRatingCurveData(periods: RatingPeriodResult[]) {
-  const labels = periods.map((p) => formatPeriodLabel(p));
+export function buildRatingCurveData(periods: RatingPeriodResult[], t: TFunction, locale: string) {
+  const labels = periods.map((p) => formatPeriodLabel(p, locale));
   return {
     labels,
     datasets: [
       {
-        label: 'Rating',
+        label: t('trends.ratingCurve.ratingLabel'),
         ...redLineDataset(),
         data: periods.map((p) => p.rating),
       },
@@ -71,7 +73,11 @@ export function buildRatingCurveData(periods: RatingPeriodResult[]) {
   };
 }
 
-function buildRatingCurveOptions(periods: RatingPeriodResult[]): ChartOptions<'line'> {
+function buildRatingCurveOptions(
+  periods: RatingPeriodResult[],
+  t: TFunction,
+  locale: string,
+): ChartOptions<'line'> {
   const theme = darkChartOptions();
   return {
     responsive: theme.responsive,
@@ -95,13 +101,11 @@ function buildRatingCurveOptions(periods: RatingPeriodResult[]): ChartOptions<'l
           title: (items) => {
             const period = periods[items[0]?.dataIndex ?? -1];
             if (!period) return '';
-            return new Date(period.end).toLocaleDateString('en-US');
+            return new Date(period.end).toLocaleDateString(locale);
           },
           afterBody: (items) => {
             const period = periods[items[0]?.dataIndex ?? -1];
-            return period
-              ? `${period.games} game${period.games === 1 ? '' : 's'} this session`
-              : '';
+            return period ? t('trends.ratingCurve.tooltipGames', { count: period.games }) : '';
           },
         },
       },
@@ -119,6 +123,7 @@ function buildRatingCurveOptions(periods: RatingPeriodResult[]): ChartOptions<'l
  * current-rating callout.
  */
 export function RatingCurve({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const hasEnoughGames = matches.length >= RATING_CURVE_UNLOCK_THRESHOLD;
   const { periods, current } = computeRatingHistory(matches);
 
@@ -126,7 +131,7 @@ export function RatingCurve({ matches }: { matches: Match[] }) {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-1.5">
-          Rating Curve
+          {t('trends.ratingCurve.title')}
           <GlickoExplainer />
         </CardTitle>
       </CardHeader>
@@ -137,25 +142,28 @@ export function RatingCurve({ matches }: { matches: Match[] }) {
               <span className="text-3xl font-bold">
                 {current.rating} <span className="text-lg font-normal">&plusmn;{current.rd}</span>
               </span>
-              <span className="pb-1 text-sm text-muted-foreground">current rating</span>
+              <span className="pb-1 text-sm text-muted-foreground">
+                {t('trends.ratingCurve.current')}
+              </span>
             </div>
             <div className="h-64">
               <Line
-                data={buildRatingCurveData(periods)}
-                options={buildRatingCurveOptions(periods)}
+                data={buildRatingCurveData(periods, t, i18n.language)}
+                options={buildRatingCurveOptions(periods, t, i18n.language)}
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              Glicko-2, session-based · unofficial. Dashed lines show the +/-RD uncertainty band.
-            </p>
+            <p className="text-xs text-muted-foreground">{t('trends.ratingCurve.caption')}</p>
           </>
         ) : (
           <>
             <p className="text-sm text-muted-foreground">
-              Rating curve unlocks at {RATING_CURVE_UNLOCK_THRESHOLD} games
+              {t('trends.ratingCurve.locked', { count: RATING_CURVE_UNLOCK_THRESHOLD })}
             </p>
             <p className="text-xs text-muted-foreground">
-              {matches.length}/{RATING_CURVE_UNLOCK_THRESHOLD} games so far
+              {t('trends.ratingCurve.progress', {
+                played: matches.length,
+                threshold: RATING_CURVE_UNLOCK_THRESHOLD,
+              })}
             </p>
           </>
         )}

--- a/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
+++ b/apps/web/src/pages/Trends/components/SessionsAndTilt.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -55,22 +57,24 @@ export function buildSessionsHeadline(sessions: SessionStats[]): SessionsHeadlin
   return { totalSessions: sessions.length, avgGamesPerSession, bestSession, worstTiltSession };
 }
 
-function formatDate(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', {
+function formatDate(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
 }
 
-function formatDuration(session: SessionStats): string {
+function formatDuration(session: SessionStats, t: TFunction): string {
   const ms = session.end - session.start;
-  if (ms <= 0) return '< 1 min';
+  if (ms <= 0) return t('trends.sessions.durationUnderMin');
   const minutes = Math.round(ms / 60_000);
-  if (minutes < 60) return `${minutes} min`;
+  if (minutes < 60) return t('trends.sessions.durationMin', { count: minutes });
   const hours = Math.floor(minutes / 60);
   const remaining = minutes % 60;
-  return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+  return remaining > 0
+    ? t('trends.sessions.durationHM', { hours, minutes: remaining })
+    : t('trends.sessions.durationH', { hours });
 }
 
 /**
@@ -80,6 +84,7 @@ function formatDuration(session: SessionStats): string {
  * by date.
  */
 export function SessionsAndTilt({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const sessions = getSessions(matches);
   const headline = buildSessionsHeadline(sessions);
   const recentSessions = [...sessions].reverse().slice(0, RECENT_SESSION_LIMIT);
@@ -87,35 +92,41 @@ export function SessionsAndTilt({ matches }: { matches: Match[] }) {
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle>Sessions &amp; Tilt</CardTitle>
+        <CardTitle>{t('trends.sessions.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {sessions.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         ) : (
           <>
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-              <Headline label="Total Sessions" value={headline.totalSessions} />
-              <Headline label="Avg Games / Session" value={headline.avgGamesPerSession} />
+              <Headline label={t('trends.sessions.total')} value={headline.totalSessions} />
+              <Headline label={t('trends.sessions.avgGames')} value={headline.avgGamesPerSession} />
               <Headline
-                label="Best Session"
+                label={t('trends.sessions.best')}
                 value={
                   headline.bestSession
                     ? `${headline.bestSession.wins}-${headline.bestSession.losses}`
                     : '—'
                 }
-                sub={headline.bestSession ? formatDate(headline.bestSession.start) : undefined}
+                sub={
+                  headline.bestSession
+                    ? formatDate(headline.bestSession.start, i18n.language)
+                    : undefined
+                }
               />
               <Headline
-                label="Worst Tilt"
+                label={t('trends.sessions.worstTilt')}
                 value={
                   headline.worstTiltSession
-                    ? `${headline.worstTiltSession.longestLossRun}L run`
+                    ? t('trends.sessions.tiltRun', {
+                        count: headline.worstTiltSession.longestLossRun,
+                      })
                     : '—'
                 }
                 sub={
                   headline.worstTiltSession
-                    ? formatDate(headline.worstTiltSession.start)
+                    ? formatDate(headline.worstTiltSession.start, i18n.language)
                     : undefined
                 }
                 tone={headline.worstTiltSession ? 'destructive' : undefined}
@@ -125,18 +136,18 @@ export function SessionsAndTilt({ matches }: { matches: Match[] }) {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Date</TableHead>
-                  <TableHead>Duration</TableHead>
-                  <TableHead>W-L</TableHead>
-                  <TableHead>Rate</TableHead>
-                  <TableHead>Longest Loss Run</TableHead>
+                  <TableHead>{t('trends.sessions.date')}</TableHead>
+                  <TableHead>{t('trends.sessions.duration')}</TableHead>
+                  <TableHead>{t('trends.monthly.wl')}</TableHead>
+                  <TableHead>{t('common.rate')}</TableHead>
+                  <TableHead>{t('trends.sessions.lossRun')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {recentSessions.map((session) => (
                   <TableRow key={session.start}>
-                    <TableCell>{formatDate(session.start)}</TableCell>
-                    <TableCell>{formatDuration(session)}</TableCell>
+                    <TableCell>{formatDate(session.start, i18n.language)}</TableCell>
+                    <TableCell>{formatDuration(session, t)}</TableCell>
                     <TableCell>
                       {session.wins}-{session.losses}
                     </TableCell>

--- a/apps/web/src/pages/Trends/components/SettingComparison.tsx
+++ b/apps/web/src/pages/Trends/components/SettingComparison.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getOnlineOfflineSplit, type OnlineOfflineSplit, type WinLossRecord } from '@/lib/stats';
@@ -37,6 +38,7 @@ export function buildSettingTakeaway(split: OnlineOfflineSplit): SettingTakeaway
  * having at least `TAKEAWAY_MIN_SAMPLE` games.
  */
 export function SettingComparison({ matches }: { matches: Match[] }) {
+  const { t } = useTranslation();
   const split = getOnlineOfflineSplit(matches);
   const takeaway = buildSettingTakeaway(split);
   const hasAny = split.online.total > 0 || split.offline.total > 0 || split.unspecified.total > 0;
@@ -44,36 +46,36 @@ export function SettingComparison({ matches }: { matches: Match[] }) {
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle>Setting Comparison</CardTitle>
+        <CardTitle>{t('trends.setting.title')}</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {!hasAny ? (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         ) : (
           <>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <SettingBlock label="Online" record={split.online} />
-              <SettingBlock label="Offline" record={split.offline} />
-              <SettingBlock label="Unspecified" record={split.unspecified} />
+              <SettingBlock label={t('trends.setting.online')} record={split.online} />
+              <SettingBlock label={t('trends.setting.offline')} record={split.offline} />
+              <SettingBlock label={t('trends.setting.unspecified')} record={split.unspecified} />
             </div>
 
             {takeaway.kind === 'takeaway' ? (
               <p className="text-sm">
                 {takeaway.deltaPoints === 0 ? (
-                  <span>You win about the same rate online and offline.</span>
+                  <span>{t('trends.setting.even')}</span>
                 ) : (
                   <span>
-                    You win{' '}
+                    {t('trends.setting.youWin')}{' '}
                     <span className="font-semibold text-foreground">{takeaway.deltaPoints}%</span>{' '}
-                    more{' '}
-                    {takeaway.better === 'online' ? 'online than offline' : 'offline than online'}.
+                    {takeaway.better === 'online'
+                      ? t('trends.setting.moreOnline')
+                      : t('trends.setting.moreOffline')}
                   </span>
                 )}
               </p>
             ) : (
               <p className="text-xs text-muted-foreground">
-                Need at least {TAKEAWAY_MIN_SAMPLE} games both online and offline for a reliable
-                comparison.
+                {t('trends.setting.smallSample', { count: TAKEAWAY_MIN_SAMPLE })}
               </p>
             )}
           </>
@@ -84,11 +86,12 @@ export function SettingComparison({ matches }: { matches: Match[] }) {
 }
 
 function SettingBlock({ label, record }: { label: string; record: WinLossRecord }) {
+  const { t } = useTranslation();
   if (record.total === 0) {
     return (
       <div className="rounded-md border p-3">
         <h3 className="text-sm text-muted-foreground">{label}</h3>
-        <p className="text-sm text-muted-foreground">no data</p>
+        <p className="text-sm text-muted-foreground">{t('trends.setting.noData')}</p>
       </div>
     );
   }
@@ -97,7 +100,7 @@ function SettingBlock({ label, record }: { label: string; record: WinLossRecord 
       <h3 className="text-sm text-muted-foreground">{label}</h3>
       <p className="text-2xl font-semibold">{record.winRate}%</p>
       <p className="text-xs text-muted-foreground">
-        {record.wins}-{record.losses} ({record.total} games)
+        {record.wins}-{record.losses} ({t('common.games', { count: record.total })})
       </p>
     </div>
   );

--- a/apps/web/src/pages/Trends/components/Tournaments.tsx
+++ b/apps/web/src/pages/Trends/components/Tournaments.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { ExternalLink } from 'lucide-react';
 import type { Match, TournamentEntry } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -41,17 +42,17 @@ export function buildTournamentEntryRows(
     }));
 }
 
-function formatDate(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', {
+function formatDate(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
 }
 
-function formatDateRange(entry: TournamentEntry): string {
-  const start = formatDate(entry.firstSetAt);
-  const end = formatDate(entry.lastSetAt);
+function formatDateRange(entry: TournamentEntry, locale: string): string {
+  const start = formatDate(entry.firstSetAt, locale);
+  const end = formatDate(entry.lastSetAt, locale);
   return start === end ? start : `${start} – ${end}`;
 }
 
@@ -69,6 +70,7 @@ function formatDateRange(entry: TournamentEntry): string {
  * trigger the internal row link); hidden entirely when the slug is absent.
  */
 export function Tournaments({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const { data: entries, isLoading } = useTournamentEntries();
 
   const rows = buildTournamentEntryRows(entries ?? [], matches);
@@ -76,29 +78,29 @@ export function Tournaments({ matches }: { matches: Match[] }) {
   return (
     <Card className="h-full">
       <CardHeader>
-        <CardTitle>Tournaments</CardTitle>
+        <CardTitle>{t('trends.tournaments.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Loading tournaments...</p>
+          <p className="text-sm text-muted-foreground">{t('trends.tournaments.loading')}</p>
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            Tournament entries attach on your next start.gg sync — head to{' '}
+            {t('trends.tournaments.resyncPrefix')}{' '}
             <Link to="/settings/integrations" className="font-medium text-primary underline">
-              Integrations
+              {t('nav.integrations')}
             </Link>{' '}
-            and hit Sync now.
+            {t('trends.tournaments.resyncSuffix')}
           </p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Tournament</TableHead>
-                <TableHead>Event</TableHead>
-                <TableHead>Dates</TableHead>
-                <TableHead>W-L</TableHead>
-                <TableHead>Rate</TableHead>
-                <TableHead>Games</TableHead>
+                <TableHead>{t('trends.tournaments.tournament')}</TableHead>
+                <TableHead>{t('trends.tournaments.event')}</TableHead>
+                <TableHead>{t('trends.tournaments.dates')}</TableHead>
+                <TableHead>{t('trends.monthly.wl')}</TableHead>
+                <TableHead>{t('common.rate')}</TableHead>
+                <TableHead>{t('trends.monthly.games')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -120,7 +122,7 @@ export function Tournaments({ matches }: { matches: Match[] }) {
                             target="_blank"
                             rel="noreferrer"
                             onClick={(e) => e.stopPropagation()}
-                            aria-label="View on start.gg"
+                            aria-label={t('shared.startgg.view')}
                             className="inline-flex text-muted-foreground hover:text-foreground"
                           >
                             <ExternalLink className="size-3.5" />
@@ -129,7 +131,7 @@ export function Tournaments({ matches }: { matches: Match[] }) {
                       </span>
                     </TableCell>
                     <TableCell className="whitespace-normal">{entry.eventName}</TableCell>
-                    <TableCell>{formatDateRange(entry)}</TableCell>
+                    <TableCell>{formatDateRange(entry, i18n.language)}</TableCell>
                     <TableCell>
                       {record.wins}-{record.losses}
                     </TableCell>

--- a/apps/web/src/pages/Trends/components/TrendsHero.tsx
+++ b/apps/web/src/pages/Trends/components/TrendsHero.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatMonthLabel } from './MonthlyPerformance';
@@ -12,61 +13,69 @@ import { BEST_MONTH_MIN_GAMES, CURRENT_FORM_WINDOW, buildTrendsHero } from '../l
  * derived from data the rest of the page already has (no new API calls).
  */
 export function TrendsHero({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   const hero = buildTrendsHero(matches);
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-      <HeroCard label="Current Rating">
+      <HeroCard label={t('trends.hero.currentRating')}>
         {hero.currentRating ? (
           <>
             <span className="text-3xl font-bold">
               {hero.currentRating.rating}{' '}
               <span className="text-lg font-normal">&plusmn;{hero.currentRating.rd}</span>
             </span>
-            <p className="text-sm text-muted-foreground">Glicko-2 rating</p>
+            <p className="text-sm text-muted-foreground">{t('trends.hero.glickoRating')}</p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">Not enough games yet</p>
+          <p className="text-sm text-muted-foreground">{t('trends.hero.notEnoughGames')}</p>
         )}
       </HeroCard>
 
-      <HeroCard label="Peak Rating">
+      <HeroCard label={t('trends.hero.peakRating')}>
         {hero.peakRating != null ? (
           <>
             <span className="text-3xl font-bold">{hero.peakRating}</span>
-            <p className="text-sm text-muted-foreground">Best session rating</p>
+            <p className="text-sm text-muted-foreground">{t('trends.hero.bestSessionRating')}</p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">Not enough games yet</p>
+          <p className="text-sm text-muted-foreground">{t('trends.hero.notEnoughGames')}</p>
         )}
       </HeroCard>
 
-      <HeroCard label="Best Month">
+      <HeroCard label={t('trends.hero.bestMonth')}>
         {hero.bestMonth ? (
           <>
             <span className="text-3xl font-bold">{hero.bestMonth.winRate}%</span>
             <p className="text-sm text-muted-foreground">
-              {formatMonthLabel(hero.bestMonth.month)} &middot; {hero.bestMonth.wins}-
-              {hero.bestMonth.losses} ({hero.bestMonth.total} games)
+              {t('trends.hero.bestMonthCaption', {
+                month: formatMonthLabel(hero.bestMonth.month, i18n.language),
+                wins: hero.bestMonth.wins,
+                losses: hero.bestMonth.losses,
+                count: hero.bestMonth.total,
+              })}
             </p>
           </>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Needs a month with {BEST_MONTH_MIN_GAMES}+ games
+            {t('trends.hero.bestMonthNeeds', { count: BEST_MONTH_MIN_GAMES })}
           </p>
         )}
       </HeroCard>
 
-      <HeroCard label="Current Form">
+      <HeroCard label={t('trends.hero.currentForm')}>
         {hero.currentFormGames > 0 ? (
           <>
             <span className="text-3xl font-bold">{hero.currentFormWinRate}%</span>
             <p className="text-sm text-muted-foreground">
-              Last {hero.currentFormGames} of {CURRENT_FORM_WINDOW} games
+              {t('trends.hero.formCaption', {
+                played: hero.currentFormGames,
+                window: CURRENT_FORM_WINDOW,
+              })}
             </p>
           </>
         ) : (
-          <p className="text-sm text-muted-foreground">No match data to report yet.</p>
+          <p className="text-sm text-muted-foreground">{t('common.noMatchData')}</p>
         )}
       </HeroCard>
     </div>


### PR DESCRIPTION
## Summary

Stacked on #146. Localizes the Trends page (`trends.*`) and the tournament detail page (`tournaments.*`) into all six locales:

- **Trends**: hero row (current/peak rating, best month, current form), monthly performance chart + table (incl. chart tooltips), the Glicko-2 rating curve (locked state, current-rating callout, uncertainty-band caption), sessions & tilt (headline stats, duration formatting, tilt runs), setting comparison (three blocks + the win-more takeaway sentence), the tournaments table with its Integrations resync hint, and the match-type mix chart buckets.
- **Tournaments detail**: loading/not-found states, header (entrants, sets played, seed→placement badges), event results (winner callout, played-them tooltip, profile-link aria), set timeline (set fallback labels, fighter-tag arias, Watch/Edit VOD affordances, game-chip tooltips, other-matches list), characters & stages cards, and the advisor retrospective (adherence summary, per-game grading tooltips).

## Implementation notes

- `shared.startgg.{view,viewName}` covers the outbound start.gg links used by both pages.
- Date helpers (`formatMonthLabel`, `formatPeriodLabel`, session/tournament date ranges) take the active locale instead of hardcoded `en-US`; chart builders take `t`. Their unit tests pass the bundled-English `i18n.t` with `'en'` and keep identical assertions.
- `buildSeedPlacementBadge` takes `t` (test updated the same way).
- Known remainder: `lib/ordinal.ts`'s compact "seed 56 · placed 129th" opponent context stays English for now — locale-correct ordinals need i18next ordinal plurals, which didn't feel worth the key surface for bracket jargon; happy to add if wanted.

## Testing

- `pnpm --filter @smash-tracker/web lint` ✅ (0 errors) · `typecheck` ✅ · `test` ✅ 926/926

🤖 Generated with [Claude Code](https://claude.com/claude-code)