### PR TITLE
Localization phase 2h: Reports, Groups, Integrations (re-lands Opponents + Scout)

### DIFF
--- a/apps/web/src/components/billing/BuyCreditsDialog.tsx
+++ b/apps/web/src/components/billing/BuyCreditsDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { CreditPackId, CreditsStatus } from '@smash-tracker/shared';
 import { ApiError } from '@/lib/api';
 import { useCheckout } from '@/hooks/useBilling';
@@ -43,6 +44,7 @@ export function BuyCreditsDialog({
   onOpenChange: (open: boolean) => void;
   packs: CreditsStatus['packs'];
 }) {
+  const { t } = useTranslation();
   const [selectedPackId, setSelectedPackId] = useState<CreditPackId | null>(packs[0]?.id ?? null);
   const checkout = useCheckout();
 
@@ -64,11 +66,8 @@ export function BuyCreditsDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Buy report credits</DialogTitle>
-          <DialogDescription>
-            Each AI scouting report costs one credit. Pick a pack — you'll be redirected to Stripe
-            to complete the purchase.
-          </DialogDescription>
+          <DialogTitle>{t('billing.title')}</DialogTitle>
+          <DialogDescription>{t('billing.description')}</DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-3 py-2">
@@ -88,7 +87,9 @@ export function BuyCreditsDialog({
                 <div>
                   <p className="font-medium">{pack.label}</p>
                   <p className="text-sm text-muted-foreground">
-                    {perReportUsd(pack.amountCents, pack.credits)} per report
+                    {t('billing.perReport', {
+                      price: perReportUsd(pack.amountCents, pack.credits),
+                    })}
                   </p>
                 </div>
                 <p className="text-lg font-semibold">{formatUsd(pack.amountCents)}</p>
@@ -101,20 +102,20 @@ export function BuyCreditsDialog({
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
             {checkout.error instanceof ApiError
               ? checkout.error.message
-              : 'Something went wrong starting checkout. Please try again.'}
+              : t('billing.checkoutError')}
           </div>
         )}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button
             type="button"
             onClick={handleContinue}
             disabled={!selectedPackId || checkout.isPending}
           >
-            {checkout.isPending ? 'Redirecting…' : 'Continue to checkout'}
+            {checkout.isPending ? t('billing.redirecting') : t('billing.continue')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -114,6 +114,12 @@
       "p1": "<strong>Glicko-2</strong> ist das Wertungssystem aus dem Schach, das auch viele kompetitive Ladder nutzen. Anders als eine reine Winrate gewichtet es, <em>wen</em> du schlägst und wie überraschend das Ergebnis war.",
       "p2": "Die <strong>±-Zahl (RD)</strong> ist die Unsicherheit: Sie schrumpft, je mehr du spielst, und wächst bei Inaktivität — ein Spieler mit 1500 ±50 ist etabliert, einer mit 1500 ±300 eine Unbekannte.",
       "p3": "Wir nutzen es, weil Bracket-Play stoßweise passiert: Glicko-2 kommt mit langen Pausen zwischen Turnieren und kleinen Stichproben deutlich besser zurecht als Elo oder Winrate allein. Die Wertungen hier sind inoffiziell und werden nur aus deinen synchronisierten bzw. erfassten Matches berechnet."
+    },
+    "relativeDate": {
+      "justNow": "gerade eben",
+      "minutesAgo": "vor {{count}} Min.",
+      "hoursAgo": "vor {{count}} Std.",
+      "daysAgo": "vor {{count}} Tagen"
     }
   },
   "dashboard": {
@@ -676,6 +682,251 @@
       "verdictFollowed": "befolgt",
       "verdictAgainst": "dagegen",
       "verdictNeutral": "neutral zu"
+    }
+  },
+  "billing": {
+    "title": "Berichts-Credits kaufen",
+    "description": "Jeder KI-Scouting-Bericht kostet einen Credit. Wähle ein Paket — du wirst zu Stripe weitergeleitet, um den Kauf abzuschließen.",
+    "perReport": "{{price}} pro Bericht",
+    "checkoutError": "Beim Start des Bezahlvorgangs ist etwas schiefgelaufen. Bitte erneut versuchen.",
+    "redirecting": "Weiterleitung…",
+    "continue": "Weiter zur Kasse"
+  },
+  "opponents": {
+    "loading": "Scouting-Berichte werden geladen...",
+    "selectPrompt": "Wähle einen Gegner aus der Liste, um seinen Scouting-Bericht zu sehen.",
+    "empty": {
+      "title": "Noch keine Matches zum Scouten!",
+      "body": "Erfasse ein Match im Dashboard oder verbinde start.gg, um deine Turnier-Sets zu synchronisieren — dann erscheinen hier Scouting-Berichte zu deinen Gegnern.",
+      "connectStartgg": "start.gg verbinden"
+    },
+    "noTags": {
+      "title": "Keines deiner Matches hat einen Gegnernamen erfasst.",
+      "body": "Gib beim Erfassen eines Matches einen Gegnernamen an, um Scouting-Berichte freizuschalten."
+    },
+    "list": {
+      "title": "Gegner",
+      "faced_one": "{{count}} Gegner gespielt",
+      "faced_other": "{{count}} Gegner gespielt",
+      "searchPlaceholder": "Gegner suchen...",
+      "searchAria": "Gegner suchen",
+      "sortAria": "Gegner sortieren",
+      "sortMostPlayed": "Meistgespielt",
+      "sortRecent": "Zuletzt gespielt",
+      "sortBestRate": "Höchste Winrate",
+      "sortWorstRate": "Niedrigste Winrate",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3+ Matches",
+      "minGamesAria": "Nur Gegner mit 3 oder mehr Matches anzeigen",
+      "emptyNone": "Noch keine Gegner gespielt.",
+      "emptyFiltered": "Keine Gegner entsprechen deinen Filtern.",
+      "rowActions": "Aktionen für {{name}}",
+      "mergeInto": "Zusammenführen mit..."
+    },
+    "source": {
+      "mixedAria": "gemischte Quellen",
+      "verified": "verifiziert",
+      "manual": "manuell",
+      "manualAria": "manuell eingetragen",
+      "startggAria": "start.gg-verifiziert",
+      "parryggAria": "parry.gg-verifiziert"
+    },
+    "header": {
+      "playedRange": "Erstes Match {{first}} · Letztes Match {{last}}",
+      "encounterSpan": "{{start}} und {{end}}",
+      "metAt_one": "Bei {{count}} Turnier getroffen, zwischen {{span}}",
+      "metAt_other": "Bei {{count}} Turnieren getroffen, zwischen {{span}}",
+      "rateOverGames_one": "{{rate}} % bei {{count}} Match",
+      "rateOverGames_other": "{{rate}} % bei {{count}} Matches"
+    },
+    "whatTheyPlay": {
+      "title": "Was er spielt",
+      "description": "Sortiert danach, wie zuverlässig du es schlägst.",
+      "empty": "Noch keine Charaktere erfasst.",
+      "character": "Charakter"
+    },
+    "stages": {
+      "title": "Stages",
+      "empty": "Noch keine Stage-Daten erfasst."
+    },
+    "trend": {
+      "title": "H2H-Trend",
+      "empty": "Noch nicht genug Matches für einen Trend.",
+      "label": "Gleitende Winrate (letzte {{count}})"
+    },
+    "encounters": {
+      "title": "Letzte Begegnungen",
+      "empty": "Noch keine Begegnungen erfasst.",
+      "aria": "Letzte Begegnungen"
+    },
+    "history": {
+      "title": "Turnier-Historie",
+      "empty": "Noch keine Turnier-Sets gegen diesen Spieler — synchronisiere start.gg neu, falls ihr kürzlich gespielt habt.",
+      "gamesAria": "Spiele",
+      "losers": "Losers",
+      "vsThemHere": "{{wins}}-{{losses}} gegen ihn hier",
+      "setsAria": "Sets gegen ihn bei {{title}}"
+    },
+    "merge": {
+      "title": "„{{name}}“ zusammenführen mit...",
+      "description": "Wähle den Gegnernamen, der als dieselbe Person behandelt werden soll. Die Matches werden überall zusammengeführt.",
+      "noMatches": "Keine passenden Gegner.",
+      "warning": "„{{opponent}}“ ist {{label}} und „{{target}}“ nur manuell. Um das verifizierte Tag kanonisch zu halten, führen wir stattdessen „{{target}}“ in „{{opponent}}“ zusammen.",
+      "anyway": "„{{opponent}}“ trotzdem in „{{target}}“ zusammenführen",
+      "merging": "Wird zusammengeführt...",
+      "merge": "Zusammenführen"
+    },
+    "merged": {
+      "title": "Zusammengeführte Namen",
+      "description": "Diese Namen sind in „{{name}}“ eingegliedert. Trenne sie, um sie wieder separat zu verfolgen.",
+      "unmerge": "Trennen"
+    },
+    "tendencies": {
+      "title": "Tendenzen",
+      "description": "Deine eigenen Scouting-Notizen zu diesem Gegner — nicht aus der Match-Historie abgeleitet.",
+      "habits": "Gewohnheiten",
+      "habitsPlaceholder": "Eröffnungsgewohnheiten, Punish-Routen, Recovery-Mixups...",
+      "banThese": "Diese bannen (max. {{count}})",
+      "banAria": "Stages, die gegen diesen Gegner gebannt werden sollten",
+      "watchFor": "Achte auf",
+      "watchForPlaceholder": "Reads, Mindgames, Tech-Chases fürs nächste Set...",
+      "saving": "Wird gespeichert...",
+      "deleteNote": "Notiz löschen",
+      "banTheseView": "Diese bannen",
+      "banViewAria": "Zu bannende Stages",
+      "savedAt": "Gespeichert am {{date}}",
+      "edit": "Bearbeiten",
+      "empty": "Noch keine Scouting-Notizen. Halte Gewohnheiten, Stage-Bans oder Dinge fest, auf die du vor dem nächsten Set achten willst.",
+      "addNote": "Notiz hinzufügen"
+    },
+    "export": {
+      "print": "H2H exportieren",
+      "copy": "Als Text kopieren",
+      "copied": "Kopiert!"
+    }
+  },
+  "scout": {
+    "title": "Spieler scouten",
+    "prompt": "Füge oben eine start.gg-Profil-URL, einen Slug oder eine Spieler-ID ein, um die öffentliche Turnier-Historie abzurufen.",
+    "promptWithParry": "Füge oben eine start.gg- oder parry.gg-Profil-URL, einen Slug/Tag oder eine Spieler-ID ein, um die öffentliche Turnier-Historie abzurufen.",
+    "errors": {
+      "notFound": "Wir konnten keinen start.gg-Spieler zu dieser Suche finden. Prüfe URL, Slug oder Spieler-ID.",
+      "badQuery": "Das sieht nicht nach einer start.gg-Profil-URL, einem Slug oder einer Spieler-ID aus.",
+      "rateLimited": "start.gg drosselt gerade die Anfragen. Versuche es in einer Minute erneut.",
+      "scoutFallback": "Beim Scouten dieses Spielers ist etwas schiefgelaufen.",
+      "generateFallback": "Beim Generieren des Berichts ist etwas schiefgelaufen."
+    },
+    "form": {
+      "description": "Füge eine start.gg-Profil-URL, eine „user/<slug>“-Referenz oder eine numerische Spieler-ID ein, um vor dem Match die öffentliche Turnier-Historie abzurufen.",
+      "descriptionWithParry": "Füge eine start.gg- oder parry.gg-Profil-URL, einen Gamer-Tag, eine „user/<slug>“-Referenz oder eine numerische Spieler-ID ein, um vor dem Match die öffentliche Turnier-Historie abzurufen.",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 oder eine parry.gg-Profil-URL",
+      "inputAria": "start.gg-Profil-URL, Slug oder Spieler-ID",
+      "inputAriaWithParry": "start.gg- oder parry.gg-Profil-URL, Slug/Tag oder Spieler-ID",
+      "scout": "Scouten",
+      "scouting": "Scoutet…",
+      "source": "Quelle:",
+      "sourceAria": "Scouting-Quelle",
+      "detectedParry": "parry.gg-Profil-URL erkannt.",
+      "pending": "Öffentliche Turnier-Historie wird abgerufen — das kann ein paar Sekunden dauern."
+    },
+    "report": {
+      "generate": "KI-Bericht generieren",
+      "regenerate": "Bericht neu generieren",
+      "generating": "Bericht wird generiert…",
+      "generatingHint": "Bericht wird generiert — das dauert normalerweise ein bis zwei Minuten."
+    },
+    "billing": {
+      "paymentReceived": "Zahlung erhalten — deine Credits kommen in Kürze an, falls nicht schon geschehen.",
+      "checkoutCancelled": "Bezahlvorgang abgebrochen — es wurde nichts berechnet.",
+      "freeAccess": "Kostenloser Zugang",
+      "credits_one": "{{count}} Credit",
+      "credits_other": "{{count}} Credits",
+      "buyCredits": "Credits kaufen",
+      "costLine": "Jeder Bericht kostet 1 Credit.",
+      "packFor": "{{label}} für {{price}}",
+      "outOfCredits": "Du hast keine Credits mehr.",
+      "buyPack": "Kaufe ein Paket",
+      "toGenerate": "um diesen Bericht zu generieren."
+    },
+    "header": {
+      "viewOn": "{{name}} auf {{source}} ansehen",
+      "profile": "{{source}}-Profil",
+      "sample": "Öffentliche {{source}}-Daten · Stichprobe der letzten {{sets}} Sets ({{games}} Spiele)"
+    },
+    "characters": {
+      "title": "Charakternutzung",
+      "description": "Was er spielt, meistgenutzt zuerst.",
+      "empty": "Noch keine Spiele in der Stichprobe."
+    },
+    "stages": {
+      "title": "Stage-Leistung",
+      "description": "Seine Ergebnisse nach Stage."
+    },
+    "events": {
+      "title": "Letzte Events",
+      "description": "Neueste Aktivität zuerst.",
+      "empty": "Keine aktuellen Events in der Stichprobe.",
+      "placement": "Platzierung",
+      "entrants": "Teilnehmer"
+    },
+    "commonOpponents": {
+      "title": "Häufige Gegner",
+      "description": "Wen er in den erfassten Sets am häufigsten trifft.",
+      "empty": "Keine wiederkehrenden Gegner in der Stichprobe.",
+      "sets_one": "{{count}} Set",
+      "sets_other": "{{count}} Sets"
+    },
+    "history": {
+      "title": "Deine Historie gegen ihn",
+      "description_one": "Du hast schon gegen {{name}} gespielt — {{count}} Match in deiner eigenen Historie erfasst.",
+      "description_other": "Du hast schon gegen {{name}} gespielt — {{count}} Matches in deiner eigenen Historie erfasst.",
+      "rate": "({{rate}} % Winrate)",
+      "fullReport": "Vollständiger Scouting-Bericht"
+    },
+    "advisor": {
+      "title": "Matchup-Berater",
+      "description": "Dein bester (und schlechtester) Pick gegen jeden seiner Charaktere — kombiniert deine eigene Bilanz mit Tierlist- und Archetyp-Daten.",
+      "noCharacterData": "Noch keine Charakterdaten für diesen Scout — auf parry.gg üblich, solange die Match-Daten dünn sind. Schau vorbei, wenn mehr Sets gespielt wurden.",
+      "noMyCharacters": "Wähle einen Main- oder Secondary-Charakter (oder erfasse ein paar Matches), um persönliche Empfehlungen zu erhalten.",
+      "vsName": "vs. {{name}}",
+      "gamesSampled_one": "{{count}} Spiel in der Stichprobe",
+      "gamesSampled_other": "{{count}} Spiele in der Stichprobe",
+      "inYourSets": "{{record}} in deinen Sets",
+      "tier": "Tier {{score}}/10",
+      "archetypeEdge": "Archetyp-Vorteil",
+      "archetypeDisadvantage": "Archetyp-Nachteil"
+    },
+    "fullAnalysis": {
+      "title": "Vollständige Analyse",
+      "rescout": "Erneut scouten, um die vollständige Analyse zu aktivieren.",
+      "noGameData": "Von dieser Quelle sind noch keine Daten pro Spiel verfügbar.",
+      "stageMasteryOverall": "Stage-Beherrschung — Gesamt",
+      "stageMasteryFor": "Stage-Beherrschung — {{name}}",
+      "topCharacter": "Top-Charakter",
+      "recentForm": "Aktuelle Form von {{name}}"
+    },
+    "aiReport": {
+      "title": "KI-Scouting-Bericht",
+      "generated": "Generiert {{rel}}",
+      "download": "Herunterladen (.md)",
+      "print": "Drucken / Als PDF speichern",
+      "gameplan": "Spielplan",
+      "characterStrategy": "Charakter-Strategie",
+      "stageStrategy": "Stage-Strategie",
+      "picks": "Picks:",
+      "bans": "Bans:",
+      "headToHead": "Direktvergleich",
+      "watchFor": "Achte auf"
+    },
+    "historySelector": {
+      "older": "Älterer Bericht",
+      "newer": "Neuerer Bericht",
+      "reportOf": "Bericht {{ordinal}} von {{total}}"
+    },
+    "pastReports": {
+      "title": "Frühere KI-Berichte",
+      "description": "Bereits generierte Berichte, neueste zuerst."
     }
   }
 }

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -928,5 +928,125 @@
       "title": "Frühere KI-Berichte",
       "description": "Bereits generierte Berichte, neueste zuerst."
     }
+  },
+  "reports": {
+    "title": "KI-Berichte",
+    "notEnabled": "KI-Berichte sind für dieses Konto noch nicht aktiviert.",
+    "loading": "Deine Berichte werden geladen…",
+    "empty": "Noch keine KI-Scouting-Berichte. Erstelle einen auf der Seite <scoutLink>Spieler scouten</scoutLink>.",
+    "yourReports": "Deine Berichte",
+    "groupedBy": "Nach Spieler gruppiert, zuletzt gescoutete zuerst.",
+    "olderReport": "Älterer Bericht",
+    "hideOlder": "Ältere Berichte ausblenden",
+    "showOlder": "Ältere Berichte anzeigen"
+  },
+  "groups": {
+    "title": "Gruppen",
+    "loading": "Deine Gruppen werden geladen...",
+    "empty": {
+      "title": "Noch keine Gruppen",
+      "body": "Erstelle eine Gruppe, um eine Freundes-Rangliste zu starten, oder tritt einer mit einem Einladungscode bei."
+    },
+    "leaderboardLoading": "Rangliste wird geladen...",
+    "leaderboardError": "Beim Laden dieser Rangliste ist etwas schiefgelaufen.",
+    "create": {
+      "trigger": "Gruppe erstellen",
+      "title": "Gruppe erstellen",
+      "description": "Starte eine Freundes-Rangliste. Nach dem Erstellen kannst du andere mit einem Code einladen.",
+      "nameLabel": "Gruppenname",
+      "namePlaceholder": "z. B. Die Locals",
+      "error": "Beim Erstellen der Gruppe ist etwas schiefgelaufen.",
+      "pending": "Wird erstellt...",
+      "confirm": "Erstellen"
+    },
+    "join": {
+      "trigger": "Mit Code beitreten",
+      "title": "Einer Gruppe beitreten",
+      "description": "Gib den Einladungscode ein, den du erhalten hast.",
+      "codeLabel": "Einladungscode",
+      "codePlaceholder": "z. B. AB3DEFGH",
+      "error": "Beim Beitreten zu dieser Gruppe ist etwas schiefgelaufen.",
+      "pending": "Wird beigetreten...",
+      "confirm": "Beitreten"
+    },
+    "members_one": "{{count}} Mitglied",
+    "members_other": "{{count}} Mitglieder",
+    "header": {
+      "deleteTrigger": "Gruppe löschen",
+      "deleteTitle": "„{{name}}“ löschen?",
+      "deleteDescription": "Dies entfernt die Gruppe und ihre Rangliste für alle Mitglieder. Das kann nicht rückgängig gemacht werden.",
+      "deleteError": "Beim Löschen der Gruppe ist etwas schiefgelaufen.",
+      "deletePending": "Wird gelöscht...",
+      "leaveTrigger": "Gruppe verlassen",
+      "leaveTitle": "„{{name}}“ verlassen?",
+      "leaveDescription": "Du brauchst einen neuen Einladungscode, um später wieder beizutreten.",
+      "leaveError": "Beim Verlassen der Gruppe ist etwas schiefgelaufen.",
+      "leavePending": "Wird verlassen...",
+      "leaveConfirm": "Verlassen",
+      "inviteCode": "Einladungscode:",
+      "copyAria": "Einladungscode kopieren"
+    },
+    "table": {
+      "player": "Spieler",
+      "rating": "Wertung",
+      "games": "Spiele",
+      "lastActive": "Zuletzt aktiv",
+      "you": "(du)",
+      "never": "nie"
+    }
+  },
+  "integrations": {
+    "title": "Integrationen",
+    "connected": "Verbunden",
+    "checkingStatus": "Verknüpfungsstatus wird geprüft…",
+    "gamerTag": "Gamer-Tag",
+    "lastSynced": "Zuletzt synchronisiert",
+    "never": "Nie",
+    "syncNow": "Jetzt synchronisieren",
+    "syncing": "Synchronisiere…",
+    "unlink": "Trennen",
+    "syncFailed": "Synchronisierung fehlgeschlagen. Bitte versuche es erneut.",
+    "unlinkFailed": "Trennen fehlgeschlagen. Bitte versuche es erneut.",
+    "linkDescription": "Verknüpfe dein {{provider}}-Konto, um deine Smash-Ultimate-Turniermatches automatisch zu importieren. Importierte Spiele landen mit Competitive-Tag in deinem Match-Pool.",
+    "unlinkTitle": "{{provider}} trennen?",
+    "unlinkDescription": "Bereits importierte Matches bleiben in deinem Verlauf; neue Turnierergebnisse werden nur nicht mehr synchronisiert, bis du dich erneut verbindest.",
+    "unlinkedToast": "{{provider}}-Konto getrennt.",
+    "summary": {
+      "importedFromSets": "{{imported}} Spiele aus {{sets}} Sets importiert",
+      "importedFromMatches": "{{imported}} Spiele aus {{matches}} Matches importiert",
+      "skippedDetail_one": "{{count}} ohne importierbare Details",
+      "skippedDetail_other": "{{count}} ohne importierbare Details",
+      "unknownStages_one": "{{count}} mit unbekannten Stages",
+      "unknownStages_other": "{{count}} mit unbekannten Stages",
+      "dqSkipped_one": "{{count}} DQ übersprungen",
+      "dqSkipped_other": "{{count}} DQs übersprungen"
+    },
+    "startgg": {
+      "connect": "start.gg-Konto verbinden",
+      "linked": "start.gg-Konto verknüpft!",
+      "linkFailed": "start.gg-Verknüpfung fehlgeschlagen ({{reason}})",
+      "unknownError": "unbekannter Fehler"
+    },
+    "parrygg": {
+      "verified": "Verifiziert",
+      "unverified": "Nicht verifiziert",
+      "verify": "Verifizieren",
+      "linkedTo": "Mit {{tag}} auf parry.gg verknüpft!",
+      "linkFailed": "Dieses Konto konnte nicht verknüpft werden. Bitte versuche es erneut.",
+      "searchPlaceholder": "Suche deinen parry.gg-Gamer-Tag...",
+      "searchAria": "parry.gg-Gamer-Tag suchen",
+      "searching": "Suche...",
+      "noAccounts": "Keine passenden parry.gg-Konten.",
+      "link": "Verknüpfen",
+      "verifyTitle": "Verifiziere dein parry.gg-Konto",
+      "verifyDescription": "Füge diesen Code in die Bio deines parry.gg-Profils ein und klicke dann auf Prüfen. Er läuft in 10 Minuten ab.",
+      "copyCodeAria": "Verifizierungscode kopieren",
+      "generatingCode": "Dein Verifizierungscode wird generiert...",
+      "check": "Prüfen",
+      "checking": "Prüfe...",
+      "verifyStartFailed": "Verifizierung konnte nicht gestartet werden. Bitte versuche es erneut.",
+      "verifiedToast": "parry.gg-Konto verifiziert!",
+      "codeNotFound": "Verifizierungscode noch nicht gefunden. Bitte versuche es erneut."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -101,6 +101,12 @@
       "view": "View on start.gg",
       "viewName": "View {{name}} on start.gg"
     },
+    "relativeDate": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    },
     "filteredNotice": {
       "message": "No matches match the current filters.",
       "clear": "Clear filters"
@@ -676,6 +682,251 @@
       "verdictFollowed": "followed",
       "verdictAgainst": "against",
       "verdictNeutral": "neutral on"
+    }
+  },
+  "billing": {
+    "title": "Buy report credits",
+    "description": "Each AI scouting report costs one credit. Pick a pack — you'll be redirected to Stripe to complete the purchase.",
+    "perReport": "{{price}} per report",
+    "checkoutError": "Something went wrong starting checkout. Please try again.",
+    "redirecting": "Redirecting…",
+    "continue": "Continue to checkout"
+  },
+  "opponents": {
+    "loading": "Loading scouting reports...",
+    "selectPrompt": "Select an opponent from the list to see their scouting report.",
+    "empty": {
+      "title": "No matches to scout yet!",
+      "body": "Report a match on the Dashboard, or connect start.gg to sync your tournament sets, and opponent scouting reports will show up here.",
+      "connectStartgg": "Connect start.gg"
+    },
+    "noTags": {
+      "title": "None of your matches have an opponent tag recorded.",
+      "body": "Add an opponent name when reporting a match to unlock scouting reports for them."
+    },
+    "list": {
+      "title": "Opponents",
+      "faced_one": "{{count}} opponent faced",
+      "faced_other": "{{count}} opponents faced",
+      "searchPlaceholder": "Search opponents...",
+      "searchAria": "Search opponents",
+      "sortAria": "Sort opponents",
+      "sortMostPlayed": "Most played",
+      "sortRecent": "Recently played",
+      "sortBestRate": "Highest win rate",
+      "sortWorstRate": "Lowest win rate",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3+ games",
+      "minGamesAria": "Only show opponents with 3 or more games",
+      "emptyNone": "No opponents faced yet.",
+      "emptyFiltered": "No opponents match your filters.",
+      "rowActions": "Actions for {{name}}",
+      "mergeInto": "Merge into..."
+    },
+    "source": {
+      "mixedAria": "mixed sources",
+      "verified": "verified",
+      "manual": "manual",
+      "manualAria": "manually entered",
+      "startggAria": "start.gg-verified",
+      "parryggAria": "parry.gg-verified"
+    },
+    "header": {
+      "playedRange": "First played {{first}} · Last played {{last}}",
+      "encounterSpan": "{{start}} and {{end}}",
+      "metAt_one": "Met at {{count}} tournament between {{span}}",
+      "metAt_other": "Met at {{count}} tournaments between {{span}}",
+      "rateOverGames_one": "{{rate}}% over {{count}} game",
+      "rateOverGames_other": "{{rate}}% over {{count}} games"
+    },
+    "whatTheyPlay": {
+      "title": "What They Play",
+      "description": "Ordered by how reliably you beat it.",
+      "empty": "No characters recorded yet.",
+      "character": "Character"
+    },
+    "stages": {
+      "title": "Stages",
+      "empty": "No stage data recorded yet."
+    },
+    "trend": {
+      "title": "H2H Trend",
+      "empty": "Not enough matches for a trend yet.",
+      "label": "Rolling win rate (last {{count}})"
+    },
+    "encounters": {
+      "title": "Recent Encounters",
+      "empty": "No encounters recorded yet.",
+      "aria": "Recent encounters"
+    },
+    "history": {
+      "title": "Tournament History",
+      "empty": "No tournament sets vs this player yet — resync start.gg if you've played recently.",
+      "gamesAria": "Games",
+      "losers": "Losers",
+      "vsThemHere": "{{wins}}-{{losses}} vs them here",
+      "setsAria": "Sets vs them at {{title}}"
+    },
+    "merge": {
+      "title": "Merge \"{{name}}\" into...",
+      "description": "Choose the opponent name that should be treated as the same person. Their matches will be combined everywhere.",
+      "noMatches": "No matching opponents.",
+      "warning": "\"{{opponent}}\" is {{label}} and \"{{target}}\" is manual-only. To keep the verified tag as canonical, we'll merge \"{{target}}\" into \"{{opponent}}\" instead.",
+      "anyway": "Merge \"{{opponent}}\" into \"{{target}}\" anyway",
+      "merging": "Merging...",
+      "merge": "Merge"
+    },
+    "merged": {
+      "title": "Merged names",
+      "description": "These names are folded into \"{{name}}\". Un-merge to track them separately again.",
+      "unmerge": "Un-merge"
+    },
+    "tendencies": {
+      "title": "Tendencies",
+      "description": "Your own scouting notes for this opponent — not derived from match history.",
+      "habits": "Habits",
+      "habitsPlaceholder": "Opening habits, punish routes, recovery mixups...",
+      "banThese": "Ban these (max {{count}})",
+      "banAria": "Stages to ban against this opponent",
+      "watchFor": "Watch for",
+      "watchForPlaceholder": "Reads, mind games, tech chases to expect next set...",
+      "saving": "Saving...",
+      "deleteNote": "Delete note",
+      "banTheseView": "Ban these",
+      "banViewAria": "Stages to ban",
+      "savedAt": "Saved {{date}}",
+      "edit": "Edit",
+      "empty": "No scouting notes yet. Jot down habits, stages to ban, or things to watch for before your next set.",
+      "addNote": "Add a note"
+    },
+    "export": {
+      "print": "Export H2H",
+      "copy": "Copy as text",
+      "copied": "Copied!"
+    }
+  },
+  "scout": {
+    "title": "Scout a Player",
+    "prompt": "Paste a start.gg profile URL, slug, or player id above to pull up their public tournament history.",
+    "promptWithParry": "Paste a start.gg or parry.gg profile URL, slug/tag, or player id above to pull up their public tournament history.",
+    "errors": {
+      "notFound": "We couldn't find a start.gg player for that query. Double-check the URL, slug, or player id.",
+      "badQuery": "That doesn't look like a start.gg profile URL, slug, or player id.",
+      "rateLimited": "start.gg is rate-limiting requests right now. Try again in a minute.",
+      "scoutFallback": "Something went wrong while scouting that player.",
+      "generateFallback": "Something went wrong while generating the report."
+    },
+    "form": {
+      "description": "Paste a start.gg profile URL, a \"user/<slug>\" reference, or a numeric player id to pull up their public tournament history before you play them.",
+      "descriptionWithParry": "Paste a start.gg or parry.gg profile URL, a bare gamer tag, a \"user/<slug>\" reference, or a numeric player id to pull up their public tournament history before you play them.",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 or a parry.gg profile URL",
+      "inputAria": "start.gg profile URL, slug, or player id",
+      "inputAriaWithParry": "start.gg or parry.gg profile URL, slug/tag, or player id",
+      "scout": "Scout",
+      "scouting": "Scouting…",
+      "source": "Source:",
+      "sourceAria": "Scouting source",
+      "detectedParry": "Detected a parry.gg profile URL.",
+      "pending": "Pulling their public tournament history — this can take a few seconds."
+    },
+    "report": {
+      "generate": "Generate AI report",
+      "regenerate": "Regenerate report",
+      "generating": "Generating report…",
+      "generatingHint": "Generating report — this usually takes a minute or two."
+    },
+    "billing": {
+      "paymentReceived": "Payment received — your credits will land shortly if they haven't already.",
+      "checkoutCancelled": "Checkout cancelled — no charge was made.",
+      "freeAccess": "Free access",
+      "credits_one": "{{count}} credit",
+      "credits_other": "{{count}} credits",
+      "buyCredits": "Buy credits",
+      "costLine": "Each report costs 1 credit.",
+      "packFor": "{{label}} for {{price}}",
+      "outOfCredits": "You're out of credits.",
+      "buyPack": "Buy a pack",
+      "toGenerate": "to generate this report."
+    },
+    "header": {
+      "viewOn": "View {{name}} on {{source}}",
+      "profile": "{{source}} profile",
+      "sample": "Public {{source}} data · sampled last {{sets}} sets ({{games}} games)"
+    },
+    "characters": {
+      "title": "Character Usage",
+      "description": "What they play, most-used first.",
+      "empty": "No sampled games yet."
+    },
+    "stages": {
+      "title": "Stage Performance",
+      "description": "Their results by stage."
+    },
+    "events": {
+      "title": "Recent Events",
+      "description": "Most recent activity first.",
+      "empty": "No recent events sampled.",
+      "placement": "Placement",
+      "entrants": "Entrants"
+    },
+    "commonOpponents": {
+      "title": "Common Opponents",
+      "description": "Who they run into most, in the sampled sets.",
+      "empty": "No repeat opponents in the sample.",
+      "sets_one": "{{count}} set",
+      "sets_other": "{{count}} sets"
+    },
+    "history": {
+      "title": "Your History vs Them",
+      "description_one": "You've played {{name}} before — {{count}} game recorded in your own match history.",
+      "description_other": "You've played {{name}} before — {{count}} games recorded in your own match history.",
+      "rate": "({{rate}}% win rate)",
+      "fullReport": "Full scouting report"
+    },
+    "advisor": {
+      "title": "Matchup Advisor",
+      "description": "Your best (and worst) pick against each of their characters — blends your own record with tier list and archetype data.",
+      "noCharacterData": "No character data for this scout yet — common on parry.gg while match data is still sparse. Check back after they've played more sets.",
+      "noMyCharacters": "Pick a primary or secondary character (or log a few matches) to get personalized recommendations.",
+      "vsName": "vs. {{name}}",
+      "gamesSampled_one": "{{count}} game sampled",
+      "gamesSampled_other": "{{count}} games sampled",
+      "inYourSets": "{{record}} in your sets",
+      "tier": "tier {{score}}/10",
+      "archetypeEdge": "archetype edge",
+      "archetypeDisadvantage": "archetype disadvantage"
+    },
+    "fullAnalysis": {
+      "title": "Full analysis",
+      "rescout": "Re-scout to enable full analysis.",
+      "noGameData": "No per-game data available from this source yet.",
+      "stageMasteryOverall": "Stage Mastery — Overall",
+      "stageMasteryFor": "Stage Mastery — {{name}}",
+      "topCharacter": "Top character",
+      "recentForm": "{{name}}'s Recent Form"
+    },
+    "aiReport": {
+      "title": "AI Scouting Report",
+      "generated": "Generated {{rel}}",
+      "download": "Download (.md)",
+      "print": "Print / Save as PDF",
+      "gameplan": "Game plan",
+      "characterStrategy": "Character strategy",
+      "stageStrategy": "Stage strategy",
+      "picks": "Picks:",
+      "bans": "Bans:",
+      "headToHead": "Head-to-head",
+      "watchFor": "Watch for"
+    },
+    "historySelector": {
+      "older": "Older report",
+      "newer": "Newer report",
+      "reportOf": "Report {{ordinal}} of {{total}}"
+    },
+    "pastReports": {
+      "title": "Past AI Reports",
+      "description": "Reports you've generated before, most recent first."
     }
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -928,5 +928,125 @@
       "title": "Past AI Reports",
       "description": "Reports you've generated before, most recent first."
     }
