### PR TITLE
Pin favorite stages in the Quick Logger and Stage Breakdown pickers

### DIFF
--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -293,6 +293,26 @@ describe('GspPage', () => {
     expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/≈ \+\d+ MMR/));
   });
 
+  it('pins favorited stages atop the Quick Logger stage picker', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    // Stage id 3 = Final Destination.
+    getStageFavorites.mockResolvedValue({ stageIds: [3], updatedAt: 0 });
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('Quick Logger');
+
+    await user.click(screen.getByRole('combobox', { name: 'Stage (optional)' }));
+
+    expect(await screen.findByText('Favorites')).toBeInTheDocument();
+    // Once under Favorites and once under All stages; the Quick Logger
+    // intentionally has no "Most played" group (no matches dependency).
+    // Exact name: /Final Destination/ would also catch "(Gen. Final Destination)".
+    expect(screen.getAllByRole('option', { name: 'Final Destination' })).toHaveLength(2);
+    expect(screen.queryByText('Most played')).not.toBeInTheDocument();
+  });
+
   it('requires an opponent character and result before submitting from the Quick Logger', async () => {
     getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
     listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { Fighter, GspPoint, GspSettings } from '@smash-tracker/shared';
@@ -9,16 +9,15 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
 import { alphaSpriteList } from '@/components/match-form/MatchForm';
 import { NO_SELECTION_STAGE } from '@/data/stages';
-import { alphaStageList, stageOptions } from '@/lib/stageOptions';
-import { StageOption } from '@/components/StageOption';
+import { getGroupedStageOptions, stageOptions } from '@/lib/stageOptions';
+import { StageSelectGroups } from '@/components/StageSelectGroups';
+import { useStageFavorites } from '@/hooks/useStageFavorites';
 import { useCreateMatch } from '@/hooks/useCreateMatch';
 import { parseGspNumber } from '../lib/parseGspNumber';
 import { calibrationFromSettings, estimateMmrAt } from '../lib/gspMmrModel';
@@ -50,6 +49,15 @@ export function QuickLogger({
   const { t } = useTranslation();
   const lastGsp = lastPoint?.gsp ?? null;
   const createMatch = useCreateMatch();
+  const { data: stageFavorites } = useStageFavorites();
+  const favoriteStageIds = stageFavorites?.stageIds;
+  // No matches passed (so no "Most played" group): the quick logger has no
+  // match-history dependency today, and pulling one in just for usage
+  // ordering isn't worth the extra query on this deliberately light form.
+  const stageGroups = useMemo(
+    () => getGroupedStageOptions([], favoriteStageIds),
+    [favoriteStageIds],
+  );
   const [opponentFighterId, setOpponentFighterId] = useState<number | undefined>(undefined);
   const [result, setResult] = useState<'win' | 'loss' | undefined>(undefined);
   const [gspInput, setGspInput] = useState<string>(lastGsp !== null ? String(lastGsp) : '');
@@ -208,17 +216,7 @@ export function QuickLogger({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={String(NO_SELECTION_STAGE.id)}>
-                  {NO_SELECTION_STAGE.name}
-                </SelectItem>
-                <SelectGroup>
-                  <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
-                  {alphaStageList.map((s) => (
-                    <SelectItem key={s.id} value={String(s.id)}>
-                      <StageOption stage={s} />
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
+                <StageSelectGroups groups={stageGroups} />
               </SelectContent>
             </Select>
           </div>

--- a/apps/web/src/pages/MatchData/MatchDataPage.tsx
+++ b/apps/web/src/pages/MatchData/MatchDataPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFighters } from '@/hooks/useFighters';
 import { useFilteredMatches } from '@/hooks/useFilteredMatches';
+import { useStageFavorites } from '@/hooks/useStageFavorites';
 import { getFighterById } from '@/data/sprites';
 import { FilteredEmptyNotice } from '@/components/FilteredEmptyNotice';
 import { MatchTable } from './components/MatchTable';
@@ -17,6 +18,7 @@ export function MatchDataPage() {
   const { t } = useTranslation();
   const { data: fighterSelection, isLoading: fightersLoading } = useFighters();
   const { matches, allMatches, isLoading: matchesLoading, filterActive } = useFilteredMatches();
+  const { data: stageFavorites } = useStageFavorites();
 
   const fighterSprites = useMemo<Fighter[]>(() => {
     const ids = [...(fighterSelection?.primary ?? []), ...(fighterSelection?.secondary ?? [])];
@@ -72,7 +74,11 @@ export function MatchDataPage() {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <RosterUsage matches={matches} fighterSprites={fighterSprites} />
-        <StageBreakdown matches={matches} usageMatches={allMatches} />
+        <StageBreakdown
+          matches={matches}
+          usageMatches={allMatches}
+          favoriteStageIds={stageFavorites?.stageIds}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/pages/MatchData/components/StageBreakdown.test.tsx
+++ b/apps/web/src/pages/MatchData/components/StageBreakdown.test.tsx
@@ -44,6 +44,18 @@ describe('StageBreakdown', () => {
     expect(thumbnail).toBeInTheDocument();
   });
 
+  it('pins a Favorites group when favoriteStageIds are passed', async () => {
+    const user = userEvent.setup();
+    render(<StageBreakdown matches={[makeMatch()]} favoriteStageIds={[3]} />);
+
+    await user.click(screen.getByLabelText('Select stage'));
+
+    expect(await screen.findByText('Favorites')).toBeInTheDocument();
+    // Final Destination (id 3) appears in Favorites and again in All stages.
+    // Exact name: /Final Destination/ would also catch "(Gen. Final Destination)".
+    expect(screen.getAllByRole('option', { name: 'Final Destination' })).toHaveLength(2);
+  });
+
   it('shows a fallback abbreviation tile for a stage lacking art', async () => {
     const user = userEvent.setup();
     render(<StageBreakdown matches={[makeMatch({ map: { id: 2, name: 'Big Battlefield' } })]} />);

--- a/apps/web/src/pages/MatchData/components/StageBreakdown.tsx
+++ b/apps/web/src/pages/MatchData/components/StageBreakdown.tsx
@@ -2,20 +2,13 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Select, SelectContent, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { NO_SELECTION_STAGE } from '@/data/stages';
 import { getFighterById } from '@/data/sprites';
 import { getStageRecords, getWinLossRecord } from '@/lib/stats';
 import { getGroupedStageOptions, stageOptions } from '@/lib/stageOptions';
-import { StageOption, stageAbbreviation } from '@/components/StageOption';
+import { stageAbbreviation } from '@/components/StageOption';
+import { StageSelectGroups } from '@/components/StageSelectGroups';
 
 /**
  * Ports legacy/src/screens/MatchData/components/StageBreakdown — pick a
@@ -25,16 +18,19 @@ import { StageOption, stageAbbreviation } from '@/components/StageOption';
 export function StageBreakdown({
   matches,
   usageMatches,
+  favoriteStageIds,
 }: {
   matches: Match[];
   /** Unfiltered matches used to compute "Most played" ordering; defaults to `matches` when omitted. */
   usageMatches?: Match[];
+  /** The user's favorited stage ids, pinned as a "Favorites" group. Passed in as a prop (rather than read via `useStageFavorites` here) to keep this component hook/provider-free for tests. */
+  favoriteStageIds?: number[];
 }) {
   const { t } = useTranslation();
   const [stageId, setStageId] = useState<number>(NO_SELECTION_STAGE.id);
-  const { mostPlayed, all: allStages } = useMemo(
-    () => getGroupedStageOptions(usageMatches ?? matches),
-    [usageMatches, matches],
+  const stageGroups = useMemo(
+    () => getGroupedStageOptions(usageMatches ?? matches, favoriteStageIds),
+    [usageMatches, matches, favoriteStageIds],
   );
 
   if (matches.length === 0) {
@@ -76,25 +72,7 @@ export function StageBreakdown({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={String(NO_SELECTION_STAGE.id)}>{NO_SELECTION_STAGE.name}</SelectItem>
-            {mostPlayed.length > 0 && (
-              <SelectGroup>
-                <SelectLabel>{t('matchForm.mostPlayed')}</SelectLabel>
-                {mostPlayed.map((s) => (
-                  <SelectItem key={`most-played-${s.id}`} value={String(s.id)}>
-                    <StageOption stage={s} />
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            )}
-            <SelectGroup>
-              <SelectLabel>{t('matchForm.allStages')}</SelectLabel>
-              {allStages.map((s) => (
-                <SelectItem key={`all-${s.id}`} value={String(s.id)}>
-                  <StageOption stage={s} />
-                </SelectItem>
-              ))}
-            </SelectGroup>
+            <StageSelectGroups groups={stageGroups} />
           </SelectContent>
         </Select>
 


### PR DESCRIPTION
## Summary

Follow-up to #147, which deliberately left two stage pickers out to avoid conflicting with the then-unmerged i18n PR #146 (since landed). Both now render through the shared `StageSelectGroups` component, so favorited stages appear as a pinned **Favorites** group:

- **GSP Quick Logger** (`QuickLogger.tsx`) — the Elite Smash quick-log flow, the exact use case behind the favorites request. Uses `getGroupedStageOptions([], favoriteIds)`: Favorites + All stages, intentionally **no "Most played" group** — the form has no match-history dependency today and stays light.
- **Stage Breakdown** (`StageBreakdown.tsx`) — stays hook-free: takes a new optional `favoriteStageIds?: number[]` prop; `MatchDataPage` supplies `useStageFavorites().data?.stageIds`.

Both pickers previously rendered their group lists inline; swapping to `StageSelectGroups` also nets a ~40-line reduction and keeps group labels/i18n in one place.

## Tests

- `GspPage.test.tsx`: new test — favorited stage renders under a pinned Favorites group in the Quick Logger picker (and no "Most played" group appears). The existing `api.stageFavorites.get` stub gains a per-test override.
- `StageBreakdown.test.tsx`: new provider-free test — passing `favoriteStageIds` pins a Favorites group.
- `pnpm typecheck` and `pnpm test` pass (web 941, api 425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)