+  },
+  "reports": {
+    "title": "AI Reports",
+    "notEnabled": "AI reports aren't enabled for this account yet.",
+    "loading": "Loading your reports…",
+    "empty": "No AI scouting reports yet. Generate one from the <scoutLink>Scout a Player</scoutLink> page.",
+    "yourReports": "Your Reports",
+    "groupedBy": "Grouped by player, most recently scouted first.",
+    "olderReport": "Older report",
+    "hideOlder": "Hide older reports",
+    "showOlder": "Show older reports"
+  },
+  "groups": {
+    "title": "Groups",
+    "loading": "Loading your groups...",
+    "empty": {
+      "title": "No groups yet",
+      "body": "Create a group to start a friend-group leaderboard, or join one with an invite code."
+    },
+    "leaderboardLoading": "Loading leaderboard...",
+    "leaderboardError": "Something went wrong loading this leaderboard.",
+    "create": {
+      "trigger": "Create group",
+      "title": "Create a group",
+      "description": "Start a friend-group leaderboard. You can invite others with a code once it's created.",
+      "nameLabel": "Group name",
+      "namePlaceholder": "e.g. The Locals",
+      "error": "Something went wrong creating the group.",
+      "pending": "Creating...",
+      "confirm": "Create"
+    },
+    "join": {
+      "trigger": "Join with code",
+      "title": "Join a group",
+      "description": "Enter the invite code someone shared with you.",
+      "codeLabel": "Invite code",
+      "codePlaceholder": "e.g. AB3DEFGH",
+      "error": "Something went wrong joining that group.",
+      "pending": "Joining...",
+      "confirm": "Join"
+    },
+    "members_one": "{{count}} member",
+    "members_other": "{{count}} members",
+    "header": {
+      "deleteTrigger": "Delete group",
+      "deleteTitle": "Delete \"{{name}}\"?",
+      "deleteDescription": "This removes the group and its leaderboard for every member. This can't be undone.",
+      "deleteError": "Something went wrong deleting the group.",
+      "deletePending": "Deleting...",
+      "leaveTrigger": "Leave group",
+      "leaveTitle": "Leave \"{{name}}\"?",
+      "leaveDescription": "You'll need a new invite code to rejoin later.",
+      "leaveError": "Something went wrong leaving the group.",
+      "leavePending": "Leaving...",
+      "leaveConfirm": "Leave",
+      "inviteCode": "Invite code:",
+      "copyAria": "Copy invite code"
+    },
+    "table": {
+      "player": "Player",
+      "rating": "Rating",
+      "games": "Games",
+      "lastActive": "Last active",
+      "you": "(you)",
+      "never": "never"
+    }
+  },
+  "integrations": {
+    "title": "Integrations",
+    "connected": "Connected",
+    "checkingStatus": "Checking link status…",
+    "gamerTag": "Gamer tag",
+    "lastSynced": "Last synced",
+    "never": "Never",
+    "syncNow": "Sync now",
+    "syncing": "Syncing…",
+    "unlink": "Unlink",
+    "syncFailed": "Sync failed. Please try again.",
+    "unlinkFailed": "Failed to unlink. Please try again.",
+    "linkDescription": "Link your {{provider}} account to automatically import your Smash Ultimate tournament matches. Imported games join your match pool with a competitive tag.",
+    "unlinkTitle": "Unlink {{provider}}?",
+    "unlinkDescription": "Already-imported matches stay in your history; new tournament results just stop syncing until you reconnect.",
+    "unlinkedToast": "{{provider}} account unlinked.",
+    "summary": {
+      "importedFromSets": "Imported {{imported}} games from {{sets}} sets",
+      "importedFromMatches": "Imported {{imported}} games from {{matches}} matches",
+      "skippedDetail_one": "{{count}} without importable detail",
+      "skippedDetail_other": "{{count}} without importable detail",
+      "unknownStages_one": "{{count}} with unrecognized stages",
+      "unknownStages_other": "{{count}} with unrecognized stages",
+      "dqSkipped_one": "{{count}} DQ skipped",
+      "dqSkipped_other": "{{count}} DQs skipped"
+    },
+    "startgg": {
+      "connect": "Connect start.gg account",
+      "linked": "start.gg account linked!",
+      "linkFailed": "start.gg linking failed ({{reason}})",
+      "unknownError": "unknown error"
+    },
+    "parrygg": {
+      "verified": "Verified",
+      "unverified": "Unverified",
+      "verify": "Verify",
+      "linkedTo": "Linked to {{tag}} on parry.gg!",
+      "linkFailed": "Failed to link that account. Please try again.",
+      "searchPlaceholder": "Search your parry.gg gamer tag...",
+      "searchAria": "Search parry.gg gamer tag",
+      "searching": "Searching...",
+      "noAccounts": "No matching parry.gg accounts.",
+      "link": "Link",
+      "verifyTitle": "Verify your parry.gg account",
+      "verifyDescription": "Paste this code into your parry.gg profile bio, then click Check. It expires in 10 minutes.",
+      "copyCodeAria": "Copy verification code",
+      "generatingCode": "Generating your verification code...",
+      "check": "Check",
+      "checking": "Checking...",
+      "verifyStartFailed": "Failed to start verification. Please try again.",
+      "verifiedToast": "parry.gg account verified!",
+      "codeNotFound": "Verification code not found yet. Please try again."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -114,6 +114,12 @@
       "p1": "<strong>Glicko-2</strong> es el sistema de puntuación que se usa en ajedrez y en muchas ligas competitivas. A diferencia de un simple porcentaje de victorias, pondera a <em>quién</em> vences y cuán sorprendente fue el resultado.",
       "p2": "El <strong>número ± (RD)</strong> es la incertidumbre: se reduce cuanto más juegas y crece cuando estás inactivo — un jugador con 1500 ±50 está consolidado, uno con 1500 ±300 es una incógnita.",
       "p3": "Lo usamos porque el juego de bracket va a rachas: Glicko-2 maneja los parones largos entre torneos y las muestras pequeñas mucho mejor que el Elo o el porcentaje de victorias por sí solos. Las puntuaciones de aquí no son oficiales y se calculan solo con tus partidas sincronizadas o registradas."
+    },
+    "relativeDate": {
+      "justNow": "justo ahora",
+      "minutesAgo": "hace {{count}} min",
+      "hoursAgo": "hace {{count}} h",
+      "daysAgo": "hace {{count}} días"
     }
   },
   "dashboard": {
@@ -676,6 +682,251 @@
       "verdictFollowed": "seguida",
       "verdictAgainst": "en contra",
       "verdictNeutral": "neutral sobre"
+    }
+  },
+  "billing": {
+    "title": "Comprar créditos de informes",
+    "description": "Cada informe de scouting con IA cuesta un crédito. Elige un paquete — se te redirigirá a Stripe para completar la compra.",
+    "perReport": "{{price}} por informe",
+    "checkoutError": "Algo salió mal al iniciar el pago. Inténtalo de nuevo.",
+    "redirecting": "Redirigiendo…",
+    "continue": "Continuar al pago"
+  },
+  "opponents": {
+    "loading": "Cargando informes de scouting...",
+    "selectPrompt": "Selecciona un rival de la lista para ver su informe de scouting.",
+    "empty": {
+      "title": "¡Aún no hay partidas que analizar!",
+      "body": "Registra una partida en el Panel, o conecta start.gg para sincronizar tus sets de torneo, y aquí aparecerán los informes de scouting de tus rivales.",
+      "connectStartgg": "Conectar start.gg"
+    },
+    "noTags": {
+      "title": "Ninguna de tus partidas tiene un nombre de rival registrado.",
+      "body": "Añade el nombre del rival al registrar una partida para desbloquear su informe de scouting."
+    },
+    "list": {
+      "title": "Rivales",
+      "faced_one": "{{count}} rival enfrentado",
+      "faced_other": "{{count}} rivales enfrentados",
+      "searchPlaceholder": "Buscar rivales...",
+      "searchAria": "Buscar rivales",
+      "sortAria": "Ordenar rivales",
+      "sortMostPlayed": "Más jugados",
+      "sortRecent": "Jugados recientemente",
+      "sortBestRate": "Mayor % de victorias",
+      "sortWorstRate": "Menor % de victorias",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3+ partidas",
+      "minGamesAria": "Mostrar solo rivales con 3 o más partidas",
+      "emptyNone": "Aún no has enfrentado a ningún rival.",
+      "emptyFiltered": "Ningún rival coincide con tus filtros.",
+      "rowActions": "Acciones para {{name}}",
+      "mergeInto": "Fusionar con..."
+    },
+    "source": {
+      "mixedAria": "fuentes mixtas",
+      "verified": "verificado",
+      "manual": "manual",
+      "manualAria": "introducido manualmente",
+      "startggAria": "verificado por start.gg",
+      "parryggAria": "verificado por parry.gg"
+    },
+    "header": {
+      "playedRange": "Primera partida {{first}} · Última partida {{last}}",
+      "encounterSpan": "{{start}} y {{end}}",
+      "metAt_one": "Coincidisteis en {{count}} torneo entre {{span}}",
+      "metAt_other": "Coincidisteis en {{count}} torneos entre {{span}}",
+      "rateOverGames_one": "{{rate}}% en {{count}} partida",
+      "rateOverGames_other": "{{rate}}% en {{count}} partidas"
+    },
+    "whatTheyPlay": {
+      "title": "Qué juega",
+      "description": "Ordenado por la fiabilidad con la que lo vences.",
+      "empty": "Aún no hay personajes registrados.",
+      "character": "Personaje"
+    },
+    "stages": {
+      "title": "Escenarios",
+      "empty": "Aún no hay datos de escenarios registrados."
+    },
+    "trend": {
+      "title": "Tendencia H2H",
+      "empty": "Aún no hay suficientes partidas para una tendencia.",
+      "label": "% de victorias móvil (últimas {{count}})"
+    },
+    "encounters": {
+      "title": "Encuentros recientes",
+      "empty": "Aún no hay encuentros registrados.",
+      "aria": "Encuentros recientes"
+    },
+    "history": {
+      "title": "Historial de torneos",
+      "empty": "Aún no hay sets de torneo contra este jugador — resincroniza start.gg si habéis jugado hace poco.",
+      "gamesAria": "Partidas",
+      "losers": "Losers",
+      "vsThemHere": "{{wins}}-{{losses}} contra él aquí",
+      "setsAria": "Sets contra él en {{title}}"
+    },
+    "merge": {
+      "title": "Fusionar \"{{name}}\" con...",
+      "description": "Elige el nombre de rival que debe tratarse como la misma persona. Sus partidas se combinarán en toda la app.",
+      "noMatches": "No hay rivales que coincidan.",
+      "warning": "\"{{opponent}}\" está {{label}} y \"{{target}}\" es solo manual. Para mantener la etiqueta verificada como canónica, fusionaremos \"{{target}}\" con \"{{opponent}}\" en su lugar.",
+      "anyway": "Fusionar \"{{opponent}}\" con \"{{target}}\" de todos modos",
+      "merging": "Fusionando...",
+      "merge": "Fusionar"
+    },
+    "merged": {
+      "title": "Nombres fusionados",
+      "description": "Estos nombres están integrados en \"{{name}}\". Sepáralos para seguirlos por separado de nuevo.",
+      "unmerge": "Separar"
+    },
+    "tendencies": {
+      "title": "Tendencias",
+      "description": "Tus propias notas de scouting para este rival — no derivadas del historial de partidas.",
+      "habits": "Hábitos",
+      "habitsPlaceholder": "Hábitos de apertura, rutas de castigo, mixups de recuperación...",
+      "banThese": "Banea estos (máx. {{count}})",
+      "banAria": "Escenarios a banear contra este rival",
+      "watchFor": "Vigila",
+      "watchForPlaceholder": "Lecturas, juegos mentales, tech chases que esperar el próximo set...",
+      "saving": "Guardando...",
+      "deleteNote": "Eliminar nota",
+      "banTheseView": "Banea estos",
+      "banViewAria": "Escenarios a banear",
+      "savedAt": "Guardado el {{date}}",
+      "edit": "Editar",
+      "empty": "Aún no hay notas de scouting. Apunta hábitos, escenarios a banear o cosas a vigilar antes de tu próximo set.",
+      "addNote": "Añadir una nota"
+    },
+    "export": {
+      "print": "Exportar H2H",
+      "copy": "Copiar como texto",
+      "copied": "¡Copiado!"
+    }
+  },
+  "scout": {
+    "title": "Buscar jugador",
+    "prompt": "Pega arriba una URL de perfil de start.gg, un slug o un id de jugador para ver su historial público de torneos.",
+    "promptWithParry": "Pega arriba una URL de perfil de start.gg o parry.gg, un slug/tag o un id de jugador para ver su historial público de torneos.",
+    "errors": {
+      "notFound": "No encontramos un jugador de start.gg con esa búsqueda. Revisa la URL, el slug o el id de jugador.",
+      "badQuery": "Eso no parece una URL de perfil de start.gg, un slug ni un id de jugador.",
+      "rateLimited": "start.gg está limitando las peticiones ahora mismo. Inténtalo de nuevo en un minuto.",
+      "scoutFallback": "Algo salió mal al buscar a ese jugador.",
+      "generateFallback": "Algo salió mal al generar el informe."
+    },
+    "form": {
+      "description": "Pega una URL de perfil de start.gg, una referencia \"user/<slug>\" o un id numérico de jugador para ver su historial público de torneos antes de enfrentarte a él.",
+      "descriptionWithParry": "Pega una URL de perfil de start.gg o parry.gg, un gamer tag, una referencia \"user/<slug>\" o un id numérico de jugador para ver su historial público de torneos antes de enfrentarte a él.",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 o una URL de perfil de parry.gg",
+      "inputAria": "URL de perfil de start.gg, slug o id de jugador",
+      "inputAriaWithParry": "URL de perfil de start.gg o parry.gg, slug/tag o id de jugador",
+      "scout": "Buscar",
+      "scouting": "Buscando…",
+      "source": "Fuente:",
+      "sourceAria": "Fuente de scouting",
+      "detectedParry": "Se detectó una URL de perfil de parry.gg.",
+      "pending": "Obteniendo su historial público de torneos — puede tardar unos segundos."
+    },
+    "report": {
+      "generate": "Generar informe con IA",
+      "regenerate": "Regenerar informe",
+      "generating": "Generando informe…",
+      "generatingHint": "Generando informe — suele tardar uno o dos minutos."
+    },
+    "billing": {
+      "paymentReceived": "Pago recibido — tus créditos llegarán en breve si no lo han hecho ya.",
+      "checkoutCancelled": "Pago cancelado — no se realizó ningún cargo.",
+      "freeAccess": "Acceso gratuito",
+      "credits_one": "{{count}} crédito",
+      "credits_other": "{{count}} créditos",
+      "buyCredits": "Comprar créditos",
+      "costLine": "Cada informe cuesta 1 crédito.",
+      "packFor": "{{label}} por {{price}}",
+      "outOfCredits": "Te has quedado sin créditos.",
+      "buyPack": "Compra un paquete",
+      "toGenerate": "para generar este informe."
+    },
+    "header": {
+      "viewOn": "Ver a {{name}} en {{source}}",
+      "profile": "Perfil de {{source}}",
+      "sample": "Datos públicos de {{source}} · muestra de los últimos {{sets}} sets ({{games}} partidas)"
+    },
+    "characters": {
+      "title": "Uso de personajes",
+      "description": "Qué juega, el más usado primero.",
+      "empty": "Aún no hay partidas en la muestra."
+    },
+    "stages": {
+      "title": "Rendimiento por escenario",
+      "description": "Sus resultados por escenario."
+    },
+    "events": {
+      "title": "Eventos recientes",
+      "description": "La actividad más reciente primero.",
+      "empty": "No hay eventos recientes en la muestra.",
+      "placement": "Puesto",
+      "entrants": "Participantes"
+    },
+    "commonOpponents": {
+      "title": "Rivales habituales",
+      "description": "Con quién se cruza más en los sets de la muestra.",
+      "empty": "No hay rivales repetidos en la muestra.",
+      "sets_one": "{{count}} set",
+      "sets_other": "{{count}} sets"
+    },
+    "history": {
+      "title": "Tu historial contra él",
+      "description_one": "Ya has jugado contra {{name}} — {{count}} partida registrada en tu propio historial.",
+      "description_other": "Ya has jugado contra {{name}} — {{count}} partidas registradas en tu propio historial.",
+      "rate": "({{rate}}% de victorias)",
+      "fullReport": "Informe de scouting completo"
+    },
+    "advisor": {
+      "title": "Asesor de matchups",
+      "description": "Tu mejor (y peor) elección contra cada uno de sus personajes — combina tu propio historial con datos de tier list y arquetipos.",
+      "noCharacterData": "Aún no hay datos de personajes para este scouting — habitual en parry.gg mientras sus datos siguen siendo escasos. Vuelve cuando haya jugado más sets.",
+      "noMyCharacters": "Elige un personaje principal o secundario (o registra algunas partidas) para recibir recomendaciones personalizadas.",
+      "vsName": "vs. {{name}}",
+      "gamesSampled_one": "{{count}} partida en la muestra",
+      "gamesSampled_other": "{{count}} partidas en la muestra",
+      "inYourSets": "{{record}} en tus sets",
+      "tier": "tier {{score}}/10",
+      "archetypeEdge": "ventaja de arquetipo",
+      "archetypeDisadvantage": "desventaja de arquetipo"
+    },
+    "fullAnalysis": {
+      "title": "Análisis completo",
+      "rescout": "Vuelve a buscar para habilitar el análisis completo.",
+      "noGameData": "Esta fuente aún no ofrece datos por partida.",
+      "stageMasteryOverall": "Dominio de escenarios — General",
+      "stageMasteryFor": "Dominio de escenarios — {{name}}",
+      "topCharacter": "Personaje principal",
+      "recentForm": "Forma reciente de {{name}}"
+    },
+    "aiReport": {
+      "title": "Informe de scouting con IA",
+      "generated": "Generado {{rel}}",
+      "download": "Descargar (.md)",
+      "print": "Imprimir / Guardar como PDF",
+      "gameplan": "Plan de juego",
+      "characterStrategy": "Estrategia de personajes",
+      "stageStrategy": "Estrategia de escenarios",
+      "picks": "Picks:",
+      "bans": "Bans:",
+      "headToHead": "Cara a cara",
+      "watchFor": "Vigila"
+    },
+    "historySelector": {
+      "older": "Informe más antiguo",
+      "newer": "Informe más reciente",
+      "reportOf": "Informe {{ordinal}} de {{total}}"
+    },
+    "pastReports": {
+      "title": "Informes de IA anteriores",
+      "description": "Informes que has generado antes, el más reciente primero."
     }
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -928,5 +928,125 @@
       "title": "Informes de IA anteriores",
       "description": "Informes que has generado antes, el más reciente primero."
     }
+  },
+  "reports": {
+    "title": "Informes de IA",
+    "notEnabled": "Los informes de IA aún no están habilitados para esta cuenta.",
+    "loading": "Cargando tus informes…",
+    "empty": "Aún no hay informes de scouting de IA. Genera uno desde la página <scoutLink>Buscar jugador</scoutLink>.",
+    "yourReports": "Tus informes",
+    "groupedBy": "Agrupados por jugador, los buscados más recientemente primero.",
+    "olderReport": "Informe anterior",
+    "hideOlder": "Ocultar informes anteriores",
+    "showOlder": "Mostrar informes anteriores"
+  },
+  "groups": {
+    "title": "Grupos",
+    "loading": "Cargando tus grupos...",
+    "empty": {
+      "title": "Aún no hay grupos",
+      "body": "Crea un grupo para iniciar una clasificación entre amigos, o únete a uno con un código de invitación."
+    },
+    "leaderboardLoading": "Cargando la clasificación...",
+    "leaderboardError": "Algo salió mal al cargar esta clasificación.",
+    "create": {
+      "trigger": "Crear grupo",
+      "title": "Crear un grupo",
+      "description": "Inicia una clasificación entre amigos. Podrás invitar a otros con un código una vez creado.",
+      "nameLabel": "Nombre del grupo",
+      "namePlaceholder": "p. ej. Los Locales",
+      "error": "Algo salió mal al crear el grupo.",
+      "pending": "Creando...",
+      "confirm": "Crear"
+    },
+    "join": {
+      "trigger": "Unirse con código",
+      "title": "Unirse a un grupo",
+      "description": "Introduce el código de invitación que te compartieron.",
+      "codeLabel": "Código de invitación",
+      "codePlaceholder": "p. ej. AB3DEFGH",
+      "error": "Algo salió mal al unirse a ese grupo.",
+      "pending": "Uniéndose...",
+      "confirm": "Unirse"
+    },
+    "members_one": "{{count}} miembro",
+    "members_other": "{{count}} miembros",
+    "header": {
+      "deleteTrigger": "Eliminar grupo",
+      "deleteTitle": "¿Eliminar \"{{name}}\"?",
+      "deleteDescription": "Esto elimina el grupo y su clasificación para todos los miembros. No se puede deshacer.",
+      "deleteError": "Algo salió mal al eliminar el grupo.",
+      "deletePending": "Eliminando...",
+      "leaveTrigger": "Salir del grupo",
+      "leaveTitle": "¿Salir de \"{{name}}\"?",
+      "leaveDescription": "Necesitarás un nuevo código de invitación para volver a unirte.",
+      "leaveError": "Algo salió mal al salir del grupo.",
+      "leavePending": "Saliendo...",
+      "leaveConfirm": "Salir",
+      "inviteCode": "Código de invitación:",
+      "copyAria": "Copiar código de invitación"
+    },
+    "table": {
+      "player": "Jugador",
+      "rating": "Puntuación",
+      "games": "Partidas",
+      "lastActive": "Última actividad",
+      "you": "(tú)",
+      "never": "nunca"
+    }
+  },
+  "integrations": {
+    "title": "Integraciones",
+    "connected": "Conectada",
+    "checkingStatus": "Comprobando el estado del vínculo…",
+    "gamerTag": "Gamer tag",
+    "lastSynced": "Última sincronización",
+    "never": "Nunca",
+    "syncNow": "Sincronizar ahora",
+    "syncing": "Sincronizando…",
+    "unlink": "Desvincular",
+    "syncFailed": "La sincronización falló. Inténtalo de nuevo.",
+    "unlinkFailed": "No se pudo desvincular. Inténtalo de nuevo.",
+    "linkDescription": "Vincula tu cuenta de {{provider}} para importar automáticamente tus partidas de torneo de Smash Ultimate. Las partidas importadas se suman a tu historial con etiqueta de competitivo.",
+    "unlinkTitle": "¿Desvincular {{provider}}?",
+    "unlinkDescription": "Las partidas ya importadas permanecen en tu historial; los nuevos resultados de torneo simplemente dejan de sincronizarse hasta que vuelvas a conectar.",
+    "unlinkedToast": "Cuenta de {{provider}} desvinculada.",
+    "summary": {
+      "importedFromSets": "{{imported}} partidas importadas de {{sets}} sets",
+      "importedFromMatches": "{{imported}} partidas importadas de {{matches}} encuentros",
+      "skippedDetail_one": "{{count}} sin detalle importable",
+      "skippedDetail_other": "{{count}} sin detalle importable",
+      "unknownStages_one": "{{count}} con stages no reconocidos",
+      "unknownStages_other": "{{count}} con stages no reconocidos",
+      "dqSkipped_one": "{{count}} DQ omitida",
+      "dqSkipped_other": "{{count}} DQs omitidas"
+    },
+    "startgg": {
+      "connect": "Conectar cuenta de start.gg",
+      "linked": "¡Cuenta de start.gg vinculada!",
+      "linkFailed": "Falló la vinculación con start.gg ({{reason}})",
+      "unknownError": "error desconocido"
+    },
+    "parrygg": {
+      "verified": "Verificada",
+      "unverified": "Sin verificar",
+      "verify": "Verificar",
+      "linkedTo": "¡Vinculado a {{tag}} en parry.gg!",
+      "linkFailed": "No se pudo vincular esa cuenta. Inténtalo de nuevo.",
+      "searchPlaceholder": "Busca tu gamer tag de parry.gg...",
+      "searchAria": "Buscar gamer tag de parry.gg",
+      "searching": "Buscando...",
+      "noAccounts": "No hay cuentas de parry.gg coincidentes.",
+      "link": "Vincular",
+      "verifyTitle": "Verifica tu cuenta de parry.gg",
+      "verifyDescription": "Pega este código en la biografía de tu perfil de parry.gg y luego pulsa Comprobar. Caduca en 10 minutos.",
+      "copyCodeAria": "Copiar código de verificación",
+      "generatingCode": "Generando tu código de verificación...",
+      "check": "Comprobar",
+      "checking": "Comprobando...",
+      "verifyStartFailed": "No se pudo iniciar la verificación. Inténtalo de nuevo.",
+      "verifiedToast": "¡Cuenta de parry.gg verificada!",
+      "codeNotFound": "Aún no se encontró el código de verificación. Inténtalo de nuevo."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -928,5 +928,125 @@
       "title": "Rapports IA passés",
       "description": "Rapports déjà générés, le plus récent en premier."
     }
+  },
+  "reports": {
+    "title": "Rapports IA",
+    "notEnabled": "Les rapports IA ne sont pas encore activés pour ce compte.",
+    "loading": "Chargement de vos rapports…",
+    "empty": "Aucun rapport de scouting IA pour l'instant. Générez-en un depuis la page <scoutLink>Chercher un joueur</scoutLink>.",
+    "yourReports": "Vos rapports",
+    "groupedBy": "Regroupés par joueur, du plus récemment analysé au plus ancien.",
+    "olderReport": "Rapport plus ancien",
+    "hideOlder": "Masquer les anciens rapports",
+    "showOlder": "Afficher les anciens rapports"
+  },
+  "groups": {
+    "title": "Groupes",
+    "loading": "Chargement de vos groupes...",
+    "empty": {
+      "title": "Aucun groupe pour l'instant",
+      "body": "Créez un groupe pour lancer un classement entre amis, ou rejoignez-en un avec un code d'invitation."
+    },
+    "leaderboardLoading": "Chargement du classement...",
+    "leaderboardError": "Une erreur est survenue lors du chargement de ce classement.",
+    "create": {
+      "trigger": "Créer un groupe",
+      "title": "Créer un groupe",
+      "description": "Lancez un classement entre amis. Vous pourrez inviter d'autres personnes avec un code une fois le groupe créé.",
+      "nameLabel": "Nom du groupe",
+      "namePlaceholder": "ex. Les Locaux",
+      "error": "Une erreur est survenue lors de la création du groupe.",
+      "pending": "Création...",
+      "confirm": "Créer"
+    },
+    "join": {
+      "trigger": "Rejoindre avec un code",
+      "title": "Rejoindre un groupe",
+      "description": "Saisissez le code d'invitation qu'on vous a partagé.",
+      "codeLabel": "Code d'invitation",
+      "codePlaceholder": "ex. AB3DEFGH",
+      "error": "Une erreur est survenue en rejoignant ce groupe.",
+      "pending": "Connexion au groupe...",
+      "confirm": "Rejoindre"
+    },
+    "members_one": "{{count}} membre",
+    "members_other": "{{count}} membres",
+    "header": {
+      "deleteTrigger": "Supprimer le groupe",
+      "deleteTitle": "Supprimer « {{name}} » ?",
+      "deleteDescription": "Cela supprime le groupe et son classement pour tous les membres. Cette action est irréversible.",
+      "deleteError": "Une erreur est survenue lors de la suppression du groupe.",
+      "deletePending": "Suppression...",
+      "leaveTrigger": "Quitter le groupe",
+      "leaveTitle": "Quitter « {{name}} » ?",
+      "leaveDescription": "Il vous faudra un nouveau code d'invitation pour revenir plus tard.",
+      "leaveError": "Une erreur est survenue en quittant le groupe.",
+      "leavePending": "Départ...",
+      "leaveConfirm": "Quitter",
+      "inviteCode": "Code d'invitation :",
+      "copyAria": "Copier le code d'invitation"
+    },
+    "table": {
+      "player": "Joueur",
+      "rating": "Classement",
+      "games": "Parties",
+      "lastActive": "Dernière activité",
+      "you": "(vous)",
+      "never": "jamais"
+    }
+  },
+  "integrations": {
+    "title": "Intégrations",
+    "connected": "Connecté",
+    "checkingStatus": "Vérification du statut de liaison…",
+    "gamerTag": "Gamer tag",
+    "lastSynced": "Dernière synchronisation",
+    "never": "Jamais",
+    "syncNow": "Synchroniser maintenant",
+    "syncing": "Synchronisation…",
+    "unlink": "Délier",
+    "syncFailed": "Échec de la synchronisation. Veuillez réessayer.",
+    "unlinkFailed": "Impossible de délier le compte. Veuillez réessayer.",
+    "linkDescription": "Liez votre compte {{provider}} pour importer automatiquement vos matchs de tournoi Smash Ultimate. Les parties importées rejoignent votre historique avec un tag compétitif.",
+    "unlinkTitle": "Délier {{provider}} ?",
+    "unlinkDescription": "Les matchs déjà importés restent dans votre historique ; les nouveaux résultats de tournoi cessent simplement de se synchroniser jusqu'à la reconnexion.",
+    "unlinkedToast": "Compte {{provider}} délié.",
+    "summary": {
+      "importedFromSets": "{{imported}} parties importées depuis {{sets}} sets",
+      "importedFromMatches": "{{imported}} parties importées depuis {{matches}} matchs",
+      "skippedDetail_one": "{{count}} sans détail importable",
+      "skippedDetail_other": "{{count}} sans détail importable",
+      "unknownStages_one": "{{count}} avec des stages non reconnus",
+      "unknownStages_other": "{{count}} avec des stages non reconnus",
+      "dqSkipped_one": "{{count}} DQ ignorée",
+      "dqSkipped_other": "{{count}} DQ ignorées"
+    },
+    "startgg": {
+      "connect": "Connecter un compte start.gg",
+      "linked": "Compte start.gg lié !",
+      "linkFailed": "Échec de la liaison start.gg ({{reason}})",
+      "unknownError": "erreur inconnue"
+    },
+    "parrygg": {
+      "verified": "Vérifié",
+      "unverified": "Non vérifié",
+      "verify": "Vérifier",
+      "linkedTo": "Lié à {{tag}} sur parry.gg !",
+      "linkFailed": "Impossible de lier ce compte. Veuillez réessayer.",
+      "searchPlaceholder": "Recherchez votre gamer tag parry.gg...",
+      "searchAria": "Rechercher un gamer tag parry.gg",
+      "searching": "Recherche...",
+      "noAccounts": "Aucun compte parry.gg correspondant.",
+      "link": "Lier",
+      "verifyTitle": "Vérifiez votre compte parry.gg",
+      "verifyDescription": "Collez ce code dans la bio de votre profil parry.gg, puis cliquez sur Vérifier. Il expire dans 10 minutes.",
+      "copyCodeAria": "Copier le code de vérification",
+      "generatingCode": "Génération de votre code de vérification...",
+      "check": "Vérifier",
+      "checking": "Vérification...",
+      "verifyStartFailed": "Impossible de démarrer la vérification. Veuillez réessayer.",
+      "verifiedToast": "Compte parry.gg vérifié !",
+      "codeNotFound": "Code de vérification introuvable pour l'instant. Veuillez réessayer."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -114,6 +114,12 @@
       "p1": "<strong>Glicko-2</strong> est le système de classement utilisé aux échecs et sur de nombreux ladders compétitifs. Contrairement à un simple taux de victoire, il tient compte de <em>qui</em> vous battez et du caractère surprenant du résultat.",
       "p2": "Le <strong>nombre ± (RD)</strong> mesure l'incertitude : il diminue à mesure que vous jouez et augmente en cas d'inactivité — un joueur à 1500 ±50 a fait ses preuves, un joueur à 1500 ±300 reste une inconnue.",
       "p3": "Nous l'utilisons parce que le jeu en bracket est irrégulier : Glicko-2 gère bien mieux les longues pauses entre tournois et les petits échantillons que l'Elo ou le taux de victoire seuls. Les classements affichés ici ne sont pas officiels et sont calculés uniquement à partir de vos matchs synchronisés ou enregistrés."
+    },
+    "relativeDate": {
+      "justNow": "à l'instant",
+      "minutesAgo": "il y a {{count}} min",
+      "hoursAgo": "il y a {{count}} h",
+      "daysAgo": "il y a {{count}} j"
     }
   },
   "dashboard": {
@@ -676,6 +682,251 @@
       "verdictFollowed": "suivi",
       "verdictAgainst": "à l'encontre",
       "verdictNeutral": "neutre sur"
+    }
+  },
+  "billing": {
+    "title": "Acheter des crédits de rapport",
+    "description": "Chaque rapport de scouting IA coûte un crédit. Choisissez un pack — vous serez redirigé vers Stripe pour finaliser l'achat.",
+    "perReport": "{{price}} par rapport",
+    "checkoutError": "Une erreur est survenue au lancement du paiement. Veuillez réessayer.",
+    "redirecting": "Redirection…",
+    "continue": "Continuer vers le paiement"
+  },
+  "opponents": {
+    "loading": "Chargement des rapports de scouting...",
+    "selectPrompt": "Sélectionnez un adversaire dans la liste pour voir son rapport de scouting.",
+    "empty": {
+      "title": "Aucun match à analyser pour l’instant !",
+      "body": "Enregistrez un match depuis le tableau de bord, ou connectez start.gg pour synchroniser vos sets de tournoi, et les rapports de scouting de vos adversaires apparaîtront ici.",
+      "connectStartgg": "Connecter start.gg"
+    },
+    "noTags": {
+      "title": "Aucun de vos matchs n'a de tag d'adversaire enregistré.",
+      "body": "Ajoutez un nom d'adversaire en enregistrant un match pour débloquer son rapport de scouting."
+    },
+    "list": {
+      "title": "Adversaires",
+      "faced_one": "{{count}} adversaire affronté",
+      "faced_other": "{{count}} adversaires affrontés",
+      "searchPlaceholder": "Rechercher des adversaires...",
+      "searchAria": "Rechercher des adversaires",
+      "sortAria": "Trier les adversaires",
+      "sortMostPlayed": "Les plus joués",
+      "sortRecent": "Joués récemment",
+      "sortBestRate": "Meilleur taux de victoire",
+      "sortWorstRate": "Pire taux de victoire",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3+ matchs",
+      "minGamesAria": "N'afficher que les adversaires avec 3 matchs ou plus",
+      "emptyNone": "Aucun adversaire affronté pour l’instant.",
+      "emptyFiltered": "Aucun adversaire ne correspond à vos filtres.",
+      "rowActions": "Actions pour {{name}}",
+      "mergeInto": "Fusionner avec..."
+    },
+    "source": {
+      "mixedAria": "sources mixtes",
+      "verified": "vérifié",
+      "manual": "manuel",
+      "manualAria": "saisi manuellement",
+      "startggAria": "vérifié start.gg",
+      "parryggAria": "vérifié parry.gg"
+    },
+    "header": {
+      "playedRange": "Premier match {{first}} · Dernier match {{last}}",
+      "encounterSpan": "{{start}} et {{end}}",
+      "metAt_one": "Rencontré à {{count}} tournoi entre {{span}}",
+      "metAt_other": "Rencontré à {{count}} tournois entre {{span}}",
+      "rateOverGames_one": "{{rate}} % sur {{count}} match",
+      "rateOverGames_other": "{{rate}} % sur {{count}} matchs"
+    },
+    "whatTheyPlay": {
+      "title": "Ce qu’il joue",
+      "description": "Classé selon la fiabilité avec laquelle vous le battez.",
+      "empty": "Aucun personnage enregistré pour l’instant.",
+      "character": "Personnage"
+    },
+    "stages": {
+      "title": "Stages",
+      "empty": "Aucune donnée de stage enregistrée pour l’instant."
+    },
+    "trend": {
+      "title": "Tendance H2H",
+      "empty": "Pas encore assez de matchs pour une tendance.",
+      "label": "Taux de victoire glissant ({{count}} derniers)"
+    },
+    "encounters": {
+      "title": "Rencontres récentes",
+      "empty": "Aucune rencontre enregistrée pour l’instant.",
+      "aria": "Rencontres récentes"
+    },
+    "history": {
+      "title": "Historique des tournois",
+      "empty": "Aucun set de tournoi contre ce joueur pour l’instant — resynchronisez start.gg si vous avez joué récemment.",
+      "gamesAria": "Matchs",
+      "losers": "Losers",
+      "vsThemHere": "{{wins}}-{{losses}} contre lui ici",
+      "setsAria": "Sets contre lui à {{title}}"
+    },
+    "merge": {
+      "title": "Fusionner « {{name}} » avec...",
+      "description": "Choisissez le nom d'adversaire à traiter comme la même personne. Ses matchs seront combinés partout.",
+      "noMatches": "Aucun adversaire correspondant.",
+      "warning": "« {{opponent}} » est {{label}} et « {{target}} » est uniquement manuel. Pour conserver le tag vérifié comme canonique, nous fusionnerons plutôt « {{target}} » avec « {{opponent}} ».",
+      "anyway": "Fusionner quand même « {{opponent}} » avec « {{target}} »",
+      "merging": "Fusion...",
+      "merge": "Fusionner"
+    },
+    "merged": {
+      "title": "Noms fusionnés",
+      "description": "Ces noms sont intégrés à « {{name}} ». Défusionnez pour les suivre à nouveau séparément.",
+      "unmerge": "Défusionner"
+    },
+    "tendencies": {
+      "title": "Tendances",
+      "description": "Vos propres notes de scouting pour cet adversaire — non dérivées de l’historique des matchs.",
+      "habits": "Habitudes",
+      "habitsPlaceholder": "Habitudes d’ouverture, routes de punition, mixups de récupération...",
+      "banThese": "À bannir (max {{count}})",
+      "banAria": "Stages à bannir contre cet adversaire",
+      "watchFor": "À surveiller",
+      "watchForPlaceholder": "Lectures, mind games, tech chases à anticiper au prochain set...",
+      "saving": "Enregistrement...",
+      "deleteNote": "Supprimer la note",
+      "banTheseView": "À bannir",
+      "banViewAria": "Stages à bannir",
+      "savedAt": "Enregistré le {{date}}",
+      "edit": "Modifier",
+      "empty": "Pas encore de notes de scouting. Notez ses habitudes, les stages à bannir ou les points à surveiller avant votre prochain set.",
+      "addNote": "Ajouter une note"
+    },
+    "export": {
+      "print": "Exporter le H2H",
+      "copy": "Copier en texte",
+      "copied": "Copié !"
+    }
+  },
+  "scout": {
+    "title": "Chercher un joueur",
+    "prompt": "Collez ci-dessus une URL de profil start.gg, un slug ou un id de joueur pour afficher son historique public de tournois.",
+    "promptWithParry": "Collez ci-dessus une URL de profil start.gg ou parry.gg, un slug/tag ou un id de joueur pour afficher son historique public de tournois.",
+    "errors": {
+      "notFound": "Nous n'avons pas trouvé de joueur start.gg pour cette recherche. Vérifiez l'URL, le slug ou l'id du joueur.",
+      "badQuery": "Cela ne ressemble pas à une URL de profil start.gg, un slug ou un id de joueur.",
+      "rateLimited": "start.gg limite les requêtes en ce moment. Réessayez dans une minute.",
+      "scoutFallback": "Une erreur est survenue pendant le scouting de ce joueur.",
+      "generateFallback": "Une erreur est survenue pendant la génération du rapport."
+    },
+    "form": {
+      "description": "Collez une URL de profil start.gg, une référence « user/<slug> » ou un id numérique de joueur pour afficher son historique public de tournois avant de l’affronter.",
+      "descriptionWithParry": "Collez une URL de profil start.gg ou parry.gg, un gamer tag, une référence « user/<slug> » ou un id numérique de joueur pour afficher son historique public de tournois avant de l’affronter.",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 ou une URL de profil parry.gg",
+      "inputAria": "URL de profil start.gg, slug ou id de joueur",
+      "inputAriaWithParry": "URL de profil start.gg ou parry.gg, slug/tag ou id de joueur",
+      "scout": "Scouter",
+      "scouting": "Scouting…",
+      "source": "Source :",
+      "sourceAria": "Source de scouting",
+      "detectedParry": "URL de profil parry.gg détectée.",
+      "pending": "Récupération de son historique public de tournois — cela peut prendre quelques secondes."
+    },
+    "report": {
+      "generate": "Générer un rapport IA",
+      "regenerate": "Régénérer le rapport",
+      "generating": "Génération du rapport…",
+      "generatingHint": "Génération du rapport — cela prend en général une à deux minutes."
+    },
+    "billing": {
+      "paymentReceived": "Paiement reçu — vos crédits arriveront sous peu s'ils ne sont pas déjà là.",
+      "checkoutCancelled": "Paiement annulé — aucun débit effectué.",
+      "freeAccess": "Accès gratuit",
+      "credits_one": "{{count}} crédit",
+      "credits_other": "{{count}} crédits",
+      "buyCredits": "Acheter des crédits",
+      "costLine": "Chaque rapport coûte 1 crédit.",
+      "packFor": "{{label}} pour {{price}}",
+      "outOfCredits": "Vous n'avez plus de crédits.",
+      "buyPack": "Achetez un pack",
+      "toGenerate": "pour générer ce rapport."
+    },
+    "header": {
+      "viewOn": "Voir {{name}} sur {{source}}",
+      "profile": "Profil {{source}}",
+      "sample": "Données publiques {{source}} · échantillon des {{sets}} derniers sets ({{games}} matchs)"
+    },
+    "characters": {
+      "title": "Personnages utilisés",
+      "description": "Ce qu’il joue, le plus utilisé en premier.",
+      "empty": "Aucun match échantillonné pour l’instant."
+    },
+    "stages": {
+      "title": "Performance par stage",
+      "description": "Ses résultats par stage."
+    },
+    "events": {
+      "title": "Évènements récents",
+      "description": "Activité la plus récente en premier.",
+      "empty": "Aucun évènement récent dans l’échantillon.",
+      "placement": "Classement",
+      "entrants": "Participants"
+    },
+    "commonOpponents": {
+      "title": "Adversaires fréquents",
+      "description": "Qui il croise le plus dans les sets échantillonnés.",
+      "empty": "Aucun adversaire récurrent dans l'échantillon.",
+      "sets_one": "{{count}} set",
+      "sets_other": "{{count}} sets"
+    },
+    "history": {
+      "title": "Votre historique contre lui",
+      "description_one": "Vous avez déjà joué contre {{name}} — {{count}} match enregistré dans votre propre historique.",
+      "description_other": "Vous avez déjà joué contre {{name}} — {{count}} matchs enregistrés dans votre propre historique.",
+      "rate": "({{rate}} % de victoires)",
+      "fullReport": "Rapport de scouting complet"
+    },
+    "advisor": {
+      "title": "Conseiller de matchup",
+      "description": "Votre meilleur (et pire) pick contre chacun de ses personnages — mélange votre propre bilan avec les données de tier list et d’archétypes.",
+      "noCharacterData": "Pas encore de données de personnages pour ce scouting — courant sur parry.gg tant que les données de match restent rares. Revenez quand il aura joué plus de sets.",
+      "noMyCharacters": "Choisissez un personnage principal ou secondaire (ou enregistrez quelques matchs) pour obtenir des recommandations personnalisées.",
+      "vsName": "vs {{name}}",
+      "gamesSampled_one": "{{count}} match échantillonné",
+      "gamesSampled_other": "{{count}} matchs échantillonnés",
+      "inYourSets": "{{record}} dans vos sets",
+      "tier": "tier {{score}}/10",
+      "archetypeEdge": "avantage d’archétype",
+      "archetypeDisadvantage": "désavantage d’archétype"
+    },
+    "fullAnalysis": {
+      "title": "Analyse complète",
+      "rescout": "Relancez un scouting pour activer l’analyse complète.",
+      "noGameData": "Pas encore de données par match disponibles depuis cette source.",
+      "stageMasteryOverall": "Maîtrise des stages — Globale",
+      "stageMasteryFor": "Maîtrise des stages — {{name}}",
+      "topCharacter": "Personnage principal",
+      "recentForm": "Forme récente de {{name}}"
+    },
+    "aiReport": {
+      "title": "Rapport de scouting IA",
+      "generated": "Généré {{rel}}",
+      "download": "Télécharger (.md)",
+      "print": "Imprimer / Enregistrer en PDF",
+      "gameplan": "Plan de jeu",
+      "characterStrategy": "Stratégie de personnages",
+      "stageStrategy": "Stratégie de stages",
+      "picks": "Picks :",
+      "bans": "Bans :",
+      "headToHead": "Face-à-face",
+      "watchFor": "À surveiller"
+    },
+    "historySelector": {
+      "older": "Rapport plus ancien",
+      "newer": "Rapport plus récent",
+      "reportOf": "Rapport {{ordinal}} sur {{total}}"
+    },
+    "pastReports": {
+      "title": "Rapports IA passés",
+      "description": "Rapports déjà générés, le plus récent en premier."
     }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -114,6 +114,12 @@
       "p1": "<strong>Glicko-2</strong>はチェスや多くの対戦ラダーで使われているレーティングシステムです。単純な勝率と違い、<em>誰に</em>勝ったか、その結果がどれだけ番狂わせだったかを重み付けします。",
       "p2": "<strong>±の数値（RD）</strong>は不確実性です。対戦を重ねるほど小さくなり、ブランクが空くと大きくなります — 1500 ±50のプレイヤーは実力が確かで、1500 ±300のプレイヤーは未知数です。",
       "p3": "ブラケット戦は間隔が空きがちなため、大会間の長いブランクや少ない対戦数の扱いに優れたGlicko-2を採用しています（Eloや勝率だけよりも適しています）。ここでのレーティングは非公式で、同期・記録された対戦のみから計算されます。"
+    },
+    "relativeDate": {
+      "justNow": "たった今",
+      "minutesAgo": "{{count}}分前",
+      "hoursAgo": "{{count}}時間前",
+      "daysAgo": "{{count}}日前"
     }
   },
   "dashboard": {
@@ -676,6 +682,251 @@
       "verdictFollowed": "従った",
       "verdictAgainst": "逆らった",
       "verdictNeutral": "どちらでもない"
+    }
+  },
+  "billing": {
+    "title": "レポートクレジットを購入",
+    "description": "AIスカウティングレポートは1件につき1クレジットです。パックを選ぶと、Stripeに移動して購入を完了できます。",
+    "perReport": "1レポートあたり{{price}}",
+    "checkoutError": "決済の開始に失敗しました。もう一度お試しください。",
+    "redirecting": "リダイレクト中…",
+    "continue": "決済に進む"
+  },
+  "opponents": {
+    "loading": "スカウティングレポートを読み込み中...",
+    "selectPrompt": "リストから相手を選ぶと、そのスカウティングレポートが表示されます。",
+    "empty": {
+      "title": "まだ分析できる対戦がありません！",
+      "body": "ダッシュボードで対戦を記録するか、start.ggを連携して大会セットを同期すると、相手ごとのスカウティングレポートがここに表示されます。",
+      "connectStartgg": "start.ggを連携"
+    },
+    "noTags": {
+      "title": "相手の名前が記録された対戦がありません。",
+      "body": "対戦を記録するときに相手の名前を入力すると、その相手のスカウティングレポートが使えるようになります。"
+    },
+    "list": {
+      "title": "相手プレイヤー",
+      "faced_one": "対戦した相手 {{count}}人",
+      "faced_other": "対戦した相手 {{count}}人",
+      "searchPlaceholder": "相手を検索...",
+      "searchAria": "相手を検索",
+      "sortAria": "相手を並べ替え",
+      "sortMostPlayed": "対戦数順",
+      "sortRecent": "最近対戦した順",
+      "sortBestRate": "勝率が高い順",
+      "sortWorstRate": "勝率が低い順",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3戦以上",
+      "minGamesAria": "3戦以上の相手のみ表示",
+      "emptyNone": "まだ対戦した相手がいません。",
+      "emptyFiltered": "フィルターに一致する相手がいません。",
+      "rowActions": "{{name}}の操作",
+      "mergeInto": "統合..."
+    },
+    "source": {
+      "mixedAria": "複数ソース",
+      "verified": "認証済み",
+      "manual": "手動",
+      "manualAria": "手動入力",
+      "startggAria": "start.gg認証済み",
+      "parryggAria": "parry.gg認証済み"
+    },
+    "header": {
+      "playedRange": "初対戦 {{first}} · 最終対戦 {{last}}",
+      "encounterSpan": "{{start}}〜{{end}}",
+      "metAt_one": "{{span}}の間に{{count}}つの大会で対戦",
+      "metAt_other": "{{span}}の間に{{count}}つの大会で対戦",
+      "rateOverGames_one": "{{count}}戦で勝率{{rate}}%",
+      "rateOverGames_other": "{{count}}戦で勝率{{rate}}%"
+    },
+    "whatTheyPlay": {
+      "title": "相手の使用キャラ",
+      "description": "安定して勝てている順に並んでいます。",
+      "empty": "まだキャラクターが記録されていません。",
+      "character": "キャラクター"
+    },
+    "stages": {
+      "title": "ステージ",
+      "empty": "まだステージのデータがありません。"
+    },
+    "trend": {
+      "title": "H2Hトレンド",
+      "empty": "トレンドを出すにはまだ対戦数が足りません。",
+      "label": "移動勝率（直近{{count}}戦）"
+    },
+    "encounters": {
+      "title": "最近の対戦",
+      "empty": "まだ対戦が記録されていません。",
+      "aria": "最近の対戦"
+    },
+    "history": {
+      "title": "大会での対戦履歴",
+      "empty": "このプレイヤーとの大会セットはまだありません — 最近対戦したならstart.ggを再同期してください。",
+      "gamesAria": "ゲーム",
+      "losers": "ルーザーズ",
+      "vsThemHere": "この大会での対戦成績 {{wins}}-{{losses}}",
+      "setsAria": "{{title}}でのセット"
+    },
+    "merge": {
+      "title": "「{{name}}」を統合...",
+      "description": "同一人物として扱う相手の名前を選んでください。対戦記録はすべての場所で統合されます。",
+      "noMatches": "一致する相手がいません。",
+      "warning": "「{{opponent}}」は{{label}}で、「{{target}}」は手動入力のみです。認証済みタグを正として保つため、代わりに「{{target}}」を「{{opponent}}」に統合します。",
+      "anyway": "それでも「{{opponent}}」を「{{target}}」に統合する",
+      "merging": "統合中...",
+      "merge": "統合"
+    },
+    "merged": {
+      "title": "統合された名前",
+      "description": "これらの名前は「{{name}}」に統合されています。解除すると再び別々に記録されます。",
+      "unmerge": "統合を解除"
+    },
+    "tendencies": {
+      "title": "癖・傾向",
+      "description": "この相手についての自分のスカウティングメモです — 対戦履歴からの自動生成ではありません。",
+      "habits": "癖",
+      "habitsPlaceholder": "立ち回りの癖、確定反撃のルート、復帰の択など...",
+      "banThese": "拒否ステージ（最大{{count}}）",
+      "banAria": "この相手に対して拒否するステージ",
+      "watchFor": "警戒ポイント",
+      "watchForPlaceholder": "次のセットで警戒すべき読み、駆け引き、受け身狩りなど...",
+      "saving": "保存中...",
+      "deleteNote": "メモを削除",
+      "banTheseView": "拒否ステージ",
+      "banViewAria": "拒否するステージ",
+      "savedAt": "{{date}}に保存",
+      "edit": "編集",
+      "empty": "まだスカウティングメモがありません。次のセットの前に、癖や拒否ステージ、警戒ポイントを書き留めましょう。",
+      "addNote": "メモを追加"
+    },
+    "export": {
+      "print": "H2Hをエクスポート",
+      "copy": "テキストとしてコピー",
+      "copied": "コピーしました！"
+    }
+  },
+  "scout": {
+    "title": "プレイヤーを検索",
+    "prompt": "上にstart.ggのプロフィールURL・スラッグ・プレイヤーIDを貼り付けると、公開されている大会履歴を表示します。",
+    "promptWithParry": "上にstart.ggまたはparry.ggのプロフィールURL・スラッグ/タグ・プレイヤーIDを貼り付けると、公開されている大会履歴を表示します。",
+    "errors": {
+      "notFound": "その検索条件に一致するstart.ggプレイヤーが見つかりませんでした。URL・スラッグ・プレイヤーIDを確認してください。",
+      "badQuery": "start.ggのプロフィールURL・スラッグ・プレイヤーIDではないようです。",
+      "rateLimited": "現在start.ggがリクエストを制限しています。1分後にもう一度お試しください。",
+      "scoutFallback": "プレイヤーの検索中に問題が発生しました。",
+      "generateFallback": "レポートの生成中に問題が発生しました。"
+    },
+    "form": {
+      "description": "start.ggのプロフィールURL、「user/<スラッグ>」形式、または数値のプレイヤーIDを貼り付けると、対戦前に公開大会履歴を確認できます。",
+      "descriptionWithParry": "start.ggまたはparry.ggのプロフィールURL、ゲーマータグ、「user/<スラッグ>」形式、または数値のプレイヤーIDを貼り付けると、対戦前に公開大会履歴を確認できます。",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 またはparry.ggのプロフィールURL",
+      "inputAria": "start.ggのプロフィールURL・スラッグ・プレイヤーID",
+      "inputAriaWithParry": "start.ggまたはparry.ggのプロフィールURL・スラッグ/タグ・プレイヤーID",
+      "scout": "検索",
+      "scouting": "検索中…",
+      "source": "ソース:",
+      "sourceAria": "スカウティングのソース",
+      "detectedParry": "parry.ggのプロフィールURLを検出しました。",
+      "pending": "公開大会履歴を取得中 — 数秒かかることがあります。"
+    },
+    "report": {
+      "generate": "AIレポートを生成",
+      "regenerate": "レポートを再生成",
+      "generating": "レポートを生成中…",
+      "generatingHint": "レポートを生成中 — 通常1〜2分かかります。"
+    },
+    "billing": {
+      "paymentReceived": "支払いを受け付けました — クレジットはまもなく反映されます。",
+      "checkoutCancelled": "決済をキャンセルしました — 請求は発生していません。",
+      "freeAccess": "無料アクセス",
+      "credits_one": "{{count}}クレジット",
+      "credits_other": "{{count}}クレジット",
+      "buyCredits": "クレジットを購入",
+      "costLine": "レポート1件につき1クレジットです。",
+      "packFor": "{{label}}（{{price}}）",
+      "outOfCredits": "クレジットがなくなりました。",
+      "buyPack": "パックを購入",
+      "toGenerate": "すると、このレポートを生成できます。"
+    },
+    "header": {
+      "viewOn": "{{name}}を{{source}}で見る",
+      "profile": "{{source}}プロフィール",
+      "sample": "{{source}}の公開データ · 直近{{sets}}セット（{{games}}ゲーム）のサンプル"
+    },
+    "characters": {
+      "title": "キャラクター使用状況",
+      "description": "使用キャラを多い順に表示。",
+      "empty": "まだサンプルのゲームがありません。"
+    },
+    "stages": {
+      "title": "ステージ別成績",
+      "description": "ステージごとの成績です。"
+    },
+    "events": {
+      "title": "最近の大会",
+      "description": "新しい順に表示。",
+      "empty": "サンプルに最近の大会がありません。",
+      "placement": "順位",
+      "entrants": "参加者"
+    },
+    "commonOpponents": {
+      "title": "よく当たる相手",
+      "description": "サンプル内のセットでよく対戦している相手です。",
+      "empty": "サンプル内に繰り返し対戦した相手はいません。",
+      "sets_one": "{{count}}セット",
+      "sets_other": "{{count}}セット"
+    },
+    "history": {
+      "title": "この相手との対戦履歴",
+      "description_one": "{{name}}とは対戦経験があります — あなたの記録に{{count}}戦あります。",
+      "description_other": "{{name}}とは対戦経験があります — あなたの記録に{{count}}戦あります。",
+      "rate": "（勝率{{rate}}%）",
+      "fullReport": "スカウティングレポート全文"
+    },
+    "advisor": {
+      "title": "相性アドバイザー",
+      "description": "相手の各キャラに対するあなたのベスト（とワースト）ピック — 自分の戦績にティア表とアーキタイプのデータを組み合わせています。",
+      "noCharacterData": "このスカウトにはまだキャラクターデータがありません — 対戦データが少ないparry.ggではよくあります。セット数が増えたら再確認してください。",
+      "noMyCharacters": "メインまたはサブのファイターを選ぶ（か、対戦をいくつか記録する）と、パーソナライズされたおすすめが表示されます。",
+      "vsName": "vs. {{name}}",
+      "gamesSampled_one": "サンプル{{count}}戦",
+      "gamesSampled_other": "サンプル{{count}}戦",
+      "inYourSets": "あなたのセットで{{record}}",
+      "tier": "ティア{{score}}/10",
+      "archetypeEdge": "アーキタイプ有利",
+      "archetypeDisadvantage": "アーキタイプ不利"
+    },
+    "fullAnalysis": {
+      "title": "完全分析",
+      "rescout": "再検索すると完全分析が有効になります。",
+      "noGameData": "このソースにはまだゲーム単位のデータがありません。",
+      "stageMasteryOverall": "ステージ習熟度 — 全体",
+      "stageMasteryFor": "ステージ習熟度 — {{name}}",
+      "topCharacter": "メインキャラ",
+      "recentForm": "{{name}}の最近の調子"
+    },
+    "aiReport": {
+      "title": "AIスカウティングレポート",
+      "generated": "{{rel}}に生成",
+      "download": "ダウンロード（.md）",
+      "print": "印刷 / PDFとして保存",
+      "gameplan": "ゲームプラン",
+      "characterStrategy": "キャラクター戦略",
+      "stageStrategy": "ステージ戦略",
+      "picks": "ピック:",
+      "bans": "バン:",
+      "headToHead": "直接対決",
+      "watchFor": "警戒ポイント"
+    },
+    "historySelector": {
+      "older": "古いレポートへ",
+      "newer": "新しいレポートへ",
+      "reportOf": "{{total}}件中{{ordinal}}件目のレポート"
+    },
+    "pastReports": {
+      "title": "過去のAIレポート",
+      "description": "これまでに生成したレポート（新しい順）。"
     }
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -928,5 +928,125 @@
       "title": "過去のAIレポート",
       "description": "これまでに生成したレポート（新しい順）。"
     }
+  },
+  "reports": {
+    "title": "AIレポート",
+    "notEnabled": "このアカウントではAIレポートはまだ有効になっていません。",
+    "loading": "レポートを読み込み中…",
+    "empty": "AIスカウティングレポートはまだありません。<scoutLink>プレイヤーを検索</scoutLink>ページから作成できます。",
+    "yourReports": "あなたのレポート",
+    "groupedBy": "プレイヤーごとにグループ化し、最近スカウトした順に表示します。",
+    "olderReport": "過去のレポート",
+    "hideOlder": "過去のレポートを隠す",
+    "showOlder": "過去のレポートを表示"
+  },
+  "groups": {
+    "title": "グループ",
+    "loading": "グループを読み込み中...",
+    "empty": {
+      "title": "グループはまだありません",
+      "body": "グループを作成して友達同士のリーダーボードを始めるか、招待コードで参加しましょう。"
+    },
+    "leaderboardLoading": "リーダーボードを読み込み中...",
+    "leaderboardError": "リーダーボードの読み込み中に問題が発生しました。",
+    "create": {
+      "trigger": "グループを作成",
+      "title": "グループを作成",
+      "description": "友達同士のリーダーボードを始めましょう。作成後、コードで他の人を招待できます。",
+      "nameLabel": "グループ名",
+      "namePlaceholder": "例: 地元勢",
+      "error": "グループの作成中に問題が発生しました。",
+      "pending": "作成中...",
+      "confirm": "作成"
+    },
+    "join": {
+      "trigger": "コードで参加",
+      "title": "グループに参加",
+      "description": "共有された招待コードを入力してください。",
+      "codeLabel": "招待コード",
+      "codePlaceholder": "例: AB3DEFGH",
+      "error": "グループへの参加中に問題が発生しました。",
+      "pending": "参加中...",
+      "confirm": "参加"
+    },
+    "members_one": "{{count}}人のメンバー",
+    "members_other": "{{count}}人のメンバー",
+    "header": {
+      "deleteTrigger": "グループを削除",
+      "deleteTitle": "「{{name}}」を削除しますか？",
+      "deleteDescription": "グループとそのリーダーボードがすべてのメンバーから削除されます。この操作は取り消せません。",
+      "deleteError": "グループの削除中に問題が発生しました。",
+      "deletePending": "削除中...",
+      "leaveTrigger": "グループを退出",
+      "leaveTitle": "「{{name}}」を退出しますか？",
+      "leaveDescription": "再参加するには新しい招待コードが必要になります。",
+      "leaveError": "グループの退出中に問題が発生しました。",
+      "leavePending": "退出中...",
+      "leaveConfirm": "退出",
+      "inviteCode": "招待コード:",
+      "copyAria": "招待コードをコピー"
+    },
+    "table": {
+      "player": "プレイヤー",
+      "rating": "レーティング",
+      "games": "試合数",
+      "lastActive": "最終アクティブ",
+      "you": "（あなた）",
+      "never": "なし"
+    }
+  },
+  "integrations": {
+    "title": "連携",
+    "connected": "連携済み",
+    "checkingStatus": "連携状態を確認中…",
+    "gamerTag": "ゲーマータグ",
+    "lastSynced": "最終同期",
+    "never": "未同期",
+    "syncNow": "今すぐ同期",
+    "syncing": "同期中…",
+    "unlink": "連携解除",
+    "syncFailed": "同期に失敗しました。もう一度お試しください。",
+    "unlinkFailed": "連携解除に失敗しました。もう一度お試しください。",
+    "linkDescription": "{{provider}}アカウントを連携すると、スマブラSPの大会の試合を自動でインポートできます。インポートされた試合は競技タグ付きで試合データに追加されます。",
+    "unlinkTitle": "{{provider}}の連携を解除しますか？",
+    "unlinkDescription": "インポート済みの試合は履歴に残ります。再連携するまで新しい大会結果の同期が止まるだけです。",
+    "unlinkedToast": "{{provider}}アカウントの連携を解除しました。",
+    "summary": {
+      "importedFromSets": "{{sets}}セットから{{imported}}ゲームをインポートしました",
+      "importedFromMatches": "{{matches}}試合から{{imported}}ゲームをインポートしました",
+      "skippedDetail_one": "{{count}}件はインポート可能な詳細がありません",
+      "skippedDetail_other": "{{count}}件はインポート可能な詳細がありません",
+      "unknownStages_one": "{{count}}件は認識できないステージを含みます",
+      "unknownStages_other": "{{count}}件は認識できないステージを含みます",
+      "dqSkipped_one": "{{count}}件のDQをスキップしました",
+      "dqSkipped_other": "{{count}}件のDQをスキップしました"
+    },
+    "startgg": {
+      "connect": "start.ggアカウントを連携",
+      "linked": "start.ggアカウントを連携しました！",
+      "linkFailed": "start.ggの連携に失敗しました（{{reason}}）",
+      "unknownError": "不明なエラー"
+    },
+    "parrygg": {
+      "verified": "認証済み",
+      "unverified": "未認証",
+      "verify": "認証する",
+      "linkedTo": "parry.ggの{{tag}}と連携しました！",
+      "linkFailed": "そのアカウントの連携に失敗しました。もう一度お試しください。",
+      "searchPlaceholder": "parry.ggのゲーマータグを検索...",
+      "searchAria": "parry.ggのゲーマータグを検索",
+      "searching": "検索中...",
+      "noAccounts": "一致するparry.ggアカウントがありません。",
+      "link": "連携",
+      "verifyTitle": "parry.ggアカウントを認証",
+      "verifyDescription": "このコードをparry.ggプロフィールの自己紹介欄に貼り付けてから「確認」を押してください。コードは10分で期限切れになります。",
+      "copyCodeAria": "認証コードをコピー",
+      "generatingCode": "認証コードを生成中...",
+      "check": "確認",
+      "checking": "確認中...",
+      "verifyStartFailed": "認証を開始できませんでした。もう一度お試しください。",
+      "verifiedToast": "parry.ggアカウントを認証しました！",
+      "codeNotFound": "認証コードがまだ見つかりません。もう一度お試しください。"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -928,5 +928,125 @@
       "title": "Relatórios de IA anteriores",
       "description": "Relatórios já gerados, o mais recente primeiro."
     }
+  },
+  "reports": {
+    "title": "Relatórios de IA",
+    "notEnabled": "Os relatórios de IA ainda não estão habilitados para esta conta.",
+    "loading": "Carregando seus relatórios…",
+    "empty": "Ainda não há relatórios de scouting de IA. Gere um na página <scoutLink>Buscar jogador</scoutLink>.",
+    "yourReports": "Seus relatórios",
+    "groupedBy": "Agrupados por jogador, do scouting mais recente para o mais antigo.",
+    "olderReport": "Relatório mais antigo",
+    "hideOlder": "Ocultar relatórios antigos",
+    "showOlder": "Mostrar relatórios antigos"
+  },
+  "groups": {
+    "title": "Grupos",
+    "loading": "Carregando seus grupos...",
+    "empty": {
+      "title": "Nenhum grupo ainda",
+      "body": "Crie um grupo para iniciar um ranking entre amigos, ou entre em um com um código de convite."
+    },
+    "leaderboardLoading": "Carregando o ranking...",
+    "leaderboardError": "Algo deu errado ao carregar este ranking.",
+    "create": {
+      "trigger": "Criar grupo",
+      "title": "Criar um grupo",
+      "description": "Inicie um ranking entre amigos. Você poderá convidar outras pessoas com um código depois de criá-lo.",
+      "nameLabel": "Nome do grupo",
+      "namePlaceholder": "ex.: Os Locais",
+      "error": "Algo deu errado ao criar o grupo.",
+      "pending": "Criando...",
+      "confirm": "Criar"
+    },
+    "join": {
+      "trigger": "Entrar com código",
+      "title": "Entrar em um grupo",
+      "description": "Digite o código de convite que compartilharam com você.",
+      "codeLabel": "Código de convite",
+      "codePlaceholder": "ex.: AB3DEFGH",
+      "error": "Algo deu errado ao entrar nesse grupo.",
+      "pending": "Entrando...",
+      "confirm": "Entrar"
+    },
+    "members_one": "{{count}} membro",
+    "members_other": "{{count}} membros",
+    "header": {
+      "deleteTrigger": "Excluir grupo",
+      "deleteTitle": "Excluir \"{{name}}\"?",
+      "deleteDescription": "Isso remove o grupo e seu ranking para todos os membros. Não é possível desfazer.",
+      "deleteError": "Algo deu errado ao excluir o grupo.",
+      "deletePending": "Excluindo...",
+      "leaveTrigger": "Sair do grupo",
+      "leaveTitle": "Sair de \"{{name}}\"?",
+      "leaveDescription": "Você precisará de um novo código de convite para entrar novamente.",
+      "leaveError": "Algo deu errado ao sair do grupo.",
+      "leavePending": "Saindo...",
+      "leaveConfirm": "Sair",
+      "inviteCode": "Código de convite:",
+      "copyAria": "Copiar código de convite"
+    },
+    "table": {
+      "player": "Jogador",
+      "rating": "Pontuação",
+      "games": "Partidas",
+      "lastActive": "Última atividade",
+      "you": "(você)",
+      "never": "nunca"
+    }
+  },
+  "integrations": {
+    "title": "Integrações",
+    "connected": "Conectada",
+    "checkingStatus": "Verificando o status do vínculo…",
+    "gamerTag": "Gamer tag",
+    "lastSynced": "Última sincronização",
+    "never": "Nunca",
+    "syncNow": "Sincronizar agora",
+    "syncing": "Sincronizando…",
+    "unlink": "Desvincular",
+    "syncFailed": "Falha na sincronização. Tente novamente.",
+    "unlinkFailed": "Falha ao desvincular. Tente novamente.",
+    "linkDescription": "Vincule sua conta do {{provider}} para importar automaticamente suas partidas de torneio de Smash Ultimate. As partidas importadas entram no seu histórico com a tag de competitivo.",
+    "unlinkTitle": "Desvincular o {{provider}}?",
+    "unlinkDescription": "As partidas já importadas permanecem no seu histórico; os novos resultados de torneio apenas param de sincronizar até você reconectar.",
+    "unlinkedToast": "Conta do {{provider}} desvinculada.",
+    "summary": {
+      "importedFromSets": "{{imported}} partidas importadas de {{sets}} sets",
+      "importedFromMatches": "{{imported}} partidas importadas de {{matches}} confrontos",
+      "skippedDetail_one": "{{count}} sem detalhes importáveis",
+      "skippedDetail_other": "{{count}} sem detalhes importáveis",
+      "unknownStages_one": "{{count}} com stages não reconhecidos",
+      "unknownStages_other": "{{count}} com stages não reconhecidos",
+      "dqSkipped_one": "{{count}} DQ ignorado",
+      "dqSkipped_other": "{{count}} DQs ignorados"
+    },
+    "startgg": {
+      "connect": "Conectar conta do start.gg",
+      "linked": "Conta do start.gg vinculada!",
+      "linkFailed": "Falha ao vincular o start.gg ({{reason}})",
+      "unknownError": "erro desconhecido"
+    },
+    "parrygg": {
+      "verified": "Verificada",
+      "unverified": "Não verificada",
+      "verify": "Verificar",
+      "linkedTo": "Vinculado a {{tag}} no parry.gg!",
+      "linkFailed": "Não foi possível vincular essa conta. Tente novamente.",
+      "searchPlaceholder": "Busque seu gamer tag do parry.gg...",
+      "searchAria": "Buscar gamer tag do parry.gg",
+      "searching": "Buscando...",
+      "noAccounts": "Nenhuma conta do parry.gg encontrada.",
+      "link": "Vincular",
+      "verifyTitle": "Verifique sua conta do parry.gg",
+      "verifyDescription": "Cole este código na bio do seu perfil do parry.gg e depois clique em Conferir. Ele expira em 10 minutos.",
+      "copyCodeAria": "Copiar código de verificação",
+      "generatingCode": "Gerando seu código de verificação...",
+      "check": "Conferir",
+      "checking": "Conferindo...",
+      "verifyStartFailed": "Não foi possível iniciar a verificação. Tente novamente.",
+      "verifiedToast": "Conta do parry.gg verificada!",
+      "codeNotFound": "Código de verificação ainda não encontrado. Tente novamente."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -114,6 +114,12 @@
       "p1": "<strong>Glicko-2</strong> é o sistema de pontuação usado no xadrez e em muitas ladders competitivas. Diferente de uma taxa de vitórias simples, ele pesa <em>quem</em> você vence e o quão surpreendente foi o resultado.",
       "p2": "O <strong>número ± (RD)</strong> é a incerteza: ele diminui conforme você joga e cresce quando você fica inativo — um jogador 1500 ±50 é comprovado, um 1500 ±300 é uma incógnita.",
       "p3": "Nós o usamos porque o jogo de bracket é irregular: o Glicko-2 lida com longas pausas entre torneios e amostras pequenas muito melhor do que o Elo ou a taxa de vitórias sozinhos. As pontuações aqui não são oficiais e são calculadas apenas com suas partidas sincronizadas ou registradas."
+    },
+    "relativeDate": {
+      "justNow": "agora mesmo",
+      "minutesAgo": "há {{count}} min",
+      "hoursAgo": "há {{count}} h",
+      "daysAgo": "há {{count}} dias"
     }
   },
   "dashboard": {
@@ -676,6 +682,251 @@
       "verdictFollowed": "seguiu",
       "verdictAgainst": "contra",
       "verdictNeutral": "neutro sobre"
+    }
+  },
+  "billing": {
+    "title": "Comprar créditos de relatório",
+    "description": "Cada relatório de scouting com IA custa um crédito. Escolha um pacote — você será redirecionado ao Stripe para concluir a compra.",
+    "perReport": "{{price}} por relatório",
+    "checkoutError": "Algo deu errado ao iniciar o pagamento. Tente novamente.",
+    "redirecting": "Redirecionando…",
+    "continue": "Continuar para o pagamento"
+  },
+  "opponents": {
+    "loading": "Carregando relatórios de scouting...",
+    "selectPrompt": "Selecione um oponente na lista para ver o relatório de scouting dele.",
+    "empty": {
+      "title": "Ainda não há partidas para analisar!",
+      "body": "Registre uma partida no Painel, ou conecte o start.gg para sincronizar seus sets de torneio, e os relatórios de scouting dos oponentes aparecerão aqui.",
+      "connectStartgg": "Conectar start.gg"
+    },
+    "noTags": {
+      "title": "Nenhuma das suas partidas tem um nome de oponente registrado.",
+      "body": "Adicione o nome do oponente ao registrar uma partida para desbloquear o relatório de scouting dele."
+    },
+    "list": {
+      "title": "Oponentes",
+      "faced_one": "{{count}} oponente enfrentado",
+      "faced_other": "{{count}} oponentes enfrentados",
+      "searchPlaceholder": "Pesquisar oponentes...",
+      "searchAria": "Pesquisar oponentes",
+      "sortAria": "Ordenar oponentes",
+      "sortMostPlayed": "Mais jogados",
+      "sortRecent": "Jogados recentemente",
+      "sortBestRate": "Maior taxa de vitórias",
+      "sortWorstRate": "Menor taxa de vitórias",
+      "sortAlphabetical": "A → Z",
+      "minGames": "3+ partidas",
+      "minGamesAria": "Mostrar só oponentes com 3 ou mais partidas",
+      "emptyNone": "Nenhum oponente enfrentado ainda.",
+      "emptyFiltered": "Nenhum oponente corresponde aos seus filtros.",
+      "rowActions": "Ações para {{name}}",
+      "mergeInto": "Mesclar com..."
+    },
+    "source": {
+      "mixedAria": "fontes mistas",
+      "verified": "verificado",
+      "manual": "manual",
+      "manualAria": "inserido manualmente",
+      "startggAria": "verificado pelo start.gg",
+      "parryggAria": "verificado pelo parry.gg"
+    },
+    "header": {
+      "playedRange": "Primeira partida {{first}} · Última partida {{last}}",
+      "encounterSpan": "{{start}} e {{end}}",
+      "metAt_one": "Vocês se encontraram em {{count}} torneio entre {{span}}",
+      "metAt_other": "Vocês se encontraram em {{count}} torneios entre {{span}}",
+      "rateOverGames_one": "{{rate}}% em {{count}} partida",
+      "rateOverGames_other": "{{rate}}% em {{count}} partidas"
+    },
+    "whatTheyPlay": {
+      "title": "O que ele joga",
+      "description": "Ordenado pela confiabilidade com que você vence.",
+      "empty": "Nenhum personagem registrado ainda.",
+      "character": "Personagem"
+    },
+    "stages": {
+      "title": "Stages",
+      "empty": "Nenhum dado de stage registrado ainda."
+    },
+    "trend": {
+      "title": "Tendência H2H",
+      "empty": "Ainda não há partidas suficientes para uma tendência.",
+      "label": "Taxa de vitórias móvel (últimas {{count}})"
+    },
+    "encounters": {
+      "title": "Encontros recentes",
+      "empty": "Nenhum encontro registrado ainda.",
+      "aria": "Encontros recentes"
+    },
+    "history": {
+      "title": "Histórico de torneios",
+      "empty": "Nenhum set de torneio contra este jogador ainda — ressincronize o start.gg se vocês jogaram recentemente.",
+      "gamesAria": "Partidas",
+      "losers": "Losers",
+      "vsThemHere": "{{wins}}-{{losses}} contra ele aqui",
+      "setsAria": "Sets contra ele em {{title}}"
+    },
+    "merge": {
+      "title": "Mesclar \"{{name}}\" com...",
+      "description": "Escolha o nome de oponente que deve ser tratado como a mesma pessoa. As partidas dele serão combinadas em todo lugar.",
+      "noMatches": "Nenhum oponente correspondente.",
+      "warning": "\"{{opponent}}\" é {{label}} e \"{{target}}\" é só manual. Para manter a tag verificada como canônica, mesclaremos \"{{target}}\" com \"{{opponent}}\" em vez disso.",
+      "anyway": "Mesclar \"{{opponent}}\" com \"{{target}}\" mesmo assim",
+      "merging": "Mesclando...",
+      "merge": "Mesclar"
+    },
+    "merged": {
+      "title": "Nomes mesclados",
+      "description": "Estes nomes estão incorporados a \"{{name}}\". Separe para acompanhá-los individualmente de novo.",
+      "unmerge": "Separar"
+    },
+    "tendencies": {
+      "title": "Tendências",
+      "description": "Suas próprias notas de scouting sobre este oponente — não derivadas do histórico de partidas.",
+      "habits": "Hábitos",
+      "habitsPlaceholder": "Hábitos de abertura, rotas de punição, mixups de recuperação...",
+      "banThese": "Bana estes (máx. {{count}})",
+      "banAria": "Stages para banir contra este oponente",
+      "watchFor": "Fique de olho",
+      "watchForPlaceholder": "Leituras, mind games, tech chases para esperar no próximo set...",
+      "saving": "Salvando...",
+      "deleteNote": "Excluir nota",
+      "banTheseView": "Bana estes",
+      "banViewAria": "Stages para banir",
+      "savedAt": "Salvo em {{date}}",
+      "edit": "Editar",
+      "empty": "Ainda não há notas de scouting. Anote hábitos, stages para banir ou coisas para observar antes do seu próximo set.",
+      "addNote": "Adicionar nota"
+    },
+    "export": {
+      "print": "Exportar H2H",
+      "copy": "Copiar como texto",
+      "copied": "Copiado!"
+    }
+  },
+  "scout": {
+    "title": "Buscar jogador",
+    "prompt": "Cole acima uma URL de perfil do start.gg, um slug ou um id de jogador para ver o histórico público de torneios.",
+    "promptWithParry": "Cole acima uma URL de perfil do start.gg ou parry.gg, um slug/tag ou um id de jogador para ver o histórico público de torneios.",
+    "errors": {
+      "notFound": "Não encontramos um jogador do start.gg para essa busca. Confira a URL, o slug ou o id do jogador.",
+      "badQuery": "Isso não parece uma URL de perfil do start.gg, um slug nem um id de jogador.",
+      "rateLimited": "O start.gg está limitando as requisições agora. Tente novamente em um minuto.",
+      "scoutFallback": "Algo deu errado ao buscar esse jogador.",
+      "generateFallback": "Algo deu errado ao gerar o relatório."
+    },
+    "form": {
+      "description": "Cole uma URL de perfil do start.gg, uma referência \"user/<slug>\" ou um id numérico de jogador para ver o histórico público de torneios antes de enfrentá-lo.",
+      "descriptionWithParry": "Cole uma URL de perfil do start.gg ou parry.gg, um gamer tag, uma referência \"user/<slug>\" ou um id numérico de jogador para ver o histórico público de torneios antes de enfrentá-lo.",
+      "placeholder": "https://start.gg/user/07dc2239",
+      "placeholderWithParry": "https://start.gg/user/07dc2239 ou uma URL de perfil do parry.gg",
+      "inputAria": "URL de perfil do start.gg, slug ou id de jogador",
+      "inputAriaWithParry": "URL de perfil do start.gg ou parry.gg, slug/tag ou id de jogador",
+      "scout": "Buscar",
+      "scouting": "Buscando…",
+      "source": "Fonte:",
+      "sourceAria": "Fonte de scouting",
+      "detectedParry": "URL de perfil do parry.gg detectada.",
+      "pending": "Obtendo o histórico público de torneios — pode levar alguns segundos."
+    },
+    "report": {
+      "generate": "Gerar relatório com IA",
+      "regenerate": "Gerar relatório novamente",
+      "generating": "Gerando relatório…",
+      "generatingHint": "Gerando relatório — normalmente leva um ou dois minutos."
+    },
+    "billing": {
+      "paymentReceived": "Pagamento recebido — seus créditos chegarão em instantes, se ainda não chegaram.",
+      "checkoutCancelled": "Pagamento cancelado — nenhuma cobrança foi feita.",
+      "freeAccess": "Acesso gratuito",
+      "credits_one": "{{count}} crédito",
+      "credits_other": "{{count}} créditos",
+      "buyCredits": "Comprar créditos",
+      "costLine": "Cada relatório custa 1 crédito.",
+      "packFor": "{{label}} por {{price}}",
+      "outOfCredits": "Seus créditos acabaram.",
+      "buyPack": "Compre um pacote",
+      "toGenerate": "para gerar este relatório."
+    },
+    "header": {
+      "viewOn": "Ver {{name}} no {{source}}",
+      "profile": "Perfil no {{source}}",
+      "sample": "Dados públicos do {{source}} · amostra dos últimos {{sets}} sets ({{games}} partidas)"
+    },
+    "characters": {
+      "title": "Uso de personagens",
+      "description": "O que ele joga, o mais usado primeiro.",
+      "empty": "Nenhuma partida na amostra ainda."
+    },
+    "stages": {
+      "title": "Desempenho por stage",
+      "description": "Os resultados dele por stage."
+    },
+    "events": {
+      "title": "Eventos recentes",
+      "description": "Atividade mais recente primeiro.",
+      "empty": "Nenhum evento recente na amostra.",
+      "placement": "Colocação",
+      "entrants": "Participantes"
+    },
+    "commonOpponents": {
+      "title": "Oponentes frequentes",
+      "description": "Com quem ele mais cruza nos sets da amostra.",
+      "empty": "Nenhum oponente repetido na amostra.",
+      "sets_one": "{{count}} set",
+      "sets_other": "{{count}} sets"
+    },
+    "history": {
+      "title": "Seu histórico contra ele",
+      "description_one": "Você já jogou contra {{name}} — {{count}} partida registrada no seu próprio histórico.",
+      "description_other": "Você já jogou contra {{name}} — {{count}} partidas registradas no seu próprio histórico.",
+      "rate": "({{rate}}% de vitórias)",
+      "fullReport": "Relatório de scouting completo"
+    },
+    "advisor": {
+      "title": "Conselheiro de confrontos",
+      "description": "Sua melhor (e pior) escolha contra cada personagem dele — combina seu próprio retrospecto com dados de tier list e arquétipos.",
+      "noCharacterData": "Ainda não há dados de personagens para este scouting — comum no parry.gg enquanto os dados de partidas são escassos. Volte quando ele tiver jogado mais sets.",
+      "noMyCharacters": "Escolha um personagem principal ou secundário (ou registre algumas partidas) para receber recomendações personalizadas.",
+      "vsName": "vs. {{name}}",
+      "gamesSampled_one": "{{count}} partida na amostra",
+      "gamesSampled_other": "{{count}} partidas na amostra",
+      "inYourSets": "{{record}} nos seus sets",
+      "tier": "tier {{score}}/10",
+      "archetypeEdge": "vantagem de arquétipo",
+      "archetypeDisadvantage": "desvantagem de arquétipo"
+    },
+    "fullAnalysis": {
+      "title": "Análise completa",
+      "rescout": "Busque novamente para habilitar a análise completa.",
+      "noGameData": "Esta fonte ainda não oferece dados por partida.",
+      "stageMasteryOverall": "Domínio de stages — Geral",
+      "stageMasteryFor": "Domínio de stages — {{name}}",
+      "topCharacter": "Personagem principal",
+      "recentForm": "Forma recente de {{name}}"
+    },
+    "aiReport": {
+      "title": "Relatório de scouting com IA",
+      "generated": "Gerado {{rel}}",
+      "download": "Baixar (.md)",
+      "print": "Imprimir / Salvar como PDF",
+      "gameplan": "Plano de jogo",
+      "characterStrategy": "Estratégia de personagens",
+      "stageStrategy": "Estratégia de stages",
+      "picks": "Picks:",
+      "bans": "Bans:",
+      "headToHead": "Confronto direto",
+      "watchFor": "Fique de olho"
+    },
+    "historySelector": {
+      "older": "Relatório mais antigo",
+      "newer": "Relatório mais recente",
+      "reportOf": "Relatório {{ordinal}} de {{total}}"
+    },
+    "pastReports": {
+      "title": "Relatórios de IA anteriores",
+      "description": "Relatórios já gerados, o mais recente primeiro."
     }
   }
 }

--- a/apps/web/src/lib/relativeDate.test.ts
+++ b/apps/web/src/lib/relativeDate.test.ts
@@ -1,27 +1,28 @@
 import { describe, expect, it } from 'vitest';
+import i18n from '@/i18n';
 import { formatRelativeDate } from './relativeDate';
 
 const NOW = 1_700_000_000_000;
 
 describe('formatRelativeDate', () => {
   it('returns "just now" for under a minute', () => {
-    expect(formatRelativeDate(NOW - 30 * 1000, NOW)).toBe('just now');
+    expect(formatRelativeDate(NOW - 30 * 1000, i18n.t, NOW)).toBe('just now');
   });
 
   it('returns minutes for under an hour', () => {
-    expect(formatRelativeDate(NOW - 5 * 60 * 1000, NOW)).toBe('5m ago');
+    expect(formatRelativeDate(NOW - 5 * 60 * 1000, i18n.t, NOW)).toBe('5m ago');
   });
 
   it('returns hours for under a day', () => {
-    expect(formatRelativeDate(NOW - 3 * 60 * 60 * 1000, NOW)).toBe('3h ago');
+    expect(formatRelativeDate(NOW - 3 * 60 * 60 * 1000, i18n.t, NOW)).toBe('3h ago');
   });
 
   it('returns days for under 30 days', () => {
-    expect(formatRelativeDate(NOW - 5 * 24 * 60 * 60 * 1000, NOW)).toBe('5d ago');
+    expect(formatRelativeDate(NOW - 5 * 24 * 60 * 60 * 1000, i18n.t, NOW)).toBe('5d ago');
   });
 
   it('falls back to an absolute date at 30+ days', () => {
     const epochMs = NOW - 40 * 24 * 60 * 60 * 1000;
-    expect(formatRelativeDate(epochMs, NOW)).toBe(new Date(epochMs).toLocaleDateString());
+    expect(formatRelativeDate(epochMs, i18n.t, NOW)).toBe(new Date(epochMs).toLocaleDateString());
   });
 });

--- a/apps/web/src/lib/relativeDate.ts
+++ b/apps/web/src/lib/relativeDate.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from 'i18next';
+
 /**
  * Minimal relative-date formatter, originally built for the group
  * leaderboard's "last active" column and reused (V7-B.1) for the Scout
@@ -5,27 +7,28 @@
  * codebase has no date library dependency (elsewhere it uses
  * `toLocaleDateString()` for absolute dates), so this is a small,
  * dependency-free helper rather than pulling one in for a single column.
+ * Takes `t` so the units come out of the active locale.
  */
-export function formatRelativeDate(epochMs: number, now = Date.now()): string {
+export function formatRelativeDate(epochMs: number, t: TFunction, now = Date.now()): string {
   const diffMs = now - epochMs;
   const minute = 60 * 1000;
   const hour = 60 * minute;
   const day = 24 * hour;
 
   if (diffMs < minute) {
-    return 'just now';
+    return t('shared.relativeDate.justNow');
   }
   if (diffMs < hour) {
     const minutes = Math.floor(diffMs / minute);
-    return `${minutes}m ago`;
+    return t('shared.relativeDate.minutesAgo', { count: minutes });
   }
   if (diffMs < day) {
     const hours = Math.floor(diffMs / hour);
-    return `${hours}h ago`;
+    return t('shared.relativeDate.hoursAgo', { count: hours });
   }
   const days = Math.floor(diffMs / day);
   if (days < 30) {
-    return `${days}d ago`;
+    return t('shared.relativeDate.daysAgo', { count: days });
   }
   return new Date(epochMs).toLocaleDateString();
 }

--- a/apps/web/src/pages/Groups/GroupsPage.tsx
+++ b/apps/web/src/pages/Groups/GroupsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Users } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useGroupLeaderboard, useGroups } from '@/hooks/useGroups';
@@ -18,6 +19,7 @@ import { describeGroupsError } from './describeGroupsError';
  * dialog.
  */
 export function GroupsPage() {
+  const { t } = useTranslation();
   const { user } = useAuth();
   const groups = useGroups();
   // Tracks an explicit user selection only; if it no longer refers to a
@@ -35,22 +37,20 @@ export function GroupsPage() {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('groups.title')}</h1>
         <div className="flex gap-2">
           <JoinGroupDialog onJoined={(groupId) => setRequestedGroupId(groupId)} />
           <CreateGroupDialog onCreated={(groupId) => setRequestedGroupId(groupId)} />
         </div>
       </div>
 
-      {groups.isLoading && <div className="text-muted-foreground">Loading your groups...</div>}
+      {groups.isLoading && <div className="text-muted-foreground">{t('groups.loading')}</div>}
 
       {!groups.isLoading && myGroups.length === 0 && (
         <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed p-16 text-center">
           <Users className="size-8 text-muted-foreground" />
-          <h2 className="text-lg font-semibold">No groups yet</h2>
-          <p className="max-w-sm text-sm text-muted-foreground">
-            Create a group to start a friend-group leaderboard, or join one with an invite code.
-          </p>
+          <h2 className="text-lg font-semibold">{t('groups.empty.title')}</h2>
+          <p className="max-w-sm text-sm text-muted-foreground">{t('groups.empty.body')}</p>
         </div>
       )}
 
@@ -65,15 +65,12 @@ export function GroupsPage() {
       {selectedGroupId && (
         <div className="flex flex-col gap-4 rounded-lg border p-4">
           {leaderboard.isLoading && (
-            <div className="text-muted-foreground">Loading leaderboard...</div>
+            <div className="text-muted-foreground">{t('groups.leaderboardLoading')}</div>
           )}
 
           {leaderboard.isError && (
             <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-              {describeGroupsError(
-                leaderboard.error,
-                'Something went wrong loading this leaderboard.',
-              )}
+              {describeGroupsError(leaderboard.error, t('groups.leaderboardError'))}
             </div>
           )}
 

--- a/apps/web/src/pages/Groups/components/CreateGroupDialog.tsx
+++ b/apps/web/src/pages/Groups/components/CreateGroupDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -16,6 +17,7 @@ import { describeGroupsError } from '../describeGroupsError';
 
 /** "Create group" dialog: a single name input, POST /api/groups on confirm. */
 export function CreateGroupDialog({ onCreated }: { onCreated?: (groupId: string) => void }) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const createGroup = useCreateGroup();
@@ -45,41 +47,39 @@ export function CreateGroupDialog({ onCreated }: { onCreated?: (groupId: string)
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button type="button">Create group</Button>
+        <Button type="button">{t('groups.create.trigger')}</Button>
       </DialogTrigger>
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Create a group</DialogTitle>
-            <DialogDescription>
-              Start a friend-group leaderboard. You can invite others with a code once it's created.
-            </DialogDescription>
+            <DialogTitle>{t('groups.create.title')}</DialogTitle>
+            <DialogDescription>{t('groups.create.description')}</DialogDescription>
           </DialogHeader>
 
           <div className="flex flex-col gap-2 py-4">
-            <Label htmlFor="group-name">Group name</Label>
+            <Label htmlFor="group-name">{t('groups.create.nameLabel')}</Label>
             <Input
               id="group-name"
               value={name}
               onChange={(event) => setName(event.target.value)}
               maxLength={40}
-              placeholder="e.g. The Locals"
+              placeholder={t('groups.create.namePlaceholder')}
               autoFocus
             />
           </div>
 
           {createGroup.isError && (
             <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-              {describeGroupsError(createGroup.error, 'Something went wrong creating the group.')}
+              {describeGroupsError(createGroup.error, t('groups.create.error'))}
             </div>
           )}
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
-              Cancel
+              {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={!name.trim() || createGroup.isPending}>
-              {createGroup.isPending ? 'Creating...' : 'Create'}
+              {createGroup.isPending ? t('groups.create.pending') : t('groups.create.confirm')}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/pages/Groups/components/GroupCardList.tsx
+++ b/apps/web/src/pages/Groups/components/GroupCardList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Users } from 'lucide-react';
 import type { GroupRecord } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -13,6 +14,7 @@ export function GroupCardList({
   selectedGroupId: string | null;
   onSelect: (groupId: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {groups.map((group) => (
@@ -36,7 +38,7 @@ export function GroupCardList({
             </CardHeader>
             <CardContent className="flex items-center gap-1.5 text-sm text-muted-foreground">
               <Users className="size-4" />
-              {group.memberCount} {group.memberCount === 1 ? 'member' : 'members'}
+              {t('groups.members', { count: group.memberCount })}
             </CardContent>
           </Card>
         </button>

--- a/apps/web/src/pages/Groups/components/GroupLeaderboardHeader.tsx
+++ b/apps/web/src/pages/Groups/components/GroupLeaderboardHeader.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Check, Copy } from 'lucide-react';
 import type { GroupRecord } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
@@ -35,6 +36,7 @@ export function GroupLeaderboardHeader({
   onLeft?: () => void;
   onDeleted?: () => void;
 }) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const leaveGroup = useLeaveGroup();
   const deleteGroup = useDeleteGroup();
@@ -54,31 +56,30 @@ export function GroupLeaderboardHeader({
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button type="button" variant="destructive" size="sm">
-                Delete group
+                {t('groups.header.deleteTrigger')}
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>Delete "{group.name}"?</AlertDialogTitle>
+                <AlertDialogTitle>
+                  {t('groups.header.deleteTitle', { name: group.name })}
+                </AlertDialogTitle>
                 <AlertDialogDescription>
-                  This removes the group and its leaderboard for every member. This can't be undone.
+                  {t('groups.header.deleteDescription')}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               {deleteGroup.isError && (
                 <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                  {describeGroupsError(
-                    deleteGroup.error,
-                    'Something went wrong deleting the group.',
-                  )}
+                  {describeGroupsError(deleteGroup.error, t('groups.header.deleteError'))}
                 </div>
               )}
               <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
                 <AlertDialogAction
                   onClick={() => deleteGroup.mutate(group.id, { onSuccess: () => onDeleted?.() })}
                   disabled={deleteGroup.isPending}
                 >
-                  {deleteGroup.isPending ? 'Deleting...' : 'Delete'}
+                  {deleteGroup.isPending ? t('groups.header.deletePending') : t('common.delete')}
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
@@ -87,28 +88,32 @@ export function GroupLeaderboardHeader({
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button type="button" variant="outline" size="sm">
-                Leave group
+                {t('groups.header.leaveTrigger')}
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>Leave "{group.name}"?</AlertDialogTitle>
+                <AlertDialogTitle>
+                  {t('groups.header.leaveTitle', { name: group.name })}
+                </AlertDialogTitle>
                 <AlertDialogDescription>
-                  You'll need a new invite code to rejoin later.
+                  {t('groups.header.leaveDescription')}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               {leaveGroup.isError && (
                 <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                  {describeGroupsError(leaveGroup.error, 'Something went wrong leaving the group.')}
+                  {describeGroupsError(leaveGroup.error, t('groups.header.leaveError'))}
                 </div>
               )}
               <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
                 <AlertDialogAction
                   onClick={() => leaveGroup.mutate(group.id, { onSuccess: () => onLeft?.() })}
                   disabled={leaveGroup.isPending}
                 >
-                  {leaveGroup.isPending ? 'Leaving...' : 'Leave'}
+                  {leaveGroup.isPending
+                    ? t('groups.header.leavePending')
+                    : t('groups.header.leaveConfirm')}
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
@@ -117,7 +122,7 @@ export function GroupLeaderboardHeader({
       </div>
 
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <span>Invite code:</span>
+        <span>{t('groups.header.inviteCode')}</span>
         <code className="rounded bg-muted px-2 py-0.5 font-mono text-foreground">
           {group.inviteCode}
         </code>
@@ -127,7 +132,7 @@ export function GroupLeaderboardHeader({
           size="icon"
           className="size-7"
           onClick={handleCopy}
-          aria-label="Copy invite code"
+          aria-label={t('groups.header.copyAria')}
         >
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>

--- a/apps/web/src/pages/Groups/components/GroupLeaderboardTable.tsx
+++ b/apps/web/src/pages/Groups/components/GroupLeaderboardTable.tsx
@@ -17,18 +17,16 @@ import { formatRelativeDate } from '@/lib/relativeDate';
  * (`isYou`) is visually highlighted.
  */
 export function GroupLeaderboardTable({ entries }: { entries: LeaderboardEntry[] }) {
-  // Only `t` for the relative-date helper here; the rest of this table's
-  // strings are extracted with the Groups page pass.
   const { t } = useTranslation();
   return (
     <Table>
       <TableHeader>
         <TableRow>
           <TableHead className="w-10">#</TableHead>
-          <TableHead>Player</TableHead>
-          <TableHead className="text-right">Rating</TableHead>
-          <TableHead className="text-right">Games</TableHead>
-          <TableHead className="text-right">Last active</TableHead>
+          <TableHead>{t('groups.table.player')}</TableHead>
+          <TableHead className="text-right">{t('groups.table.rating')}</TableHead>
+          <TableHead className="text-right">{t('groups.table.games')}</TableHead>
+          <TableHead className="text-right">{t('groups.table.lastActive')}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -40,14 +38,20 @@ export function GroupLeaderboardTable({ entries }: { entries: LeaderboardEntry[]
             <TableCell className="text-muted-foreground">{index + 1}</TableCell>
             <TableCell>
               {entry.displayName}
-              {entry.isYou && <span className="ml-1.5 text-xs text-muted-foreground">(you)</span>}
+              {entry.isYou && (
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  {t('groups.table.you')}
+                </span>
+              )}
             </TableCell>
             <TableCell className="text-right tabular-nums">
               {entry.rating} <span className="text-muted-foreground">± {entry.rd}</span>
             </TableCell>
             <TableCell className="text-right tabular-nums">{entry.games}</TableCell>
             <TableCell className="text-right text-muted-foreground">
-              {entry.lastMatchAt != null ? formatRelativeDate(entry.lastMatchAt, t) : 'never'}
+              {entry.lastMatchAt != null
+                ? formatRelativeDate(entry.lastMatchAt, t)
+                : t('groups.table.never')}
             </TableCell>
           </TableRow>
         ))}

--- a/apps/web/src/pages/Groups/components/GroupLeaderboardTable.tsx
+++ b/apps/web/src/pages/Groups/components/GroupLeaderboardTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { LeaderboardEntry } from '@smash-tracker/shared';
 import {
   Table,
@@ -16,6 +17,9 @@ import { formatRelativeDate } from '@/lib/relativeDate';
  * (`isYou`) is visually highlighted.
  */
 export function GroupLeaderboardTable({ entries }: { entries: LeaderboardEntry[] }) {
+  // Only `t` for the relative-date helper here; the rest of this table's
+  // strings are extracted with the Groups page pass.
+  const { t } = useTranslation();
   return (
     <Table>
       <TableHeader>
@@ -43,7 +47,7 @@ export function GroupLeaderboardTable({ entries }: { entries: LeaderboardEntry[]
             </TableCell>
             <TableCell className="text-right tabular-nums">{entry.games}</TableCell>
             <TableCell className="text-right text-muted-foreground">
-              {entry.lastMatchAt != null ? formatRelativeDate(entry.lastMatchAt) : 'never'}
+              {entry.lastMatchAt != null ? formatRelativeDate(entry.lastMatchAt, t) : 'never'}
             </TableCell>
           </TableRow>
         ))}

--- a/apps/web/src/pages/Groups/components/JoinGroupDialog.tsx
+++ b/apps/web/src/pages/Groups/components/JoinGroupDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -16,6 +17,7 @@ import { describeGroupsError } from '../describeGroupsError';
 
 /** "Join with code" dialog: an 8-char invite code input, POST /api/groups/join on confirm. */
 export function JoinGroupDialog({ onJoined }: { onJoined?: (groupId: string) => void }) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [code, setCode] = useState('');
   const joinGroup = useJoinGroup();
@@ -46,24 +48,24 @@ export function JoinGroupDialog({ onJoined }: { onJoined?: (groupId: string) => 
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button type="button" variant="outline">
-          Join with code
+          {t('groups.join.trigger')}
         </Button>
       </DialogTrigger>
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Join a group</DialogTitle>
-            <DialogDescription>Enter the invite code someone shared with you.</DialogDescription>
+            <DialogTitle>{t('groups.join.title')}</DialogTitle>
+            <DialogDescription>{t('groups.join.description')}</DialogDescription>
           </DialogHeader>
 
           <div className="flex flex-col gap-2 py-4">
-            <Label htmlFor="invite-code">Invite code</Label>
+            <Label htmlFor="invite-code">{t('groups.join.codeLabel')}</Label>
             <Input
               id="invite-code"
               value={code}
               onChange={(event) => setCode(event.target.value.toUpperCase())}
               maxLength={8}
-              placeholder="e.g. AB3DEFGH"
+              placeholder={t('groups.join.codePlaceholder')}
               className="font-mono uppercase"
               autoFocus
             />
@@ -71,16 +73,16 @@ export function JoinGroupDialog({ onJoined }: { onJoined?: (groupId: string) => 
 
           {joinGroup.isError && (
             <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-              {describeGroupsError(joinGroup.error, 'Something went wrong joining that group.')}
+              {describeGroupsError(joinGroup.error, t('groups.join.error'))}
             </div>
           )}
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
-              Cancel
+              {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={!code.trim() || joinGroup.isPending}>
-              {joinGroup.isPending ? 'Joining...' : 'Join'}
+              {joinGroup.isPending ? t('groups.join.pending') : t('groups.join.confirm')}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/pages/Integrations/IntegrationsPage.tsx
+++ b/apps/web/src/pages/Integrations/IntegrationsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { toast } from 'sonner';
 import { RefreshCw, Unlink } from 'lucide-react';
 import type { StartggSyncSummary } from '@smash-tracker/shared';
@@ -24,24 +26,27 @@ import {
 } from '@/hooks/useStartgg';
 import { ParryggCard } from './components/ParryggCard';
 
-function describeSummary(summary: StartggSyncSummary): string {
+function describeSummary(summary: StartggSyncSummary, t: TFunction): string {
   const skipped =
     summary.setsWithoutGames + summary.gamesUnmappedCharacter + summary.gamesMissingSelections;
-  const parts = [`Imported ${summary.imported} games from ${summary.sets} sets`];
+  const parts = [
+    t('integrations.summary.importedFromSets', { imported: summary.imported, sets: summary.sets }),
+  ];
   if (skipped > 0) {
-    parts.push(`${skipped} without importable detail`);
+    parts.push(t('integrations.summary.skippedDetail', { count: skipped }));
   }
   if (summary.gamesUnknownStage > 0) {
-    parts.push(`${summary.gamesUnknownStage} with unrecognized stages`);
+    parts.push(t('integrations.summary.unknownStages', { count: summary.gamesUnknownStage }));
   }
   if (summary.dqSets > 0) {
-    parts.push(`${summary.dqSets} DQs skipped`);
+    parts.push(t('integrations.summary.dqSkipped', { count: summary.dqSets }));
   }
   return parts.join(' · ');
 }
 
 /** Settings > Integrations: link a start.gg account and sync tournament matches. */
 export function IntegrationsPage() {
+  const { t, i18n } = useTranslation();
   const { data: status, isLoading } = useStartggStatus();
   const connect = useStartggConnect();
   const sync = useStartggSync();
@@ -59,20 +64,24 @@ export function IntegrationsPage() {
     }
     announcedCallback.current = true;
     if (outcome === 'linked') {
-      toast.success('start.gg account linked!');
+      toast.success(t('integrations.startgg.linked'));
     } else {
-      toast.error(`start.gg linking failed (${searchParams.get('reason') ?? 'unknown error'})`);
+      toast.error(
+        t('integrations.startgg.linkFailed', {
+          reason: searchParams.get('reason') ?? t('integrations.startgg.unknownError'),
+        }),
+      );
     }
     setSearchParams({}, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, t]);
 
   const handleSync = async () => {
     try {
       const summary = await sync.mutateAsync();
       setLastSummary(summary);
-      toast.success(describeSummary(summary));
+      toast.success(describeSummary(summary, t));
     } catch {
-      toast.error('Sync failed. Please try again.');
+      toast.error(t('integrations.syncFailed'));
     }
   };
 
@@ -81,47 +90,48 @@ export function IntegrationsPage() {
     try {
       await unlink.mutateAsync();
       setLastSummary(null);
-      toast.success('start.gg account unlinked.');
+      toast.success(t('integrations.unlinkedToast', { provider: 'start.gg' }));
     } catch {
-      toast.error('Failed to unlink. Please try again.');
+      toast.error(t('integrations.unlinkFailed'));
     }
   };
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Integrations</h1>
+      <h1 className="text-2xl font-semibold tracking-tight">{t('integrations.title')}</h1>
 
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle>start.gg</CardTitle>
-            {status?.linked && <Badge variant="success">Connected</Badge>}
+            {status?.linked && <Badge variant="success">{t('integrations.connected')}</Badge>}
           </div>
           <CardDescription>
-            Link your start.gg account to automatically import your Smash Ultimate tournament
-            matches. Imported games join your match pool with a competitive tag.
+            {t('integrations.linkDescription', { provider: 'start.gg' })}
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           {isLoading ? (
-            <p className="text-sm text-muted-foreground">Checking link status…</p>
+            <p className="text-sm text-muted-foreground">{t('integrations.checkingStatus')}</p>
           ) : status?.linked ? (
             <>
               <dl className="grid grid-cols-2 gap-2 text-sm">
-                <dt className="text-muted-foreground">Gamer tag</dt>
+                <dt className="text-muted-foreground">{t('integrations.gamerTag')}</dt>
                 <dd className="font-medium">{status.gamerTag}</dd>
-                <dt className="text-muted-foreground">Last synced</dt>
+                <dt className="text-muted-foreground">{t('integrations.lastSynced')}</dt>
                 <dd>
-                  {status.lastSyncAt ? new Date(status.lastSyncAt).toLocaleString() : 'Never'}
+                  {status.lastSyncAt
+                    ? new Date(status.lastSyncAt).toLocaleString(i18n.language)
+                    : t('integrations.never')}
                 </dd>
               </dl>
               {lastSummary && (
-                <p className="text-sm text-muted-foreground">{describeSummary(lastSummary)}</p>
+                <p className="text-sm text-muted-foreground">{describeSummary(lastSummary, t)}</p>
               )}
               <div className="flex flex-wrap gap-2">
                 <Button onClick={handleSync} disabled={sync.isPending}>
                   <RefreshCw className={sync.isPending ? 'animate-spin' : ''} />
-                  {sync.isPending ? 'Syncing…' : 'Sync now'}
+                  {sync.isPending ? t('integrations.syncing') : t('integrations.syncNow')}
                 </Button>
                 <Button
                   variant="outline"
@@ -129,14 +139,14 @@ export function IntegrationsPage() {
                   disabled={unlink.isPending}
                 >
                   <Unlink />
-                  Unlink
+                  {t('integrations.unlink')}
                 </Button>
               </div>
             </>
           ) : (
             <div>
               <Button onClick={() => connect.mutate()} disabled={connect.isPending}>
-                Connect start.gg account
+                {t('integrations.startgg.connect')}
               </Button>
             </div>
           )}
@@ -146,15 +156,14 @@ export function IntegrationsPage() {
       <AlertDialog open={confirmUnlink} onOpenChange={(open) => !open && setConfirmUnlink(false)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Unlink start.gg?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Already-imported matches stay in your history; new tournament results just stop
-              syncing until you reconnect.
-            </AlertDialogDescription>
+            <AlertDialogTitle>
+              {t('integrations.unlinkTitle', { provider: 'start.gg' })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>{t('integrations.unlinkDescription')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleUnlink}>Unlink</AlertDialogAction>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleUnlink}>{t('integrations.unlink')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/pages/Integrations/components/ParryggCard.tsx
+++ b/apps/web/src/pages/Integrations/components/ParryggCard.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { toast } from 'sonner';
 import { Check, Copy, RefreshCw, Unlink } from 'lucide-react';
 import type { ParryggSearchResult, ParryggSyncSummary } from '@smash-tracker/shared';
@@ -36,7 +38,7 @@ import {
 } from '@/hooks/useParrygg';
 
 /** Mirrors start.gg's `describeSummary` in IntegrationsPage.tsx — same shape of "imported X, skipped Y" toast copy. */
-function describeSummary(summary: ParryggSyncSummary): string {
+function describeSummary(summary: ParryggSyncSummary, t: TFunction): string {
   const skipped =
     summary.dqOrIncomplete +
     summary.otherGame +
@@ -44,17 +46,23 @@ function describeSummary(summary: ParryggSyncSummary): string {
     summary.teamEntrants +
     summary.unmappedCharacters +
     summary.setsWithoutGameData;
-  const parts = [`Imported ${summary.imported} games from ${summary.matches} matches`];
+  const parts = [
+    t('integrations.summary.importedFromMatches', {
+      imported: summary.imported,
+      matches: summary.matches,
+    }),
+  ];
   if (skipped > 0) {
-    parts.push(`${skipped} without importable detail`);
+    parts.push(t('integrations.summary.skippedDetail', { count: skipped }));
   }
   if (summary.unmappedStages > 0) {
-    parts.push(`${summary.unmappedStages} with unrecognized stages`);
+    parts.push(t('integrations.summary.unknownStages', { count: summary.unmappedStages }));
   }
   return parts.join(' · ');
 }
 
 function SearchAndLink({ onLinked }: { onLinked: () => void }) {
+  const { t } = useTranslation();
   const [tag, setTag] = useState('');
   const { data: candidates, isFetching } = useParryggSearch(tag);
   const link = useParryggLink();
@@ -62,25 +70,27 @@ function SearchAndLink({ onLinked }: { onLinked: () => void }) {
   async function handleLink(candidate: ParryggSearchResult) {
     try {
       await link.mutateAsync({ parryUserId: candidate.id });
-      toast.success(`Linked to ${candidate.gamerTag} on parry.gg!`);
+      toast.success(t('integrations.parrygg.linkedTo', { tag: candidate.gamerTag }));
       onLinked();
     } catch {
-      toast.error('Failed to link that account. Please try again.');
+      toast.error(t('integrations.parrygg.linkFailed'));
     }
   }
 
   return (
     <div className="flex flex-col gap-3">
       <Input
-        placeholder="Search your parry.gg gamer tag..."
+        placeholder={t('integrations.parrygg.searchPlaceholder')}
         value={tag}
         onChange={(e) => setTag(e.target.value)}
-        aria-label="Search parry.gg gamer tag"
+        aria-label={t('integrations.parrygg.searchAria')}
       />
       {tag.trim().length > 0 && (
         <div className="flex flex-col divide-y rounded-md border">
           {isFetching ? (
-            <p className="p-3 text-sm text-muted-foreground">Searching...</p>
+            <p className="p-3 text-sm text-muted-foreground">
+              {t('integrations.parrygg.searching')}
+            </p>
           ) : candidates && candidates.length > 0 ? (
             candidates.map((candidate) => (
               <div key={candidate.id} className="flex items-center justify-between gap-2 p-2">
@@ -106,12 +116,14 @@ function SearchAndLink({ onLinked }: { onLinked: () => void }) {
                   onClick={() => handleLink(candidate)}
                   disabled={link.isPending}
                 >
-                  Link
+                  {t('integrations.parrygg.link')}
                 </Button>
               </div>
             ))
           ) : (
-            <p className="p-3 text-sm text-muted-foreground">No matching parry.gg accounts.</p>
+            <p className="p-3 text-sm text-muted-foreground">
+              {t('integrations.parrygg.noAccounts')}
+            </p>
           )}
         </div>
       )}
@@ -126,6 +138,7 @@ function VerifyDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const { t } = useTranslation();
   const verifyStart = useParryggVerifyStart();
   const verifyComplete = useParryggVerifyComplete();
   const [copied, setCopied] = useState(false);
@@ -139,7 +152,7 @@ function VerifyDialog({
   useEffect(() => {
     if (open && !verifyStart.data && !verifyStart.isPending) {
       verifyStart.mutate(undefined, {
-        onError: () => toast.error('Failed to start verification. Please try again.'),
+        onError: () => toast.error(t('integrations.parrygg.verifyStartFailed')),
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- verifyStart is a fresh mutation object every render; keying on `open` alone is intentional
@@ -165,12 +178,10 @@ function VerifyDialog({
     setCheckError(null);
     try {
       await verifyComplete.mutateAsync();
-      toast.success('parry.gg account verified!');
+      toast.success(t('integrations.parrygg.verifiedToast'));
       onOpenChange(false);
     } catch (err) {
-      setCheckError(
-        err instanceof Error ? err.message : 'Verification code not found yet. Please try again.',
-      );
+      setCheckError(err instanceof Error ? err.message : t('integrations.parrygg.codeNotFound'));
     }
   }
 
@@ -178,11 +189,8 @@ function VerifyDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Verify your parry.gg account</DialogTitle>
-          <DialogDescription>
-            Paste this code into your parry.gg profile bio, then click Check. It expires in 10
-            minutes.
-          </DialogDescription>
+          <DialogTitle>{t('integrations.parrygg.verifyTitle')}</DialogTitle>
+          <DialogDescription>{t('integrations.parrygg.verifyDescription')}</DialogDescription>
         </DialogHeader>
 
         {code ? (
@@ -195,23 +203,27 @@ function VerifyDialog({
               variant="outline"
               size="icon"
               onClick={handleCopy}
-              aria-label="Copy verification code"
+              aria-label={t('integrations.parrygg.copyCodeAria')}
             >
               {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
             </Button>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">Generating your verification code...</p>
+          <p className="text-sm text-muted-foreground">
+            {t('integrations.parrygg.generatingCode')}
+          </p>
         )}
 
         {checkError && <p className="text-sm text-destructive">{checkError}</p>}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button type="button" onClick={handleCheck} disabled={!code || verifyComplete.isPending}>
-            {verifyComplete.isPending ? 'Checking...' : 'Check'}
+            {verifyComplete.isPending
+              ? t('integrations.parrygg.checking')
+              : t('integrations.parrygg.check')}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -221,6 +233,7 @@ function VerifyDialog({
 
 /** Settings > Integrations: link a parry.gg account, verify ownership, and sync tournament matches. */
 export function ParryggCard() {
+  const { t, i18n } = useTranslation();
   const { data: status, isLoading } = useParryggStatus();
   const sync = useParryggSync();
   const unlink = useParryggUnlink();
@@ -232,9 +245,9 @@ export function ParryggCard() {
     try {
       const summary = await sync.mutateAsync();
       setLastSummary(summary);
-      toast.success(describeSummary(summary));
+      toast.success(describeSummary(summary, t));
     } catch {
-      toast.error('Sync failed. Please try again.');
+      toast.error(t('integrations.syncFailed'));
     }
   };
 
@@ -243,9 +256,9 @@ export function ParryggCard() {
     try {
       await unlink.mutateAsync();
       setLastSummary(null);
-      toast.success('parry.gg account unlinked.');
+      toast.success(t('integrations.unlinkedToast', { provider: 'parry.gg' }));
     } catch {
-      toast.error('Failed to unlink. Please try again.');
+      toast.error(t('integrations.unlinkFailed'));
     }
   };
 
@@ -256,37 +269,42 @@ export function ParryggCard() {
           <CardTitle>parry.gg</CardTitle>
           {status?.linked && (
             <Badge variant={status.verified ? 'success' : 'outline'}>
-              {status.verified ? 'Verified' : 'Unverified'}
+              {status.verified
+                ? t('integrations.parrygg.verified')
+                : t('integrations.parrygg.unverified')}
             </Badge>
           )}
         </div>
         <CardDescription>
-          Link your parry.gg account to automatically import your Smash Ultimate tournament matches.
-          Imported games join your match pool with a competitive tag.
+          {t('integrations.linkDescription', { provider: 'parry.gg' })}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Checking link status…</p>
+          <p className="text-sm text-muted-foreground">{t('integrations.checkingStatus')}</p>
         ) : status?.linked ? (
           <>
             <dl className="grid grid-cols-2 gap-2 text-sm">
-              <dt className="text-muted-foreground">Gamer tag</dt>
+              <dt className="text-muted-foreground">{t('integrations.gamerTag')}</dt>
               <dd className="font-medium">{status.gamerTag}</dd>
-              <dt className="text-muted-foreground">Last synced</dt>
-              <dd>{status.lastSyncAt ? new Date(status.lastSyncAt).toLocaleString() : 'Never'}</dd>
+              <dt className="text-muted-foreground">{t('integrations.lastSynced')}</dt>
+              <dd>
+                {status.lastSyncAt
+                  ? new Date(status.lastSyncAt).toLocaleString(i18n.language)
+                  : t('integrations.never')}
+              </dd>
             </dl>
             {lastSummary && (
-              <p className="text-sm text-muted-foreground">{describeSummary(lastSummary)}</p>
+              <p className="text-sm text-muted-foreground">{describeSummary(lastSummary, t)}</p>
             )}
             <div className="flex flex-wrap gap-2">
               <Button onClick={handleSync} disabled={sync.isPending}>
                 <RefreshCw className={sync.isPending ? 'animate-spin' : ''} />
-                {sync.isPending ? 'Syncing…' : 'Sync now'}
+                {sync.isPending ? t('integrations.syncing') : t('integrations.syncNow')}
               </Button>
               {!status.verified && (
                 <Button variant="outline" onClick={() => setVerifyOpen(true)}>
-                  Verify
+                  {t('integrations.parrygg.verify')}
                 </Button>
               )}
               <Button
@@ -295,7 +313,7 @@ export function ParryggCard() {
                 disabled={unlink.isPending}
               >
                 <Unlink />
-                Unlink
+                {t('integrations.unlink')}
               </Button>
             </div>
           </>
@@ -309,15 +327,14 @@ export function ParryggCard() {
       <AlertDialog open={confirmUnlink} onOpenChange={(open) => !open && setConfirmUnlink(false)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Unlink parry.gg?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Already-imported matches stay in your history; new tournament results just stop
-              syncing until you reconnect.
-            </AlertDialogDescription>
+            <AlertDialogTitle>
+              {t('integrations.unlinkTitle', { provider: 'parry.gg' })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>{t('integrations.unlinkDescription')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleUnlink}>Unlink</AlertDialogAction>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleUnlink}>{t('integrations.unlink')}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/pages/Opponents/OpponentsPage.tsx
+++ b/apps/web/src/pages/Opponents/OpponentsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { getOpponentSources, useFilteredMatches } from '@/hooks/useFilteredMatches';
 import { useTournamentEntries } from '@/hooks/useTournamentEntries';
@@ -29,6 +30,7 @@ import { buildEvidencePacket } from './evidencePacket';
  * to, and recent encounters. Searchable list ranked by games played.
  */
 export function OpponentsPage() {
+  const { t } = useTranslation();
   const { matches, allMatches, isLoading, filterActive } = useFilteredMatches();
   const { data: tournamentEntries } = useTournamentEntries();
   const { data: aliasMap } = useOpponentAliases();
@@ -96,23 +98,20 @@ export function OpponentsPage() {
   }, [profile, tournamentBlocks, user]);
 
   if (isLoading) {
-    return <div className="text-muted-foreground">Loading scouting reports...</div>;
+    return <div className="text-muted-foreground">{t('opponents.loading')}</div>;
   }
 
   if (allMatches.length === 0) {
     return (
       <div className="flex flex-col items-center gap-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">No matches to scout yet!</h1>
-        <p className="max-w-md text-muted-foreground">
-          Report a match on the Dashboard, or connect start.gg to sync your tournament sets, and
-          opponent scouting reports will show up here.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('opponents.empty.title')}</h1>
+        <p className="max-w-md text-muted-foreground">{t('opponents.empty.body')}</p>
         <div className="flex flex-wrap justify-center gap-2">
           <Button asChild>
-            <Link to="/dashboard">Go to Dashboard</Link>
+            <Link to="/dashboard">{t('common.goToDashboard')}</Link>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/settings/integrations">Connect start.gg</Link>
+            <Link to="/settings/integrations">{t('opponents.empty.connectStartgg')}</Link>
           </Button>
         </div>
       </div>
@@ -123,14 +122,10 @@ export function OpponentsPage() {
   if (allOpponentsNamed.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-16 text-center">
-        <h2 className="text-xl font-semibold tracking-tight">
-          None of your matches have an opponent tag recorded.
-        </h2>
-        <p className="max-w-md text-muted-foreground">
-          Add an opponent name when reporting a match to unlock scouting reports for them.
-        </p>
+        <h2 className="text-xl font-semibold tracking-tight">{t('opponents.noTags.title')}</h2>
+        <p className="max-w-md text-muted-foreground">{t('opponents.noTags.body')}</p>
         <Button asChild className="mt-2">
-          <Link to="/dashboard">Go to Dashboard</Link>
+          <Link to="/dashboard">{t('common.goToDashboard')}</Link>
         </Button>
       </div>
     );
@@ -174,7 +169,7 @@ export function OpponentsPage() {
           </div>
         ) : (
           <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
-            Select an opponent from the list to see their scouting report.
+            {t('opponents.selectPrompt')}
           </div>
         )}
       </div>

--- a/apps/web/src/pages/Opponents/components/ExportH2HButton.tsx
+++ b/apps/web/src/pages/Opponents/components/ExportH2HButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Printer, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { EvidencePacket } from '../evidencePacket';
@@ -14,6 +15,7 @@ const COPY_FEEDBACK_MS = 2000;
  * message to a teammate before a set.
  */
 export function ExportH2HButton({ packet }: { packet: EvidencePacket }) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
@@ -32,11 +34,11 @@ export function ExportH2HButton({ packet }: { packet: EvidencePacket }) {
     <div className="flex flex-wrap items-center gap-2">
       <Button type="button" variant="outline" size="sm" onClick={() => window.print()}>
         <Printer />
-        Export H2H
+        {t('opponents.export.print')}
       </Button>
       <Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
         {copied ? <Check /> : <Copy />}
-        {copied ? 'Copied!' : 'Copy as text'}
+        {copied ? t('opponents.export.copied') : t('opponents.export.copy')}
       </Button>
     </div>
   );

--- a/apps/web/src/pages/Opponents/components/MergeOpponentDialog.tsx
+++ b/apps/web/src/pages/Opponents/components/MergeOpponentDialog.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -48,6 +49,7 @@ export function MergeOpponentDialog({
   sources,
   onMerged,
 }: MergeOpponentDialogProps) {
+  const { t } = useTranslation();
   const [target, setTarget] = useState<string | null>(null);
   const [confirmedDespiteWarning, setConfirmedDespiteWarning] = useState(false);
   const upsertAlias = useUpsertOpponentAlias();
@@ -106,29 +108,26 @@ export function MergeOpponentDialog({
   /** "start.gg-verified" / "parry.gg-verified" / "verified" (mixed), matching the OpponentSourceBadge labels. */
   function verifiedLabel(source: OpponentSource | undefined): string {
     if (source === 'startgg') {
-      return 'start.gg-verified';
+      return t('opponents.source.startggAria');
     }
     if (source === 'parrygg') {
-      return 'parry.gg-verified';
+      return t('opponents.source.parryggAria');
     }
-    return 'verified';
+    return t('opponents.source.verified');
   }
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Merge &quot;{opponent}&quot; into...</DialogTitle>
-          <DialogDescription>
-            Choose the opponent name that should be treated as the same person. Their matches will
-            be combined everywhere.
-          </DialogDescription>
+          <DialogTitle>{t('opponents.merge.title', { name: opponent })}</DialogTitle>
+          <DialogDescription>{t('opponents.merge.description')}</DialogDescription>
         </DialogHeader>
 
         <Command className="rounded-md border">
-          <CommandInput placeholder="Search opponents..." />
+          <CommandInput placeholder={t('opponents.list.searchPlaceholder')} />
           <CommandList>
-            <CommandEmpty>No matching opponents.</CommandEmpty>
+            <CommandEmpty>{t('opponents.merge.noMatches')}</CommandEmpty>
             <CommandGroup>
               {ranked.map((name) => (
                 <CommandItem
@@ -151,9 +150,11 @@ export function MergeOpponentDialog({
         {target && wouldLoseVerifiedTag && !confirmedDespiteWarning && (
           <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400">
             <p>
-              &quot;{opponent}&quot; is {verifiedLabel(opponentSource)} and &quot;{target}&quot; is
-              manual-only. To keep the verified tag as canonical, we&apos;ll merge &quot;{target}
-              &quot; into &quot;{opponent}&quot; instead.
+              {t('opponents.merge.warning', {
+                opponent,
+                target,
+                label: verifiedLabel(opponentSource),
+              })}
             </p>
             <Button
               type="button"
@@ -161,17 +162,17 @@ export function MergeOpponentDialog({
               className="mt-1 h-auto p-0 text-sm"
               onClick={() => setConfirmedDespiteWarning(true)}
             >
-              Merge &quot;{opponent}&quot; into &quot;{target}&quot; anyway
+              {t('opponents.merge.anyway', { opponent, target })}
             </Button>
           </div>
         )}
 
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button type="button" disabled={!target || upsertAlias.isPending} onClick={handleConfirm}>
-            {upsertAlias.isPending ? 'Merging...' : 'Merge'}
+            {upsertAlias.isPending ? t('opponents.merge.merging') : t('opponents.merge.merge')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/pages/Opponents/components/MergedNamesCard.tsx
+++ b/apps/web/src/pages/Opponents/components/MergedNamesCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useDeleteOpponentAlias } from '@/hooks/useOpponentAliases';
@@ -16,6 +17,7 @@ export interface MergedNamesCardProps {
  * out into its own separate scouting identity.
  */
 export function MergedNamesCard({ canonical, aliases }: MergedNamesCardProps) {
+  const { t } = useTranslation();
   const deleteAlias = useDeleteOpponentAlias();
 
   if (aliases.length === 0) {
@@ -25,14 +27,11 @@ export function MergedNamesCard({ canonical, aliases }: MergedNamesCardProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Merged names</CardTitle>
-        <CardDescription>
-          These names are folded into &quot;{canonical}&quot;. Un-merge to track them separately
-          again.
-        </CardDescription>
+        <CardTitle>{t('opponents.merged.title')}</CardTitle>
+        <CardDescription>{t('opponents.merged.description', { name: canonical })}</CardDescription>
       </CardHeader>
       <CardContent>
-        <ul className="flex flex-col gap-2" role="list" aria-label="Merged names">
+        <ul className="flex flex-col gap-2" role="list" aria-label={t('opponents.merged.title')}>
           {aliases.map((alias) => (
             <li key={alias} className="flex items-center justify-between gap-2 text-sm">
               <span className="min-w-0 flex-1 truncate">{alias}</span>
@@ -43,7 +42,7 @@ export function MergedNamesCard({ canonical, aliases }: MergedNamesCardProps) {
                 disabled={deleteAlias.isPending}
                 onClick={() => deleteAlias.mutate(alias)}
               >
-                Un-merge
+                {t('opponents.merged.unmerge')}
               </Button>
             </li>
           ))}

--- a/apps/web/src/pages/Opponents/components/OpponentList.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentList.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MoreVertical, Search } from 'lucide-react';
 import type { Match } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -33,12 +34,12 @@ export interface OpponentListProps {
 /** Sort orders for the opponent list. */
 export type OpponentSort = 'most-played' | 'recent' | 'best-rate' | 'worst-rate' | 'alphabetical';
 
-const SORT_LABELS: Record<OpponentSort, string> = {
-  'most-played': 'Most played',
-  recent: 'Recently played',
-  'best-rate': 'Highest win rate',
-  'worst-rate': 'Lowest win rate',
-  alphabetical: 'A → Z',
+const SORT_LABEL_KEYS: Record<OpponentSort, string> = {
+  'most-played': 'opponents.list.sortMostPlayed',
+  recent: 'opponents.list.sortRecent',
+  'best-rate': 'opponents.list.sortBestRate',
+  'worst-rate': 'opponents.list.sortWorstRate',
+  alphabetical: 'opponents.list.sortAlphabetical',
 };
 
 /** Games threshold applied by the "3+ games" small-sample toggle. */
@@ -80,6 +81,7 @@ function sortOpponents(
  * kebab menu with a "Merge into..." action.
  */
 export function OpponentList({ matches, selected, onSelect, onRequestMerge }: OpponentListProps) {
+  const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<OpponentSort>('most-played');
   const [minGamesOnly, setMinGamesOnly] = useState(false);
@@ -117,9 +119,9 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
     <Card className="flex h-full flex-col">
       <CardHeader className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle>Opponents</CardTitle>
+          <CardTitle>{t('opponents.list.title')}</CardTitle>
           <span className="text-sm text-muted-foreground">
-            {opponents.length} opponent{opponents.length === 1 ? '' : 's'} faced
+            {t('opponents.list.faced', { count: opponents.length })}
           </span>
         </div>
         <div className="relative">
@@ -127,20 +129,20 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
           <Input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search opponents..."
-            aria-label="Search opponents"
+            placeholder={t('opponents.list.searchPlaceholder')}
+            aria-label={t('opponents.list.searchAria')}
             className="pl-8"
           />
         </div>
         <div className="flex items-center gap-2">
           <Select value={sort} onValueChange={(value) => setSort(value as OpponentSort)}>
-            <SelectTrigger className="h-8 flex-1" aria-label="Sort opponents">
+            <SelectTrigger className="h-8 flex-1" aria-label={t('opponents.list.sortAria')}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {(Object.keys(SORT_LABELS) as OpponentSort[]).map((key) => (
+              {(Object.keys(SORT_LABEL_KEYS) as OpponentSort[]).map((key) => (
                 <SelectItem key={key} value={key}>
-                  {SORT_LABELS[key]}
+                  {t(SORT_LABEL_KEYS[key])}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -150,9 +152,9 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
             variant="outline"
             pressed={minGamesOnly}
             onPressedChange={setMinGamesOnly}
-            aria-label="Only show opponents with 3 or more games"
+            aria-label={t('opponents.list.minGamesAria')}
           >
-            3+ games
+            {t('opponents.list.minGames')}
           </Toggle>
         </div>
       </CardHeader>
@@ -160,11 +162,11 @@ export function OpponentList({ matches, selected, onSelect, onRequestMerge }: Op
         {filtered.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             {opponents.length === 0
-              ? 'No opponents faced yet.'
-              : 'No opponents match your filters.'}
+              ? t('opponents.list.emptyNone')
+              : t('opponents.list.emptyFiltered')}
           </p>
         ) : (
-          <ul className="flex flex-col gap-1" role="list" aria-label="Opponents">
+          <ul className="flex flex-col gap-1" role="list" aria-label={t('opponents.list.title')}>
             {filtered.map((opponent) => (
               <OpponentRow
                 key={opponent.opponent}
@@ -199,6 +201,7 @@ function OpponentRow({
   onSelect: (opponent: string) => void;
   onRequestMerge: (opponent: string) => void;
 }) {
+  const { t, i18n } = useTranslation();
   return (
     <li
       className={`flex items-center gap-1 rounded-md border px-1 transition-colors ${
@@ -222,11 +225,11 @@ function OpponentRow({
           </span>
           <span className="font-medium">{opponent.winRate}%</span>
           <span className="text-xs text-muted-foreground">
-            {opponent.total} game{opponent.total === 1 ? '' : 's'}
+            {t('common.games', { count: opponent.total })}
           </span>
           {lastPlayedAt != null && (
             <span className="text-xs text-muted-foreground">
-              {new Date(lastPlayedAt).toLocaleDateString()}
+              {new Date(lastPlayedAt).toLocaleDateString(i18n.language)}
             </span>
           )}
         </span>
@@ -237,14 +240,14 @@ function OpponentRow({
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label={`Actions for ${opponent.opponent}`}
+            aria-label={t('opponents.list.rowActions', { name: opponent.opponent })}
           >
             <MoreVertical className="size-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={() => onRequestMerge(opponent.opponent)}>
-            Merge into...
+            {t('opponents.list.mergeInto')}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/pages/Opponents/components/OpponentSourceBadge.tsx
+++ b/apps/web/src/pages/Opponents/components/OpponentSourceBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Check } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { OpponentSource } from '@/hooks/useFilteredMatches';
@@ -13,21 +14,22 @@ import type { OpponentSource } from '@/hooks/useFilteredMatches';
  * state rather than adding a fourth dedicated combination.
  */
 export function OpponentSourceBadge({ source }: { source: OpponentSource }) {
+  const { t } = useTranslation();
   if (source === 'mixed') {
     return (
-      <span className="inline-flex items-center gap-1" aria-label="mixed sources">
+      <span className="inline-flex items-center gap-1" aria-label={t('opponents.source.mixedAria')}>
         <Badge variant="success" className="gap-0.5">
           <Check className="size-3" />
-          verified
+          {t('opponents.source.verified')}
         </Badge>
-        <Badge variant="outline">manual</Badge>
+        <Badge variant="outline">{t('opponents.source.manual')}</Badge>
       </span>
     );
   }
 
   if (source === 'startgg') {
     return (
-      <Badge variant="success" className="gap-0.5" aria-label="start.gg-verified">
+      <Badge variant="success" className="gap-0.5" aria-label={t('opponents.source.startggAria')}>
         <Check className="size-3" />
         start.gg
       </Badge>
@@ -36,7 +38,7 @@ export function OpponentSourceBadge({ source }: { source: OpponentSource }) {
 
   if (source === 'parrygg') {
     return (
-      <Badge variant="success" className="gap-0.5" aria-label="parry.gg-verified">
+      <Badge variant="success" className="gap-0.5" aria-label={t('opponents.source.parryggAria')}>
         <Check className="size-3" />
         parry.gg
       </Badge>
@@ -44,8 +46,8 @@ export function OpponentSourceBadge({ source }: { source: OpponentSource }) {
   }
 
   return (
-    <Badge variant="outline" aria-label="manually entered">
-      manual
+    <Badge variant="outline" aria-label={t('opponents.source.manualAria')}>
+      {t('opponents.source.manual')}
     </Badge>
   );
 }

--- a/apps/web/src/pages/Opponents/components/RecentEncounters.tsx
+++ b/apps/web/src/pages/Opponents/components/RecentEncounters.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import type { Match } from '@smash-tracker/shared';
@@ -11,16 +12,17 @@ import { stagesById } from '@/data/stages';
  * start.gg matches).
  */
 export function RecentEncounters({ matches }: { matches: Match[] }) {
+  const { t, i18n } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Recent Encounters</CardTitle>
+        <CardTitle>{t('opponents.encounters.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {matches.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No encounters recorded yet.</p>
+          <p className="text-sm text-muted-foreground">{t('opponents.encounters.empty')}</p>
         ) : (
-          <ul className="flex flex-col gap-2" aria-label="Recent encounters">
+          <ul className="flex flex-col gap-2" aria-label={t('opponents.encounters.aria')}>
             {matches.map((match) => {
               const fighterSprite = getFighterById(match.fighter_id);
               const opponentSprite = getFighterById(match.opponent_id);
@@ -37,7 +39,7 @@ export function RecentEncounters({ matches }: { matches: Match[] }) {
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-sm text-muted-foreground">
-                      {new Date(match.time).toLocaleDateString()}
+                      {new Date(match.time).toLocaleDateString(i18n.language)}
                     </span>
                     <div className="flex items-center gap-1">
                       {fighterSprite && (
@@ -47,7 +49,7 @@ export function RecentEncounters({ matches }: { matches: Match[] }) {
                           className="size-6 object-contain"
                         />
                       )}
-                      <span className="text-xs text-muted-foreground">vs</span>
+                      <span className="text-xs text-muted-foreground">{t('matchups.vs')}</span>
                       {opponentSprite && (
                         <img
                           src={opponentSprite.url}
@@ -62,7 +64,7 @@ export function RecentEncounters({ matches }: { matches: Match[] }) {
                     )}
                   </div>
                   <Badge variant={match.win ? 'success' : 'destructive'}>
-                    {match.win ? 'Win' : 'Loss'}
+                    {match.win ? t('common.win') : t('common.loss')}
                   </Badge>
                 </li>
               );

--- a/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingHeader.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WinLossPips } from '@/components/WinLossPips';
 import type { OpponentProfile } from '@/lib/stats';
@@ -5,22 +7,25 @@ import type { OpponentSource } from '@/hooks/useFilteredMatches';
 import type { EncounterContext } from '../tournamentHistory';
 import { OpponentSourceBadge } from './OpponentSourceBadge';
 
-function formatEncounterContext(context: EncounterContext): string | null {
+function formatEncounterContext(
+  context: EncounterContext,
+  t: TFunction,
+  locale: string,
+): string | null {
   if (context.tournamentCount === 0 || !context.span) {
     return null;
   }
   const count = context.tournamentCount;
-  const start = new Date(context.span.start).toLocaleDateString('en-US', {
+  const start = new Date(context.span.start).toLocaleDateString(locale, {
     month: 'short',
     year: 'numeric',
   });
-  const end = new Date(context.span.end).toLocaleDateString('en-US', {
+  const end = new Date(context.span.end).toLocaleDateString(locale, {
     month: 'short',
     year: 'numeric',
   });
-  const tournamentWord = count === 1 ? 'tournament' : 'tournaments';
-  const span = start === end ? start : `${start} and ${end}`;
-  return `Met at ${count} ${tournamentWord} between ${span}`;
+  const span = start === end ? start : t('opponents.header.encounterSpan', { start, end });
+  return t('opponents.header.metAt', { count, span });
 }
 
 /**
@@ -38,8 +43,9 @@ export function ScoutingHeader({
   encounterContext: EncounterContext;
   source: OpponentSource;
 }) {
+  const { t, i18n } = useTranslation();
   const { record } = profile;
-  const encounterLine = formatEncounterContext(encounterContext);
+  const encounterLine = formatEncounterContext(encounterContext, t, i18n.language);
 
   return (
     <Card>
@@ -50,8 +56,10 @@ export function ScoutingHeader({
             <OpponentSourceBadge source={source} />
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
-            First played {new Date(profile.firstPlayedAt).toLocaleDateString()} · Last played{' '}
-            {new Date(profile.lastPlayedAt).toLocaleDateString()}
+            {t('opponents.header.playedRange', {
+              first: new Date(profile.firstPlayedAt).toLocaleDateString(i18n.language),
+              last: new Date(profile.lastPlayedAt).toLocaleDateString(i18n.language),
+            })}
           </p>
           {encounterLine && <p className="mt-1 text-sm text-muted-foreground">{encounterLine}</p>}
         </div>
@@ -60,12 +68,14 @@ export function ScoutingHeader({
             {record.wins}-{record.losses}
           </p>
           <p className="text-sm text-muted-foreground">
-            {record.winRate}% over {record.total} game{record.total === 1 ? '' : 's'}
+            {t('opponents.header.rateOverGames', { rate: record.winRate, count: record.total })}
           </p>
         </div>
       </CardHeader>
       <CardContent>
-        <h3 className="mb-2 text-sm font-medium text-muted-foreground">Last 10 (newest first)</h3>
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+          {t('fighterAnalysis.hero.last10')}
+        </h3>
         <WinLossPips matches={profile.recent} limit={10} />
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Opponents/components/ScoutingStagesCard.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingStagesCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -14,23 +15,24 @@ const MAX_STAGES = 6;
 
 /** Stages this opponent takes you to most, sorted by sample size, top 6. */
 export function ScoutingStagesCard({ byStage }: { byStage: StageRecord[] }) {
+  const { t } = useTranslation();
   const top = byStage.slice(0, MAX_STAGES);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Stages</CardTitle>
+        <CardTitle>{t('opponents.stages.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {top.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No stage data recorded yet.</p>
+          <p className="text-sm text-muted-foreground">{t('opponents.stages.empty')}</p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Stage</TableHead>
-                <TableHead>Record</TableHead>
-                <TableHead className="text-right">Win Rate</TableHead>
+                <TableHead>{t('matchups.stageTable.stage')}</TableHead>
+                <TableHead>{t('matchups.stageTable.record')}</TableHead>
+                <TableHead className="text-right">{t('matchups.stageTable.winRate')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -39,7 +41,7 @@ export function ScoutingStagesCard({ byStage }: { byStage: StageRecord[] }) {
                   <TableCell>
                     {record.stageId === 0
                       ? 'unknown'
-                      : (stagesById.get(record.stageId)?.name ?? 'Unknown')}
+                      : (stagesById.get(record.stageId)?.name ?? t('common.unknown'))}
                   </TableCell>
                   <TableCell>
                     {record.wins}-{record.losses}

--- a/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
+++ b/apps/web/src/pages/Opponents/components/ScoutingTrendChart.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -25,37 +27,32 @@ const ROLLING_WINDOW = 5;
  * e.g. the Scout page's "Full analysis" section, where `matches` is a
  * scouted player's OWN game history rather than a head-to-head slice.
  */
-export function ScoutingTrendChart({
-  matches,
-  title = 'H2H Trend',
-}: {
-  matches: Match[];
-  title?: string;
-}) {
+export function ScoutingTrendChart({ matches, title }: { matches: Match[]; title?: string }) {
+  const { t, i18n } = useTranslation();
   const series = getRollingWinRate(matches, ROLLING_WINDOW);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
+        <CardTitle>{title ?? t('opponents.trend.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {series.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Not enough matches for a trend yet.</p>
+          <p className="text-sm text-muted-foreground">{t('opponents.trend.empty')}</p>
         ) : (
-          <Line data={buildData(series)} options={buildOptions(series)} />
+          <Line data={buildData(series, t)} options={buildOptions(series, i18n.language)} />
         )}
       </CardContent>
     </Card>
   );
 }
 
-function buildData(series: ReturnType<typeof getRollingWinRate>) {
+function buildData(series: ReturnType<typeof getRollingWinRate>, t: TFunction) {
   return {
     labels: series.map((point) => point.index.toString()),
     datasets: [
       {
-        label: `Rolling win rate (last ${ROLLING_WINDOW})`,
+        label: t('opponents.trend.label', { count: ROLLING_WINDOW }),
         ...redLineDataset(),
         data: series.map((point) => point.winRate),
       },
@@ -63,7 +60,10 @@ function buildData(series: ReturnType<typeof getRollingWinRate>) {
   };
 }
 
-function buildOptions(series: ReturnType<typeof getRollingWinRate>): ChartOptions<'line'> {
+function buildOptions(
+  series: ReturnType<typeof getRollingWinRate>,
+  locale: string,
+): ChartOptions<'line'> {
   const theme = darkChartOptions();
   return {
     scales: {
@@ -88,7 +88,7 @@ function buildOptions(series: ReturnType<typeof getRollingWinRate>): ChartOption
           title: (items) => {
             const point = series[items[0]?.dataIndex ?? -1];
             if (!point) return '';
-            return new Date(point.match.time).toLocaleDateString('en-US');
+            return new Date(point.match.time).toLocaleDateString(locale);
           },
           label: (item) => `: ${Math.round(Number(item.formattedValue) * 100) / 100}%`,
         },

--- a/apps/web/src/pages/Opponents/components/TendenciesCard.tsx
+++ b/apps/web/src/pages/Opponents/components/TendenciesCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -44,6 +45,7 @@ function draftFromNote(note: OpponentNote | undefined): DraftState {
  * reset in-progress edit state from a prop change.
  */
 export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
+  const { t, i18n } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<DraftState>(() => draftFromNote(note));
   const upsertNote = useUpsertOpponentNote();
@@ -91,19 +93,17 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Tendencies</CardTitle>
-        <CardDescription>
-          Your own scouting notes for this opponent — not derived from match history.
-        </CardDescription>
+        <CardTitle>{t('opponents.tendencies.title')}</CardTitle>
+        <CardDescription>{t('opponents.tendencies.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {editing ? (
           <>
             <div className="flex flex-col gap-2">
-              <Label htmlFor="tendencies-habits">Habits</Label>
+              <Label htmlFor="tendencies-habits">{t('opponents.tendencies.habits')}</Label>
               <Textarea
                 id="tendencies-habits"
-                placeholder="Opening habits, punish routes, recovery mixups..."
+                placeholder={t('opponents.tendencies.habitsPlaceholder')}
                 value={draft.habits}
                 maxLength={OPPONENT_NOTE_TEXT_MAX_LENGTH}
                 onChange={(e) => setDraft((d) => ({ ...d, habits: e.target.value }))}
@@ -112,7 +112,9 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label>Ban these (max {OPPONENT_NOTE_BAN_STAGES_MAX})</Label>
+              <Label>
+                {t('opponents.tendencies.banThese', { count: OPPONENT_NOTE_BAN_STAGES_MAX })}
+              </Label>
               <ToggleGroup
                 type="multiple"
                 variant="outline"
@@ -124,7 +126,7 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
                   }
                   setDraft((d) => ({ ...d, banThese: ids }));
                 }}
-                aria-label="Stages to ban against this opponent"
+                aria-label={t('opponents.tendencies.banAria')}
                 className="flex-wrap justify-start gap-2"
               >
                 {banStageOptions.map((stage) => (
@@ -141,10 +143,10 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="tendencies-watch-for">Watch for</Label>
+              <Label htmlFor="tendencies-watch-for">{t('opponents.tendencies.watchFor')}</Label>
               <Textarea
                 id="tendencies-watch-for"
-                placeholder="Reads, mind games, tech chases to expect next set..."
+                placeholder={t('opponents.tendencies.watchForPlaceholder')}
                 value={draft.watchFor}
                 maxLength={OPPONENT_NOTE_TEXT_MAX_LENGTH}
                 onChange={(e) => setDraft((d) => ({ ...d, watchFor: e.target.value }))}
@@ -154,10 +156,10 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
 
             <div className="flex flex-wrap items-center gap-2">
               <Button type="button" onClick={handleSave} disabled={upsertNote.isPending}>
-                {upsertNote.isPending ? 'Saving...' : 'Save'}
+                {upsertNote.isPending ? t('opponents.tendencies.saving') : t('common.save')}
               </Button>
               <Button type="button" variant="outline" onClick={cancelEditing}>
-                Cancel
+                {t('common.cancel')}
               </Button>
               {hasContent && (
                 <Button
@@ -167,7 +169,7 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
                   disabled={deleteNote.isPending}
                   onClick={handleClear}
                 >
-                  Delete note
+                  {t('opponents.tendencies.deleteNote')}
                 </Button>
               )}
             </div>
@@ -176,14 +178,21 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
           <>
             {note?.habits && (
               <div>
-                <h4 className="text-sm font-medium text-muted-foreground">Habits</h4>
+                <h4 className="text-sm font-medium text-muted-foreground">
+                  {t('opponents.tendencies.habits')}
+                </h4>
                 <p className="whitespace-pre-wrap text-sm">{note.habits}</p>
               </div>
             )}
             {note?.banThese && note.banThese.length > 0 && (
               <div>
-                <h4 className="mb-1 text-sm font-medium text-muted-foreground">Ban these</h4>
-                <ul className="flex flex-wrap gap-2" aria-label="Stages to ban">
+                <h4 className="mb-1 text-sm font-medium text-muted-foreground">
+                  {t('opponents.tendencies.banTheseView')}
+                </h4>
+                <ul
+                  className="flex flex-wrap gap-2"
+                  aria-label={t('opponents.tendencies.banViewAria')}
+                >
                   {note.banThese.map((stageId) => {
                     const stage = alphaStageList.find((s) => s.id === stageId);
                     if (!stage) {
@@ -200,29 +209,30 @@ export function TendenciesCard({ opponent, note }: TendenciesCardProps) {
             )}
             {note?.watchFor && (
               <div>
-                <h4 className="text-sm font-medium text-muted-foreground">Watch for</h4>
+                <h4 className="text-sm font-medium text-muted-foreground">
+                  {t('opponents.tendencies.watchFor')}
+                </h4>
                 <p className="whitespace-pre-wrap text-sm">{note.watchFor}</p>
               </div>
             )}
             <div className="flex items-center justify-between gap-2">
               {note?.updatedAt && (
                 <p className="text-xs text-muted-foreground">
-                  Saved {new Date(note.updatedAt).toLocaleString()}
+                  {t('opponents.tendencies.savedAt', {
+                    date: new Date(note.updatedAt).toLocaleString(i18n.language),
+                  })}
                 </p>
               )}
               <Button type="button" variant="outline" size="sm" onClick={startEditing}>
-                Edit
+                {t('opponents.tendencies.edit')}
               </Button>
             </div>
           </>
         ) : (
           <div className="flex flex-col items-center gap-3 py-6 text-center">
-            <p className="text-sm text-muted-foreground">
-              No scouting notes yet. Jot down habits, stages to ban, or things to watch for before
-              your next set.
-            </p>
+            <p className="text-sm text-muted-foreground">{t('opponents.tendencies.empty')}</p>
             <Button type="button" onClick={startEditing}>
-              Add a note
+              {t('opponents.tendencies.addNote')}
             </Button>
           </div>
         )}

--- a/apps/web/src/pages/Opponents/components/TournamentHistory.tsx
+++ b/apps/web/src/pages/Opponents/components/TournamentHistory.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import type { TournamentEntry } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -8,17 +9,17 @@ import {
   type TournamentSet,
 } from '../tournamentHistory';
 
-function formatDate(time: number): string {
-  return new Date(time).toLocaleDateString('en-US', {
+function formatDate(time: number, locale: string): string {
+  return new Date(time).toLocaleDateString(locale, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
 }
 
-function formatDateRange(startTime: number, endTime: number): string {
-  const start = formatDate(startTime);
-  const end = formatDate(endTime);
+function formatDateRange(startTime: number, endTime: number, locale: string): string {
+  const start = formatDate(startTime, locale);
+  const end = formatDate(endTime, locale);
   return start === end ? start : `${start} – ${end}`;
 }
 
@@ -27,14 +28,15 @@ function formatDateRange(startTime: number, endTime: number): string {
  * and a tooltip (native `title`) with the full stage name + date + result.
  */
 function GameChips({ games }: { games: TournamentSet['games'] }) {
+  const { t, i18n } = useTranslation();
   return (
-    <div className="flex flex-wrap gap-1" aria-label="Games">
+    <div className="flex flex-wrap gap-1" aria-label={t('opponents.history.gamesAria')}>
       {games.map((game) => (
         <span
           key={game.match.id}
-          title={`${game.stageName} — ${game.win ? 'Win' : 'Loss'} — ${new Date(
+          title={`${game.stageName} — ${game.win ? t('common.win') : t('common.loss')} — ${new Date(
             game.match.time,
-          ).toLocaleDateString()}`}
+          ).toLocaleDateString(i18n.language)}`}
           className={`inline-flex size-7 items-center justify-center rounded text-[10px] font-semibold ${
             game.win
               ? 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400'
@@ -49,6 +51,7 @@ function GameChips({ games }: { games: TournamentSet['games'] }) {
 }
 
 function SetRow({ set }: { set: TournamentSet }) {
+  const { t } = useTranslation();
   return (
     <li
       className={`flex flex-wrap items-center justify-between gap-3 rounded-md border p-2 ${
@@ -60,7 +63,7 @@ function SetRow({ set }: { set: TournamentSet }) {
           {set.roundLabel}
           {set.isLosersSide && (
             <Badge variant="destructive" className="ml-2 align-middle">
-              Losers
+              {t('opponents.history.losers')}
             </Badge>
           )}
         </span>
@@ -80,6 +83,7 @@ function TournamentBlockCard({
   block: TournamentBlock;
   registryEntry: TournamentEntry | null;
 }) {
+  const { t, i18n } = useTranslation();
   const title = block.displayName;
   return (
     <div className="rounded-lg border">
@@ -96,14 +100,17 @@ function TournamentBlockCard({
             <span className="font-semibold">{title}</span>
           )}
           <p className="text-xs text-muted-foreground">
-            {formatDateRange(block.startTime, block.endTime)}
+            {formatDateRange(block.startTime, block.endTime, i18n.language)}
           </p>
         </div>
         <span className="text-sm font-semibold">
-          {block.wins}-{block.losses} vs them here
+          {t('opponents.history.vsThemHere', { wins: block.wins, losses: block.losses })}
         </span>
       </div>
-      <ul className="flex flex-col gap-2 p-3" aria-label={`Sets vs them at ${title}`}>
+      <ul
+        className="flex flex-col gap-2 p-3"
+        aria-label={t('opponents.history.setsAria', { title })}
+      >
         {block.sets.map((set) => (
           <SetRow key={set.setId} set={set} />
         ))}
@@ -126,16 +133,15 @@ export function TournamentHistory({
   blocks: TournamentBlock[];
   tournamentEntries: TournamentEntry[];
 }) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Tournament History</CardTitle>
+        <CardTitle>{t('opponents.history.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         {blocks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No tournament sets vs this player yet — resync start.gg if you&apos;ve played recently.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('opponents.history.empty')}</p>
         ) : (
           <div className="flex flex-col gap-4">
             {blocks.map((block) => (

--- a/apps/web/src/pages/Opponents/components/WhatTheyPlayTable.tsx
+++ b/apps/web/src/pages/Opponents/components/WhatTheyPlayTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -16,23 +17,24 @@ import { getFighterById } from '@/data/sprites';
  * reliably win sit at the top.
  */
 export function WhatTheyPlayTable({ byTheirFighter }: { byTheirFighter: RankedMatchup[] }) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>What They Play</CardTitle>
-        <CardDescription>Ordered by how reliably you beat it.</CardDescription>
+        <CardTitle>{t('opponents.whatTheyPlay.title')}</CardTitle>
+        <CardDescription>{t('opponents.whatTheyPlay.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {byTheirFighter.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No characters recorded yet.</p>
+          <p className="text-sm text-muted-foreground">{t('opponents.whatTheyPlay.empty')}</p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Character</TableHead>
-                <TableHead>Record</TableHead>
-                <TableHead>Win Rate</TableHead>
-                <TableHead className="text-right">Games</TableHead>
+                <TableHead>{t('opponents.whatTheyPlay.character')}</TableHead>
+                <TableHead>{t('matchups.stageTable.record')}</TableHead>
+                <TableHead>{t('matchups.stageTable.winRate')}</TableHead>
+                <TableHead className="text-right">{t('trends.monthly.games')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -45,7 +47,7 @@ export function WhatTheyPlayTable({ byTheirFighter }: { byTheirFighter: RankedMa
                         {sprite && (
                           <img src={sprite.url} alt="" className="size-6 object-contain" />
                         )}
-                        <span>{sprite?.name ?? 'Unknown'}</span>
+                        <span>{sprite?.name ?? t('common.unknown')}</span>
                       </div>
                     </TableCell>
                     <TableCell>

--- a/apps/web/src/pages/Reports/ReportsPage.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
 import { scoutIdentityKey, type ScoutReportRecord } from '@smash-tracker/shared';
 import { useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
@@ -52,6 +53,7 @@ function ReportGroupRow({
   selectedId: string | null;
   onSelect: (record: ScoutReportRecord) => void;
 }) {
+  const { t, i18n } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const newest = group.reports[0];
   if (!newest) {
@@ -70,7 +72,7 @@ function ReportGroupRow({
           <span className="font-medium">{group.gamerTag}</span>
           <span className="text-xs text-muted-foreground">{sourceLabel(group.source)}</span>
           <span className="ml-auto text-xs text-muted-foreground">
-            {new Date(newest.createdAt).toLocaleDateString()}
+            {new Date(newest.createdAt).toLocaleDateString(i18n.language)}
           </span>
         </Button>
         {group.reports.length > 1 && (
@@ -80,7 +82,7 @@ function ReportGroupRow({
             size="icon"
             className="size-8 shrink-0"
             onClick={() => setExpanded((v) => !v)}
-            aria-label={expanded ? 'Hide older reports' : 'Show older reports'}
+            aria-label={expanded ? t('reports.hideOlder') : t('reports.showOlder')}
             aria-expanded={expanded}
           >
             {expanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
@@ -97,9 +99,9 @@ function ReportGroupRow({
                 className="h-auto w-full justify-between px-2 py-1.5 font-normal"
                 onClick={() => onSelect(record)}
               >
-                <span className="text-sm text-muted-foreground">Older report</span>
+                <span className="text-sm text-muted-foreground">{t('reports.olderReport')}</span>
                 <span className="text-xs text-muted-foreground">
-                  {new Date(record.createdAt).toLocaleDateString()}
+                  {new Date(record.createdAt).toLocaleDateString(i18n.language)}
                 </span>
               </Button>
             </li>
@@ -130,6 +132,7 @@ function ReportGroupRow({
  * generated yet", which shows the ordinary empty state).
  */
 export function ReportsPage() {
+  const { t } = useTranslation();
   const reportsConfig = useReportsConfig();
   const reportsList = useScoutReportsList();
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -142,36 +145,35 @@ export function ReportsPage() {
     <div className="mx-auto flex max-w-3xl flex-col gap-6">
       <div className="flex items-center gap-2">
         <Sparkles className="size-6 text-primary" />
-        <h1 className="text-2xl font-semibold tracking-tight">AI Reports</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('reports.title')}</h1>
       </div>
 
       {reportsConfig.isSuccess && !enabled && (
         <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-          AI reports aren't enabled for this account yet.
+          {t('reports.notEnabled')}
         </div>
       )}
 
       {enabled && (
         <>
           {reportsList.isLoading && (
-            <p className="text-sm text-muted-foreground">Loading your reports…</p>
+            <p className="text-sm text-muted-foreground">{t('reports.loading')}</p>
           )}
 
           {reportsList.isSuccess && groups.length === 0 && (
             <div className="rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
-              No AI scouting reports yet. Generate one from the{' '}
-              <a href="/scout" className="underline">
-                Scout a Player
-              </a>{' '}
-              page.
+              <Trans
+                i18nKey="reports.empty"
+                components={{ scoutLink: <a href="/scout" className="underline" /> }}
+              />
             </div>
           )}
 
           {groups.length > 0 && (
             <Card>
               <CardHeader>
-                <CardTitle>Your Reports</CardTitle>
-                <CardDescription>Grouped by player, most recently scouted first.</CardDescription>
+                <CardTitle>{t('reports.yourReports')}</CardTitle>
+                <CardDescription>{t('reports.groupedBy')}</CardDescription>
               </CardHeader>
               <CardContent className="flex flex-col gap-3">
                 {groups.map((group) => (

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -30,16 +32,16 @@ import { ScoutReportHistorySelector } from './components/ScoutReportHistorySelec
 import { ScoutPastReportsCard } from './components/ScoutPastReportsCard';
 import { BuyCreditsDialog } from '@/components/billing/BuyCreditsDialog';
 
-function describeError(error: unknown, fallback: string): string {
+function describeError(error: unknown, fallback: string, t: TFunction): string {
   if (error instanceof ApiError) {
     if (error.status === 404) {
-      return "We couldn't find a start.gg player for that query. Double-check the URL, slug, or player id.";
+      return t('scout.errors.notFound');
     }
     if (error.status === 400) {
-      return error.message || "That doesn't look like a start.gg profile URL, slug, or player id.";
+      return error.message || t('scout.errors.badQuery');
     }
     if (error.status === 429) {
-      return 'start.gg is rate-limiting requests right now. Try again in a minute.';
+      return t('scout.errors.rateLimited');
     }
     return error.message || fallback;
   }
@@ -92,6 +94,7 @@ function formatUsd(amountCents: number): string {
  * a few seconds since webhook delivery can lag the redirect.
  */
 export function ScoutPage() {
+  const { t } = useTranslation();
   const scout = useScoutPlayer();
   const { data: matches = [] } = useMatches();
   const reportsConfig = useReportsConfig();
@@ -141,7 +144,7 @@ export function ScoutPage() {
     }
     announcedBilling.current = true;
     if (outcome === 'success') {
-      toast.success("Payment received — your credits will land shortly if they haven't already.");
+      toast.success(t('scout.billing.paymentReceived'));
       let attempts = 0;
       const poll = setInterval(() => {
         attempts += 1;
@@ -151,7 +154,7 @@ export function ScoutPage() {
         }
       }, CREDITS_POLL_INTERVAL_MS);
     } else if (outcome === 'cancelled') {
-      toast('Checkout cancelled — no charge was made.');
+      toast(t('scout.billing.checkoutCancelled'));
     }
     setSearchParams({}, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- credits.refetch is stable per render but not a dep we want to re-trigger this effect on
@@ -237,7 +240,7 @@ export function ScoutPage() {
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Scout a Player</h1>
+      <h1 className="text-2xl font-semibold tracking-tight">{t('scout.title')}</h1>
 
       <ScoutSearchForm
         onSubmit={handleSubmit}
@@ -247,7 +250,7 @@ export function ScoutPage() {
 
       {scout.isError && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-          {describeError(scout.error, 'Something went wrong while scouting that player.')}
+          {describeError(scout.error, t('scout.errors.scoutFallback'), t)}
         </div>
       )}
 
@@ -266,15 +269,17 @@ export function ScoutPage() {
                 >
                   <Sparkles className={generateReport.isPending ? 'animate-spin' : ''} />
                   {generateReport.isPending
-                    ? 'Generating report…'
+                    ? t('scout.report.generating')
                     : displayedRecord
-                      ? 'Regenerate report'
-                      : 'Generate AI report'}
+                      ? t('scout.report.regenerate')
+                      : t('scout.report.generate')}
                 </Button>
 
                 {(freeAccess || creditsData) && (
                   <span className="text-sm text-muted-foreground">
-                    {freeAccess ? 'Free access' : `${creditsData?.balance ?? 0} credits`}
+                    {freeAccess
+                      ? t('scout.billing.freeAccess')
+                      : t('scout.billing.credits', { count: creditsData?.balance ?? 0 })}
                   </span>
                 )}
                 {canBuyCredits && (
@@ -284,7 +289,7 @@ export function ScoutPage() {
                     className="h-auto p-0 text-sm"
                     onClick={() => setBuyCreditsOpen(true)}
                   >
-                    Buy credits
+                    {t('scout.billing.buyCredits')}
                   </Button>
                 )}
               </div>
@@ -292,32 +297,35 @@ export function ScoutPage() {
                   the button, so the pricing is visible before checkout. */}
               {canBuyCredits && (
                 <p className="text-sm text-muted-foreground">
-                  Each report costs 1 credit.{' '}
+                  {t('scout.billing.costLine')}{' '}
                   {availablePacks
-                    .map((pack) => `${pack.label} for ${formatUsd(pack.amountCents)}`)
+                    .map((pack) =>
+                      t('scout.billing.packFor', {
+                        label: pack.label,
+                        price: formatUsd(pack.amountCents),
+                      }),
+                    )
                     .join(' · ')}
                   .
                 </p>
               )}
               {generateReport.isPending && (
-                <p className="text-sm text-muted-foreground">
-                  Generating report — this usually takes a minute or two.
-                </p>
+                <p className="text-sm text-muted-foreground">{t('scout.report.generatingHint')}</p>
               )}
               {/* A 402 auto-opens the buy dialog; this leaves a persistent cue
                   after it's dismissed rather than a scary red error. */}
               {lastGenerateWas402 && canBuyCredits && !generateReport.isPending && (
                 <p className="text-sm text-muted-foreground">
-                  You're out of credits.{' '}
+                  {t('scout.billing.outOfCredits')}{' '}
                   <Button
                     type="button"
                     variant="link"
                     className="h-auto p-0 text-sm"
                     onClick={() => setBuyCreditsOpen(true)}
                   >
-                    Buy a pack
+                    {t('scout.billing.buyPack')}
                   </Button>{' '}
-                  to generate this report.
+                  {t('scout.billing.toGenerate')}
                 </p>
               )}
               {generateReport.isError &&
@@ -325,10 +333,7 @@ export function ScoutPage() {
                   generateReport.error instanceof ApiError && generateReport.error.status === 402
                 ) && (
                   <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-                    {describeError(
-                      generateReport.error,
-                      'Something went wrong while generating the report.',
-                    )}
+                    {describeError(generateReport.error, t('scout.errors.generateFallback'), t)}
                   </div>
                 )}
             </div>
@@ -378,9 +383,7 @@ export function ScoutPage() {
 
       {!report && !selectedRecord && !scout.isError && !scout.isPending && (
         <div className="flex items-center justify-center rounded-lg border border-dashed p-16 text-center text-sm text-muted-foreground">
-          {parryggEnabled
-            ? 'Paste a start.gg or parry.gg profile URL, slug/tag, or player id above to pull up their public tournament history.'
-            : 'Paste a start.gg profile URL, slug, or player id above to pull up their public tournament history.'}
+          {parryggEnabled ? t('scout.promptWithParry') : t('scout.prompt')}
         </div>
       )}
 

--- a/apps/web/src/pages/Scout/components/FullAnalysisSection.tsx
+++ b/apps/web/src/pages/Scout/components/FullAnalysisSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
 import type { ScoutGame } from '@smash-tracker/shared';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -32,6 +33,7 @@ export function FullAnalysisSection({
   games: ScoutGame[] | undefined;
   gamerTag: string;
 }) {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
   return (
@@ -41,7 +43,7 @@ export function FullAnalysisSection({
           type="button"
           className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
         >
-          <span>Full analysis</span>
+          <span>{t('scout.fullAnalysis.title')}</span>
           <ChevronDown
             className={cn('size-4 shrink-0 transition-transform', open && 'rotate-180')}
             aria-hidden="true"
@@ -54,8 +56,8 @@ export function FullAnalysisSection({
         ) : (
           <p className="text-sm text-muted-foreground">
             {games === undefined
-              ? 'Re-scout to enable full analysis.'
-              : 'No per-game data available from this source yet.'}
+              ? t('scout.fullAnalysis.rescout')
+              : t('scout.fullAnalysis.noGameData')}
           </p>
         )}
       </CollapsibleContent>
@@ -66,6 +68,7 @@ export function FullAnalysisSection({
 const MIN_MATCHUP_GAMES = 3;
 
 function FullAnalysisContent({ games, gamerTag }: { games: ScoutGame[]; gamerTag: string }) {
+  const { t } = useTranslation();
   const matches = scoutGamesToMatches(games);
 
   // "Their top character" — the character with the most sampled games,
@@ -92,18 +95,23 @@ function FullAnalysisContent({ games, gamerTag }: { games: ScoutGame[]; gamerTag
 
   return (
     <>
-      <StageMastery fighterMatches={matches} title="Stage Mastery — Overall" />
+      <StageMastery fighterMatches={matches} title={t('scout.fullAnalysis.stageMasteryOverall')} />
 
       {showTopCharacterCard && (
         <StageMastery
           fighterMatches={topCharacterMatches}
-          title={`Stage Mastery — ${topCharacterSprite?.name ?? 'Top character'}`}
+          title={t('scout.fullAnalysis.stageMasteryFor', {
+            name: topCharacterSprite?.name ?? t('scout.fullAnalysis.topCharacter'),
+          })}
         />
       )}
 
       <WhatTheyPlayTable byTheirFighter={matchupSpread} />
 
-      <ScoutingTrendChart matches={matches} title={`${gamerTag}'s Recent Form`} />
+      <ScoutingTrendChart
+        matches={matches}
+        title={t('scout.fullAnalysis.recentForm', { name: gamerTag })}
+      />
 
       <OpponentTable fighterMatches={matches} />
     </>

--- a/apps/web/src/pages/Scout/components/ScoutAiReportCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutAiReportCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Download, Printer, Sparkles } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -37,6 +38,7 @@ function downloadMarkdown(record: ScoutReportRecord) {
  *   when absent rather than rendering an empty section.
  */
 export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
+  const { t } = useTranslation();
   const { report } = record;
 
   return (
@@ -45,11 +47,11 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Sparkles className="size-4 text-primary" />
-            AI Scouting Report
+            {t('scout.aiReport.title')}
           </CardTitle>
           <CardDescription>{report.overview}</CardDescription>
           <p className="text-xs text-muted-foreground">
-            Generated {formatRelativeDate(record.createdAt)}
+            {t('scout.aiReport.generated', { rel: formatRelativeDate(record.createdAt, t) })}
           </p>
         </CardHeader>
         <CardContent className="flex flex-col gap-5">
@@ -61,16 +63,16 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
               onClick={() => downloadMarkdown(record)}
             >
               <Download />
-              Download (.md)
+              {t('scout.aiReport.download')}
             </Button>
             <Button type="button" variant="outline" size="sm" onClick={() => window.print()}>
               <Printer />
-              Print / Save as PDF
+              {t('scout.aiReport.print')}
             </Button>
           </div>
 
           <div className="flex flex-col gap-2">
-            <h3 className="text-sm font-semibold">Game plan</h3>
+            <h3 className="text-sm font-semibold">{t('scout.aiReport.gameplan')}</h3>
             <ul className="list-disc space-y-1 pl-5 text-sm">
               {report.gameplan.map((item, index) => (
                 <li key={index}>{item}</li>
@@ -80,11 +82,11 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
 
           {report.characterStrategy && (
             <div className="flex flex-col gap-2">
-              <h3 className="text-sm font-semibold">Character strategy</h3>
+              <h3 className="text-sm font-semibold">{t('scout.aiReport.characterStrategy')}</h3>
               <div className="flex flex-col gap-2 text-sm">
                 {report.characterStrategy.picks.length > 0 && (
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-muted-foreground">Picks:</span>
+                    <span className="text-muted-foreground">{t('scout.aiReport.picks')}</span>
                     {report.characterStrategy.picks.map((character) => (
                       <Badge key={character} variant="success">
                         {character}
@@ -98,11 +100,11 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
           )}
 
           <div className="flex flex-col gap-2">
-            <h3 className="text-sm font-semibold">Stage strategy</h3>
+            <h3 className="text-sm font-semibold">{t('scout.aiReport.stageStrategy')}</h3>
             <div className="flex flex-col gap-2 text-sm">
               {report.stageStrategy.bans.length > 0 && (
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-muted-foreground">Bans:</span>
+                  <span className="text-muted-foreground">{t('scout.aiReport.bans')}</span>
                   {report.stageStrategy.bans.map((stage) => (
                     <Badge key={stage} variant="destructive">
                       {stage}
@@ -112,7 +114,7 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
               )}
               {report.stageStrategy.picks.length > 0 && (
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-muted-foreground">Picks:</span>
+                  <span className="text-muted-foreground">{t('scout.aiReport.picks')}</span>
                   {report.stageStrategy.picks.map((stage) => (
                     <Badge key={stage} variant="success">
                       {stage}
@@ -126,13 +128,13 @@ export function ScoutAiReportCard({ record }: { record: ScoutReportRecord }) {
 
           {report.headToHead && (
             <div className="flex flex-col gap-2">
-              <h3 className="text-sm font-semibold">Head-to-head</h3>
+              <h3 className="text-sm font-semibold">{t('scout.aiReport.headToHead')}</h3>
               <p className="text-sm text-muted-foreground">{report.headToHead}</p>
             </div>
           )}
 
           <div className="flex flex-col gap-2">
-            <h3 className="text-sm font-semibold">Watch for</h3>
+            <h3 className="text-sm font-semibold">{t('scout.aiReport.watchFor')}</h3>
             <ul className="list-disc space-y-1 pl-5 text-sm">
               {report.watchFor.map((item, index) => (
                 <li key={index}>{item}</li>

--- a/apps/web/src/pages/Scout/components/ScoutCharactersCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutCharactersCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Table,
@@ -14,24 +15,25 @@ const MAX_ROWS = 8;
 
 /** The scouted player's most-used characters (sprite + games + win rate). */
 export function ScoutCharactersCard({ characters }: { characters: ScoutCharacterUsage[] }) {
+  const { t } = useTranslation();
   const top = characters.slice(0, MAX_ROWS);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Character Usage</CardTitle>
-        <CardDescription>What they play, most-used first.</CardDescription>
+        <CardTitle>{t('scout.characters.title')}</CardTitle>
+        <CardDescription>{t('scout.characters.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {top.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No sampled games yet.</p>
+          <p className="text-sm text-muted-foreground">{t('scout.characters.empty')}</p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Character</TableHead>
-                <TableHead className="text-right">Win Rate</TableHead>
-                <TableHead className="text-right">Games</TableHead>
+                <TableHead>{t('opponents.whatTheyPlay.character')}</TableHead>
+                <TableHead className="text-right">{t('matchups.stageTable.winRate')}</TableHead>
+                <TableHead className="text-right">{t('trends.monthly.games')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -49,7 +51,7 @@ export function ScoutCharactersCard({ characters }: { characters: ScoutCharacter
                             ?
                           </span>
                         )}
-                        <span>{sprite?.name ?? 'Unknown'}</span>
+                        <span>{sprite?.name ?? t('common.unknown')}</span>
                       </div>
                     </TableCell>
                     <TableCell className="text-right">{winRate}%</TableCell>

--- a/apps/web/src/pages/Scout/components/ScoutCommonOpponentsCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutCommonOpponentsCard.tsx
@@ -1,24 +1,26 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ScoutCommonOpponent } from '@smash-tracker/shared';
 
 /** Opponents the scouted player has faced most often in the sampled sets. */
 export function ScoutCommonOpponentsCard({ opponents }: { opponents: ScoutCommonOpponent[] }) {
+  const { t } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Common Opponents</CardTitle>
-        <CardDescription>Who they run into most, in the sampled sets.</CardDescription>
+        <CardTitle>{t('scout.commonOpponents.title')}</CardTitle>
+        <CardDescription>{t('scout.commonOpponents.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {opponents.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No repeat opponents in the sample.</p>
+          <p className="text-sm text-muted-foreground">{t('scout.commonOpponents.empty')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {opponents.map((opponent) => (
               <li key={opponent.gamerTag} className="flex items-center justify-between gap-2">
                 <span className="text-sm">{opponent.gamerTag}</span>
                 <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
-                  {opponent.sets} set{opponent.sets === 1 ? '' : 's'}
+                  {t('scout.commonOpponents.sets', { count: opponent.sets })}
                 </span>
               </li>
             ))}

--- a/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutMatchupAdvisorCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Swords } from 'lucide-react';
 import type {
   Match,
@@ -20,21 +21,18 @@ interface AdvisorRow {
   worst: MatchupPick | null;
 }
 
-function fighterLabel(fighterId: number): string {
-  return getFighterById(fighterId)?.name ?? 'Unknown';
-}
-
 function PickChip({ pick, tone }: { pick: MatchupPick; tone: 'best' | 'worst' }) {
+  const { t } = useTranslation();
   const sprite = getFighterById(pick.fighterId);
   const evidenceParts: string[] = [];
   if (pick.evidence.record) {
-    evidenceParts.push(`${pick.evidence.record} in your sets`);
+    evidenceParts.push(t('scout.advisor.inYourSets', { record: pick.evidence.record }));
   }
-  evidenceParts.push(`tier ${pick.evidence.tierScore.toFixed(1)}/10`);
+  evidenceParts.push(t('scout.advisor.tier', { score: pick.evidence.tierScore.toFixed(1) }));
   if (pick.evidence.archetypeEdge > 0) {
-    evidenceParts.push('archetype edge');
+    evidenceParts.push(t('scout.advisor.archetypeEdge'));
   } else if (pick.evidence.archetypeEdge < 0) {
-    evidenceParts.push('archetype disadvantage');
+    evidenceParts.push(t('scout.advisor.archetypeDisadvantage'));
   }
 
   return (
@@ -48,7 +46,7 @@ function PickChip({ pick, tone }: { pick: MatchupPick; tone: 'best' | 'worst' })
       )}
       <div className="flex flex-col leading-tight">
         <span className={`text-sm font-medium ${tone === 'worst' ? 'text-muted-foreground' : ''}`}>
-          {sprite?.name ?? 'Unknown'}
+          {sprite?.name ?? t('common.unknown')}
         </span>
         <span className="text-xs text-muted-foreground">{evidenceParts.join(' · ')}</span>
       </div>
@@ -76,6 +74,7 @@ export function ScoutMatchupAdvisorCard({
   scoutedCharacters: ScoutCharacterUsage[];
   matches: Match[];
 }) {
+  const { t } = useTranslation();
   const { data: fighters } = useFighters();
 
   const myFighterIds = useMemo(
@@ -132,24 +131,15 @@ export function ScoutMatchupAdvisorCard({
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Swords className="size-4" />
-          Matchup Advisor
+          {t('scout.advisor.title')}
         </CardTitle>
-        <CardDescription>
-          Your best (and worst) pick against each of their characters — blends your own record with
-          tier list and archetype data.
-        </CardDescription>
+        <CardDescription>{t('scout.advisor.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {opponentFighterIds.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No character data for this scout yet — common on parry.gg while match data is still
-            sparse. Check back after they've played more sets.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('scout.advisor.noCharacterData')}</p>
         ) : myFighterIds.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Pick a primary or secondary character (or log a few matches) to get personalized
-            recommendations.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('scout.advisor.noMyCharacters')}</p>
         ) : (
           <ul className="flex flex-col gap-4">
             {rows.map((row) => (
@@ -170,10 +160,12 @@ export function ScoutMatchupAdvisorCard({
                   })()}
                   <div className="flex flex-col leading-tight">
                     <span className="text-sm font-medium">
-                      vs. {fighterLabel(row.opponentFighterId)}
+                      {t('scout.advisor.vsName', {
+                        name: getFighterById(row.opponentFighterId)?.name ?? t('common.unknown'),
+                      })}
                     </span>
                     <span className="text-xs text-muted-foreground">
-                      {row.opponentGames} game{row.opponentGames === 1 ? '' : 's'} sampled
+                      {t('scout.advisor.gamesSampled', { count: row.opponentGames })}
                     </span>
                   </div>
                 </div>

--- a/apps/web/src/pages/Scout/components/ScoutPastReportsCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutPastReportsCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { History } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -17,14 +18,15 @@ export function ScoutPastReportsCard({
   reports: ScoutReportRecord[];
   onSelect: (report: ScoutReportRecord) => void;
 }) {
+  const { t, i18n } = useTranslation();
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <History className="size-4" />
-          Past AI Reports
+          {t('scout.pastReports.title')}
         </CardTitle>
-        <CardDescription>Reports you've generated before, most recent first.</CardDescription>
+        <CardDescription>{t('scout.pastReports.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-1">
         {reports.map((record) => (
@@ -37,7 +39,7 @@ export function ScoutPastReportsCard({
           >
             <span className="font-medium">{record.player.gamerTag}</span>
             <span className="text-xs text-muted-foreground">
-              {new Date(record.createdAt).toLocaleDateString()}
+              {new Date(record.createdAt).toLocaleDateString(i18n.language)}
             </span>
           </Button>
         ))}

--- a/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutRecentEventsCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ExternalLink, Trophy } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -54,23 +55,24 @@ function ordinal(n: number): string {
 
 /** The scouted player's most recent events (placement/entrants), most recent first. */
 export function ScoutRecentEventsCard({ events }: { events: ScoutRecentEvent[] }) {
+  const { t, i18n } = useTranslation();
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Recent Events</CardTitle>
-        <CardDescription>Most recent activity first.</CardDescription>
+        <CardTitle>{t('scout.events.title')}</CardTitle>
+        <CardDescription>{t('scout.events.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No recent events sampled.</p>
+          <p className="text-sm text-muted-foreground">{t('scout.events.empty')}</p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Event</TableHead>
-                <TableHead>Placement</TableHead>
-                <TableHead className="text-right">Entrants</TableHead>
-                <TableHead className="text-right">Date</TableHead>
+                <TableHead>{t('trends.tournaments.event')}</TableHead>
+                <TableHead>{t('scout.events.placement')}</TableHead>
+                <TableHead className="text-right">{t('scout.events.entrants')}</TableHead>
+                <TableHead className="text-right">{t('trends.sessions.date')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -112,7 +114,7 @@ export function ScoutRecentEventsCard({ events }: { events: ScoutRecentEvent[] }
                     </TableCell>
                     <TableCell className="text-right">{event.numEntrants ?? '—'}</TableCell>
                     <TableCell className="text-right text-muted-foreground">
-                      {new Date(event.lastSetAt).toLocaleDateString()}
+                      {new Date(event.lastSetAt).toLocaleDateString(i18n.language)}
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ExternalLink } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import type { ScoutReportData } from '@smash-tracker/shared';
@@ -15,6 +16,7 @@ import type { ScoutReportData } from '@smash-tracker/shared';
  * shape (see apps/api/src/parrygg/scout.ts).
  */
 export function ScoutReportHeader({ report }: { report: ScoutReportData }) {
+  const { t } = useTranslation();
   const source = report.player.source ?? 'startgg';
   const profileUrl =
     source === 'parrygg'
@@ -36,18 +38,23 @@ export function ScoutReportHeader({ report }: { report: ScoutReportData }) {
               href={profileUrl}
               target="_blank"
               rel="noreferrer"
-              aria-label={`View ${report.player.gamerTag} on ${sourceLabel}`}
+              aria-label={t('scout.header.viewOn', {
+                name: report.player.gamerTag,
+                source: sourceLabel,
+              })}
               className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
             >
               <ExternalLink className="size-3.5" />
-              {sourceLabel} profile
+              {t('scout.header.profile', { source: sourceLabel })}
             </a>
           )}
         </div>
         <p className="text-sm text-muted-foreground">
-          Public {sourceLabel} data · sampled last {report.sampledSets} set
-          {report.sampledSets === 1 ? '' : 's'} ({report.sampledGames} game
-          {report.sampledGames === 1 ? '' : 's'})
+          {t('scout.header.sample', {
+            source: sourceLabel,
+            sets: report.sampledSets,
+            games: report.sampledGames,
+          })}
         </p>
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHistorySelector.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, History } from 'lucide-react';
 import type { ScoutReportRecord } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
@@ -18,6 +19,7 @@ export function ScoutReportHistorySelector({
   index: number;
   onChange: (index: number) => void;
 }) {
+  const { t, i18n } = useTranslation();
   const total = reports.length;
   const current = reports[index];
   if (!current) {
@@ -40,12 +42,13 @@ export function ScoutReportHistorySelector({
         className="size-7"
         disabled={index >= total - 1}
         onClick={() => onChange(index + 1)}
-        aria-label="Older report"
+        aria-label={t('scout.historySelector.older')}
       >
         <ChevronLeft className="size-4" />
       </Button>
       <span>
-        Report {ordinal} of {total} · {new Date(current.createdAt).toLocaleDateString()}
+        {t('scout.historySelector.reportOf', { ordinal, total })} ·{' '}
+        {new Date(current.createdAt).toLocaleDateString(i18n.language)}
       </span>
       <Button
         type="button"
@@ -54,7 +57,7 @@ export function ScoutReportHistorySelector({
         className="size-7"
         disabled={index <= 0}
         onClick={() => onChange(index - 1)}
-        aria-label="Newer report"
+        aria-label={t('scout.historySelector.newer')}
       >
         <ChevronRight className="size-4" />
       </Button>

--- a/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
 import type { ScoutSource } from '@smash-tracker/shared';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,7 @@ export function ScoutSearchForm({
   /** Hides the source toggle entirely when parry.gg isn't configured on this deployment (V9-B Feature 4). */
   parryggEnabled?: boolean;
 }) {
+  const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [source, setSource] = useState<ScoutSource>('startgg');
 
@@ -46,11 +48,9 @@ export function ScoutSearchForm({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Scout a Player</CardTitle>
+        <CardTitle>{t('scout.title')}</CardTitle>
         <CardDescription>
-          {parryggEnabled
-            ? 'Paste a start.gg or parry.gg profile URL, a bare gamer tag, a "user/<slug>" reference, or a numeric player id to pull up their public tournament history before you play them.'
-            : 'Paste a start.gg profile URL, a "user/<slug>" reference, or a numeric player id to pull up their public tournament history before you play them.'}
+          {parryggEnabled ? t('scout.form.descriptionWithParry') : t('scout.form.description')}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -63,26 +63,24 @@ export function ScoutSearchForm({
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder={
                   parryggEnabled
-                    ? 'https://start.gg/user/07dc2239 or a parry.gg profile URL'
-                    : 'https://start.gg/user/07dc2239'
+                    ? t('scout.form.placeholderWithParry')
+                    : t('scout.form.placeholder')
                 }
                 className="pl-8"
                 disabled={isPending}
                 aria-label={
-                  parryggEnabled
-                    ? 'start.gg or parry.gg profile URL, slug/tag, or player id'
-                    : 'start.gg profile URL, slug, or player id'
+                  parryggEnabled ? t('scout.form.inputAriaWithParry') : t('scout.form.inputAria')
                 }
               />
             </div>
             <Button type="submit" disabled={isPending || query.trim().length === 0}>
-              {isPending ? 'Scouting…' : 'Scout'}
+              {isPending ? t('scout.form.scouting') : t('scout.form.scout')}
             </Button>
           </div>
 
           {parryggEnabled && (
             <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">Source:</span>
+              <span className="text-sm text-muted-foreground">{t('scout.form.source')}</span>
               <ToggleGroup
                 type="single"
                 variant="outline"
@@ -94,7 +92,7 @@ export function ScoutSearchForm({
                     setSource(value);
                   }
                 }}
-                aria-label="Scouting source"
+                aria-label={t('scout.form.sourceAria')}
               >
                 <ToggleGroupItem value="startgg" aria-label="start.gg">
                   start.gg
@@ -105,16 +103,14 @@ export function ScoutSearchForm({
               </ToggleGroup>
               {detectedParryUrl && (
                 <span className="text-xs text-muted-foreground">
-                  Detected a parry.gg profile URL.
+                  {t('scout.form.detectedParry')}
                 </span>
               )}
             </div>
           )}
         </form>
         {isPending && (
-          <p className="mt-2 text-sm text-muted-foreground">
-            Pulling their public tournament history — this can take a few seconds.
-          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{t('scout.form.pending')}</p>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Scout/components/ScoutStagesCard.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutStagesCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ScoutStageUsage } from '@smash-tracker/shared';
 import { stagesById } from '@/data/stages';
@@ -6,17 +7,18 @@ const MAX_STAGES = 6;
 
 /** The scouted player's stage results (art tile + record + win rate), most-played first. */
 export function ScoutStagesCard({ stages }: { stages: ScoutStageUsage[] }) {
+  const { t } = useTranslation();
   const top = stages.filter((s) => s.stageId !== 0).slice(0, MAX_STAGES);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Stage Performance</CardTitle>
-        <CardDescription>Their results by stage.</CardDescription>
+        <CardTitle>{t('scout.stages.title')}</CardTitle>
+        <CardDescription>{t('scout.stages.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {top.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No stage data recorded yet.</p>
+          <p className="text-sm text-muted-foreground">{t('opponents.stages.empty')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {top.map((row) => {
@@ -32,11 +34,11 @@ export function ScoutStagesCard({ stages }: { stages: ScoutStageUsage[] }) {
                         {stage ? stage.name.slice(0, 3).toUpperCase() : '??'}
                       </span>
                     )}
-                    <span className="text-sm">{stage?.name ?? 'Unknown'}</span>
+                    <span className="text-sm">{stage?.name ?? t('common.unknown')}</span>
                   </div>
                   <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
-                    {row.wins}-{row.games - row.wins} · {winRate}% · {row.games} game
-                    {row.games === 1 ? '' : 's'}
+                    {row.wins}-{row.games - row.wins} · {winRate}% ·{' '}
+                    {t('common.games', { count: row.games })}
                   </span>
                 </li>
               );

--- a/apps/web/src/pages/Scout/components/YourHistoryStrip.tsx
+++ b/apps/web/src/pages/Scout/components/YourHistoryStrip.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { WinLossPips } from '@/components/WinLossPips';
@@ -13,13 +14,16 @@ import type { OpponentProfile } from '@/lib/stats';
  * just a compact pointer to it.
  */
 export function YourHistoryStrip({ profile }: { profile: OpponentProfile }) {
+  const { t } = useTranslation();
   return (
     <Card className="border-primary/30 bg-primary/5">
       <CardHeader>
-        <CardTitle>Your History vs Them</CardTitle>
+        <CardTitle>{t('scout.history.title')}</CardTitle>
         <CardDescription>
-          You've played {profile.opponent} before — {profile.record.total} game
-          {profile.record.total === 1 ? '' : 's'} recorded in your own match history.
+          {t('scout.history.description', {
+            name: profile.opponent,
+            count: profile.record.total,
+          })}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-wrap items-center justify-between gap-4">
@@ -27,13 +31,13 @@ export function YourHistoryStrip({ profile }: { profile: OpponentProfile }) {
           <span className="text-lg font-semibold">
             {profile.record.wins}-{profile.record.losses}{' '}
             <span className="text-sm font-normal text-muted-foreground">
-              ({profile.record.winRate}% win rate)
+              {t('scout.history.rate', { rate: profile.record.winRate })}
             </span>
           </span>
           <WinLossPips matches={profile.recent} />
         </div>
         <Button asChild variant="outline" size="sm">
-          <Link to="/opponents">Full scouting report</Link>
+          <Link to="/opponents">{t('scout.history.fullReport')}</Link>
         </Button>
       </CardContent>
     </Card>


### PR DESCRIPTION
Part 8 of the localization phase-2 series, based on master.

**Note on the first commit:** #149 (Opponents scouting + Scout pages) was merged into `feat/i18n-trends-tournaments` *after* #148 had already landed that branch in master, so its changes never reached master and the branch was deleted. This PR re-lands that commit and adds the Reports/Groups/Integrations pass on top (same situation #146 handled for the GSP/Match Data commits).

## New in this PR

Extracts every remaining hardcoded string on `/reports`, `/groups`, and `/settings/integrations` into `reports.*`, `groups.*`, and `integrations.*` namespaces — 98 new keys, each translated into es/fr/de/pt/ja with full key parity across all six locales.

- **Reports**: page chrome, empty/not-enabled states (the empty state's inline Scout link uses `<Trans>` so the link stays inside the localized sentence), older-report rows and their expand/collapse aria-labels; report dates now format with the active locale. `sourceLabel` (start.gg / parry.gg) stays as brand names.
- **Groups**: page states, create/join dialogs, member-count plural (`groups.members` with `count`), leaderboard header (invite code, copy aria, delete/leave confirm dialogs reusing `common.cancel`/`common.delete`), and the leaderboard table headers/`(you)`/`never`.
- **Integrations**: the start.gg and parry.gg cards share provider-parameterized copy (`linkDescription`, `unlinkTitle`, `unlinkDescription`, `unlinkedToast` with `{{provider}}`) plus a plural-aware sync-summary block (`skippedDetail`/`unknownStages`/`dqSkipped` with `_one`/`_other` in every locale); both `describeSummary` helpers now take `t`. All toasts, the parry.gg search/link flow, and the bio-code verify dialog are localized; last-synced timestamps format with the active locale.

## Checks (after rebase onto master)

- `pnpm --filter @smash-tracker/web lint` — 0 errors
- `pnpm --filter @smash-tracker/web typecheck` — clean
- `pnpm --filter @smash-tracker/web test` — 941/941 passing (includes the locale key-parity test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)