### PR TITLE
Localization phase 2i: Profile + Character Select pages

### DIFF
--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "parry.gg-Konto verifiziert!",
       "codeNotFound": "Verifizierungscode noch nicht gefunden. Bitte versuche es erneut."
     }
+  },
+  "profile": {
+    "title": "Profil",
+    "account": {
+      "title": "Konto",
+      "description": "Deine smash-tracker-Identität.",
+      "parryggNoEmailLinked": "parry.gg-Konto (keine E-Mail) — verknüpft mit {{tag}}",
+      "parryggNoEmail": "parry.gg-Konto (keine E-Mail)",
+      "memberSince": "Mitglied seit {{date}}",
+      "signInMethods": "Anmeldemethoden",
+      "methodEmailPassword": "E-Mail & Passwort",
+      "methodParrygg": "parry.gg-Verifizierung",
+      "methodCustom": "Benutzerdefinierte Anmeldung"
+    },
+    "security": {
+      "title": "Sicherheit",
+      "descPassword": "Ändere das Passwort, mit dem du dich anmeldest.",
+      "descResetOnly": "Füge deinem Konto die Passwort-Anmeldung hinzu.",
+      "descNoEmail": "Wie sich dein Konto anmeldet.",
+      "resetExplainer": "Du meldest dich derzeit ohne Passwort an. Mit einer Passwort-Zurücksetzen-E-Mail kannst du eines einrichten, um dich künftig auch mit E-Mail und Passwort anzumelden.",
+      "sendReset": "Passwort-Zurücksetzen-E-Mail senden",
+      "sending": "Wird gesendet…",
+      "resetSent": "Zurücksetzen-E-Mail an {{email}} gesendet. Folge dem Link, um die Passwort-Anmeldung hinzuzufügen.",
+      "noEmailBody": "Dein Konto hat weder Passwort noch E-Mail — die Anmeldung läuft über die parry.gg-Profilverifizierung. Verwalte diese Verknüpfung unter <integrationsLink>Integrationen</integrationsLink>."
+    },
+    "password": {
+      "currentLabel": "Aktuelles Passwort",
+      "newLabel": "Neues Passwort",
+      "confirmLabel": "Neues Passwort bestätigen",
+      "submit": "Passwort ändern",
+      "updating": "Wird aktualisiert…",
+      "updated": "Passwort aktualisiert!",
+      "currentRequired": "Aktuelles Passwort ist erforderlich",
+      "minLength": "Das Passwort sollte mindestens 6 Zeichen haben",
+      "confirmRequired": "Bitte bestätige dein neues Passwort",
+      "mismatch": "Die Passwörter stimmen nicht überein",
+      "wrongCurrent": "Das aktuelle Passwort ist falsch.",
+      "weak": "Das Passwort sollte mindestens 6 Zeichen haben.",
+      "requiresRecentLogin": "Melde dich zu deiner Sicherheit ab und wieder an, und versuche es dann erneut.",
+      "genericError": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
+    },
+    "connected": {
+      "title": "Verbundene Konten",
+      "description": "start.gg- und parry.gg-Verknüpfungen für den automatischen Match-Import.",
+      "linked": "Verknüpft",
+      "notLinked": "Nicht verknüpft",
+      "manage": "Unter Integrationen verwalten"
+    },
+    "fighters": {
+      "title": "Kämpfer",
+      "description": "Deine Main- und Secondary-Kämpfer in Smash Ultimate.",
+      "loading": "Deine Kämpfer werden geladen...",
+      "primary": "Mains",
+      "secondary": "Secondaries",
+      "none": "Keine ausgewählt",
+      "edit": "Kämpfer bearbeiten"
+    },
+    "favoriteStages": {
+      "title": "Lieblings-Stages",
+      "description": "Beim Erfassen von Matches oben in den Stage-Auswahlen angepinnt — praktisch für die übliche Quickplay-/Elite-Smash-Rotation.",
+      "loading": "Deine Lieblings-Stages werden geladen...",
+      "empty": "Noch keine Lieblings-Stages.",
+      "removeAria": "{{name}} aus den Favoriten entfernen",
+      "add": "Lieblings-Stage hinzufügen...",
+      "addAria": "Lieblings-Stage hinzufügen",
+      "searchPlaceholder": "Stages suchen...",
+      "noStage": "Keine Stage gefunden.",
+      "saveError": "Deine Lieblings-Stages konnten nicht gespeichert werden. Bitte versuche es erneut."
+    },
+    "billing": {
+      "title": "Abrechnung",
+      "description": "Credits für KI-Scouting-Berichte.",
+      "freeAccess": "Kostenloser Zugang",
+      "credits_one": "{{count}} Credit",
+      "credits_other": "{{count}} Credits",
+      "packsStartAt_one": "Pakete beginnen bei {{price}} für {{count}} Bericht.",
+      "packsStartAt_other": "Pakete beginnen bei {{price}} für {{count}} Berichte.",
+      "buyCredits": "Credits kaufen"
+    },
+    "data": {
+      "title": "Deine Daten",
+      "description": "Was smash-tracker über dich gespeichert hat.",
+      "totalMatches": "Matches insgesamt",
+      "fromStartgg": "Von start.gg",
+      "fromParrygg": "Von parry.gg",
+      "manual": "Manuell erfasst",
+      "groupsJoined": "Beigetretene Gruppen",
+      "aiReports": "Erstellte KI-Berichte"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "Wähle deine Mains",
+    "primaryDescription": "Wähle zunächst deine Main-Kämpfer aus. Mit dem Eingabefeld unten kannst du suchen. Um einen Charakter zu entfernen, klicke ihn einfach erneut an. Wenn du fertig bist, drücke Speichern.",
+    "secondaryHeading": "Wähle deine Secondaries",
+    "secondaryDescription": "Wähle zunächst deine Secondary-Kämpfer aus. Mit dem Eingabefeld unten kannst du suchen. Um einen Charakter zu entfernen, klicke ihn einfach erneut an. Wenn du fertig bist, drücke Speichern, um Smash Tracker zu nutzen!",
+    "saveAndSecondaries": "Speichern und Secondaries wählen",
+    "saveAndDashboard": "Speichern und zum Dashboard",
+    "saveAndPrimaries": "Speichern und Mains wählen",
+    "loading": "Deine Kämpfer werden geladen...",
+    "selected_one": "Ausgewählt ({{count}})",
+    "selected_other": "Ausgewählt ({{count}})",
+    "emptySelected": "Noch keine Kämpfer ausgewählt. Klicke unten auf einen Kämpfer, um ihn hinzuzufügen.",
+    "filterPlaceholder": "Nach Name filtern...",
+    "saved": "Kämpfer gespeichert!",
+    "saveFailed": "Kämpfer konnten nicht gespeichert werden. Bitte versuche es erneut."
   }
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "parry.gg account verified!",
       "codeNotFound": "Verification code not found yet. Please try again."
     }
+  },
+  "profile": {
+    "title": "Profile",
+    "account": {
+      "title": "Account",
+      "description": "Your smash-tracker identity.",
+      "parryggNoEmailLinked": "parry.gg account (no email) — linked to {{tag}}",
+      "parryggNoEmail": "parry.gg account (no email)",
+      "memberSince": "Member since {{date}}",
+      "signInMethods": "Sign-in methods",
+      "methodEmailPassword": "Email & password",
+      "methodParrygg": "parry.gg verification",
+      "methodCustom": "Custom sign-in"
+    },
+    "security": {
+      "title": "Security",
+      "descPassword": "Change the password you use to sign in.",
+      "descResetOnly": "Add password sign-in to your account.",
+      "descNoEmail": "How your account signs in.",
+      "resetExplainer": "You currently sign in without a password. Sending a password reset email lets you set one up, so you can also sign in with your email and a password going forward.",
+      "sendReset": "Send password reset email",
+      "sending": "Sending…",
+      "resetSent": "Reset email sent to {{email}}. Follow the link to add password sign-in.",
+      "noEmailBody": "Your account has no password or email — sign-in works through parry.gg profile verification. Manage that link from <integrationsLink>Integrations</integrationsLink>."
+    },
+    "password": {
+      "currentLabel": "Current password",
+      "newLabel": "New password",
+      "confirmLabel": "Confirm new password",
+      "submit": "Change password",
+      "updating": "Updating…",
+      "updated": "Password updated!",
+      "currentRequired": "Current password is required",
+      "minLength": "Password should be at least 6 characters",
+      "confirmRequired": "Please confirm your new password",
+      "mismatch": "Passwords don't match",
+      "wrongCurrent": "Current password is incorrect.",
+      "weak": "Password should be at least 6 characters.",
+      "requiresRecentLogin": "For your security, please sign out and sign back in, then try again.",
+      "genericError": "Something went wrong. Please try again."
+    },
+    "connected": {
+      "title": "Connected accounts",
+      "description": "start.gg and parry.gg links for automatic match import.",
+      "linked": "Linked",
+      "notLinked": "Not linked",
+      "manage": "Manage on Integrations"
+    },
+    "fighters": {
+      "title": "Fighters",
+      "description": "Your primary and secondary Smash Ultimate fighters.",
+      "loading": "Loading your fighters...",
+      "primary": "Primary",
+      "secondary": "Secondary",
+      "none": "None selected",
+      "edit": "Edit fighters"
+    },
+    "favoriteStages": {
+      "title": "Favorite Stages",
+      "description": "Pinned to the top of stage pickers when logging matches — handy for the usual quickplay/Elite Smash rotation.",
+      "loading": "Loading your favorite stages...",
+      "empty": "No favorite stages yet.",
+      "removeAria": "Remove {{name}} from favorites",
+      "add": "Add a favorite stage...",
+      "addAria": "Add a favorite stage",
+      "searchPlaceholder": "Search stages...",
+      "noStage": "No stage found.",
+      "saveError": "Could not save your favorite stages. Please try again."
+    },
+    "billing": {
+      "title": "Billing",
+      "description": "AI scouting report credits.",
+      "freeAccess": "Free access",
+      "credits_one": "{{count}} credit",
+      "credits_other": "{{count}} credits",
+      "packsStartAt_one": "Packs start at {{price}} for {{count}} report.",
+      "packsStartAt_other": "Packs start at {{price}} for {{count}} reports.",
+      "buyCredits": "Buy credits"
+    },
+    "data": {
+      "title": "Your data",
+      "description": "What smash-tracker has on file for you.",
+      "totalMatches": "Total matches",
+      "fromStartgg": "From start.gg",
+      "fromParrygg": "From parry.gg",
+      "manual": "Manually entered",
+      "groupsJoined": "Groups joined",
+      "aiReports": "AI reports generated"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "Choose Your Primaries",
+    "primaryDescription": "Begin by selecting your primary fighters. You can search using the input below. To remove a character, simply click it again. When you're finished, press Save.",
+    "secondaryHeading": "Choose Your Secondaries",
+    "secondaryDescription": "Begin by selecting your secondary fighters. You can search using the input below. To remove a character, simply click it again. When you're finished, press Save to begin using Smash Tracker!",
+    "saveAndSecondaries": "Save and Choose Secondaries",
+    "saveAndDashboard": "Save and go to Dashboard",
+    "saveAndPrimaries": "Save and choose Primary Fighters",
+    "loading": "Loading your fighters...",
+    "selected_one": "Selected ({{count}})",
+    "selected_other": "Selected ({{count}})",
+    "emptySelected": "No fighters selected yet. Click a fighter below to add them.",
+    "filterPlaceholder": "Filter by name...",
+    "saved": "Fighters saved!",
+    "saveFailed": "Failed to save fighters. Please try again."
   }
 }

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "¡Cuenta de parry.gg verificada!",
       "codeNotFound": "Aún no se encontró el código de verificación. Inténtalo de nuevo."
     }
+  },
+  "profile": {
+    "account": {
+      "title": "Cuenta",
+      "description": "Tu identidad en smash-tracker.",
+      "parryggNoEmailLinked": "Cuenta de parry.gg (sin correo) — vinculada a {{tag}}",
+      "parryggNoEmail": "Cuenta de parry.gg (sin correo)",
+      "memberSince": "Miembro desde {{date}}",
+      "signInMethods": "Métodos de inicio de sesión",
+      "methodEmailPassword": "Correo y contraseña",
+      "methodParrygg": "Verificación de parry.gg",
+      "methodCustom": "Inicio de sesión personalizado"
+    },
+    "title": "Perfil",
+    "security": {
+      "title": "Seguridad",
+      "descPassword": "Cambia la contraseña con la que inicias sesión.",
+      "descResetOnly": "Añade el inicio de sesión con contraseña a tu cuenta.",
+      "descNoEmail": "Cómo inicia sesión tu cuenta.",
+      "resetExplainer": "Actualmente inicias sesión sin contraseña. Enviar un correo de restablecimiento te permite configurar una, para que también puedas iniciar sesión con tu correo y una contraseña en adelante.",
+      "sendReset": "Enviar correo de restablecimiento",
+      "sending": "Enviando…",
+      "resetSent": "Correo de restablecimiento enviado a {{email}}. Sigue el enlace para añadir el inicio de sesión con contraseña.",
+      "noEmailBody": "Tu cuenta no tiene contraseña ni correo: el inicio de sesión funciona mediante la verificación del perfil de parry.gg. Gestiona ese vínculo desde <integrationsLink>Integraciones</integrationsLink>."
+    },
+    "password": {
+      "currentLabel": "Contraseña actual",
+      "newLabel": "Nueva contraseña",
+      "confirmLabel": "Confirmar nueva contraseña",
+      "submit": "Cambiar contraseña",
+      "updating": "Actualizando…",
+      "updated": "¡Contraseña actualizada!",
+      "currentRequired": "La contraseña actual es obligatoria",
+      "minLength": "La contraseña debe tener al menos 6 caracteres",
+      "confirmRequired": "Confirma tu nueva contraseña",
+      "mismatch": "Las contraseñas no coinciden",
+      "wrongCurrent": "La contraseña actual es incorrecta.",
+      "weak": "La contraseña debe tener al menos 6 caracteres.",
+      "requiresRecentLogin": "Por tu seguridad, cierra sesión y vuelve a iniciarla, luego inténtalo de nuevo.",
+      "genericError": "Algo salió mal. Inténtalo de nuevo."
+    },
+    "connected": {
+      "title": "Cuentas conectadas",
+      "description": "Vínculos con start.gg y parry.gg para la importación automática de partidas.",
+      "linked": "Vinculada",
+      "notLinked": "Sin vincular",
+      "manage": "Gestionar en Integraciones"
+    },
+    "fighters": {
+      "title": "Luchadores",
+      "description": "Tus luchadores principales y secundarios de Smash Ultimate.",
+      "loading": "Cargando tus luchadores...",
+      "primary": "Principales",
+      "secondary": "Secundarios",
+      "none": "Ninguno seleccionado",
+      "edit": "Editar luchadores"
+    },
+    "favoriteStages": {
+      "title": "Stages favoritos",
+      "description": "Fijados al inicio de los selectores de stage al registrar partidas — útil para la rotación habitual de quickplay/Elite Smash.",
+      "loading": "Cargando tus stages favoritos...",
+      "empty": "Aún no hay stages favoritos.",
+      "removeAria": "Quitar {{name}} de favoritos",
+      "add": "Añadir un stage favorito...",
+      "addAria": "Añadir un stage favorito",
+      "searchPlaceholder": "Buscar stages...",
+      "noStage": "No se encontró ningún stage.",
+      "saveError": "No se pudieron guardar tus stages favoritos. Inténtalo de nuevo."
+    },
+    "billing": {
+      "title": "Facturación",
+      "description": "Créditos para informes de scouting de IA.",
+      "freeAccess": "Acceso gratuito",
+      "credits_one": "{{count}} crédito",
+      "credits_other": "{{count}} créditos",
+      "packsStartAt_one": "Los packs empiezan en {{price}} por {{count}} informe.",
+      "packsStartAt_other": "Los packs empiezan en {{price}} por {{count}} informes.",
+      "buyCredits": "Comprar créditos"
+    },
+    "data": {
+      "title": "Tus datos",
+      "description": "Lo que smash-tracker tiene registrado sobre ti.",
+      "totalMatches": "Partidas totales",
+      "fromStartgg": "De start.gg",
+      "fromParrygg": "De parry.gg",
+      "manual": "Registradas a mano",
+      "groupsJoined": "Grupos a los que perteneces",
+      "aiReports": "Informes de IA generados"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "Elige tus principales",
+    "primaryDescription": "Empieza seleccionando tus luchadores principales. Puedes buscar con el campo de abajo. Para quitar un personaje, simplemente vuelve a hacer clic en él. Cuando termines, pulsa Guardar.",
+    "secondaryHeading": "Elige tus secundarios",
+    "secondaryDescription": "Empieza seleccionando tus luchadores secundarios. Puedes buscar con el campo de abajo. Para quitar un personaje, simplemente vuelve a hacer clic en él. Cuando termines, pulsa Guardar para empezar a usar Smash Tracker.",
+    "saveAndSecondaries": "Guardar y elegir secundarios",
+    "saveAndDashboard": "Guardar e ir al Panel",
+    "saveAndPrimaries": "Guardar y elegir principales",
+    "loading": "Cargando tus luchadores...",
+    "selected_one": "Seleccionados ({{count}})",
+    "selected_other": "Seleccionados ({{count}})",
+    "emptySelected": "Aún no hay luchadores seleccionados. Haz clic en un luchador de abajo para añadirlo.",
+    "filterPlaceholder": "Filtrar por nombre...",
+    "saved": "¡Luchadores guardados!",
+    "saveFailed": "No se pudieron guardar los luchadores. Inténtalo de nuevo."
   }
 }

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "Compte parry.gg vérifié !",
       "codeNotFound": "Code de vérification introuvable pour l'instant. Veuillez réessayer."
     }
+  },
+  "profile": {
+    "title": "Profil",
+    "account": {
+      "title": "Compte",
+      "description": "Votre identité smash-tracker.",
+      "parryggNoEmailLinked": "Compte parry.gg (sans e-mail) — lié à {{tag}}",
+      "parryggNoEmail": "Compte parry.gg (sans e-mail)",
+      "memberSince": "Membre depuis {{date}}",
+      "signInMethods": "Méthodes de connexion",
+      "methodEmailPassword": "E-mail et mot de passe",
+      "methodParrygg": "Vérification parry.gg",
+      "methodCustom": "Connexion personnalisée"
+    },
+    "security": {
+      "title": "Sécurité",
+      "descPassword": "Changez le mot de passe que vous utilisez pour vous connecter.",
+      "descResetOnly": "Ajoutez la connexion par mot de passe à votre compte.",
+      "descNoEmail": "Comment votre compte se connecte.",
+      "resetExplainer": "Vous vous connectez actuellement sans mot de passe. L'envoi d'un e-mail de réinitialisation vous permet d'en définir un, pour pouvoir aussi vous connecter avec votre e-mail et un mot de passe à l'avenir.",
+      "sendReset": "Envoyer l'e-mail de réinitialisation",
+      "sending": "Envoi…",
+      "resetSent": "E-mail de réinitialisation envoyé à {{email}}. Suivez le lien pour ajouter la connexion par mot de passe.",
+      "noEmailBody": "Votre compte n'a ni mot de passe ni e-mail — la connexion passe par la vérification du profil parry.gg. Gérez ce lien depuis <integrationsLink>Intégrations</integrationsLink>."
+    },
+    "password": {
+      "currentLabel": "Mot de passe actuel",
+      "newLabel": "Nouveau mot de passe",
+      "confirmLabel": "Confirmer le nouveau mot de passe",
+      "submit": "Changer le mot de passe",
+      "updating": "Mise à jour…",
+      "updated": "Mot de passe mis à jour !",
+      "currentRequired": "Le mot de passe actuel est requis",
+      "minLength": "Le mot de passe doit contenir au moins 6 caractères",
+      "confirmRequired": "Veuillez confirmer votre nouveau mot de passe",
+      "mismatch": "Les mots de passe ne correspondent pas",
+      "wrongCurrent": "Le mot de passe actuel est incorrect.",
+      "weak": "Le mot de passe doit contenir au moins 6 caractères.",
+      "requiresRecentLogin": "Pour votre sécurité, déconnectez-vous puis reconnectez-vous, et réessayez.",
+      "genericError": "Une erreur est survenue. Veuillez réessayer."
+    },
+    "connected": {
+      "title": "Comptes connectés",
+      "description": "Liens start.gg et parry.gg pour l'import automatique des matchs.",
+      "linked": "Lié",
+      "notLinked": "Non lié",
+      "manage": "Gérer dans Intégrations"
+    },
+    "fighters": {
+      "title": "Combattants",
+      "description": "Vos combattants principaux et secondaires de Smash Ultimate.",
+      "loading": "Chargement de vos combattants...",
+      "primary": "Principaux",
+      "secondary": "Secondaires",
+      "none": "Aucun sélectionné",
+      "edit": "Modifier les combattants"
+    },
+    "favoriteStages": {
+      "title": "Stages favoris",
+      "description": "Épinglés en haut des sélecteurs de stage lors de l'enregistrement des matchs — pratique pour la rotation habituelle quickplay/Elite Smash.",
+      "loading": "Chargement de vos stages favoris...",
+      "empty": "Aucun stage favori pour l'instant.",
+      "removeAria": "Retirer {{name}} des favoris",
+      "add": "Ajouter un stage favori...",
+      "addAria": "Ajouter un stage favori",
+      "searchPlaceholder": "Rechercher des stages...",
+      "noStage": "Aucun stage trouvé.",
+      "saveError": "Impossible d'enregistrer vos stages favoris. Veuillez réessayer."
+    },
+    "billing": {
+      "title": "Facturation",
+      "description": "Crédits de rapports de scouting IA.",
+      "freeAccess": "Accès gratuit",
+      "credits_one": "{{count}} crédit",
+      "credits_other": "{{count}} crédits",
+      "packsStartAt_one": "Les packs commencent à {{price}} pour {{count}} rapport.",
+      "packsStartAt_other": "Les packs commencent à {{price}} pour {{count}} rapports.",
+      "buyCredits": "Acheter des crédits"
+    },
+    "data": {
+      "title": "Vos données",
+      "description": "Ce que smash-tracker a enregistré pour vous.",
+      "totalMatches": "Matchs au total",
+      "fromStartgg": "Depuis start.gg",
+      "fromParrygg": "Depuis parry.gg",
+      "manual": "Saisis manuellement",
+      "groupsJoined": "Groupes rejoints",
+      "aiReports": "Rapports IA générés"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "Choisissez vos principaux",
+    "primaryDescription": "Commencez par sélectionner vos combattants principaux. Vous pouvez chercher avec le champ ci-dessous. Pour retirer un personnage, cliquez simplement à nouveau dessus. Quand vous avez terminé, appuyez sur Enregistrer.",
+    "secondaryHeading": "Choisissez vos secondaires",
+    "secondaryDescription": "Commencez par sélectionner vos combattants secondaires. Vous pouvez chercher avec le champ ci-dessous. Pour retirer un personnage, cliquez simplement à nouveau dessus. Quand vous avez terminé, appuyez sur Enregistrer pour commencer à utiliser Smash Tracker !",
+    "saveAndSecondaries": "Enregistrer et choisir les secondaires",
+    "saveAndDashboard": "Enregistrer et aller au tableau de bord",
+    "saveAndPrimaries": "Enregistrer et choisir les principaux",
+    "loading": "Chargement de vos combattants...",
+    "selected_one": "Sélectionnés ({{count}})",
+    "selected_other": "Sélectionnés ({{count}})",
+    "emptySelected": "Aucun combattant sélectionné pour le moment. Cliquez sur un combattant ci-dessous pour l’ajouter.",
+    "filterPlaceholder": "Filtrer par nom...",
+    "saved": "Combattants enregistrés !",
+    "saveFailed": "Impossible d'enregistrer les combattants. Veuillez réessayer."
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "parry.ggアカウントを認証しました！",
       "codeNotFound": "認証コードがまだ見つかりません。もう一度お試しください。"
     }
+  },
+  "profile": {
+    "title": "プロフィール",
+    "account": {
+      "title": "アカウント",
+      "description": "あなたのsmash-trackerアカウント情報。",
+      "parryggNoEmailLinked": "parry.ggアカウント（メールなし）— {{tag}}と連携中",
+      "parryggNoEmail": "parry.ggアカウント（メールなし）",
+      "memberSince": "{{date}}から利用中",
+      "signInMethods": "ログイン方法",
+      "methodEmailPassword": "メールとパスワード",
+      "methodParrygg": "parry.gg認証",
+      "methodCustom": "カスタムログイン"
+    },
+    "security": {
+      "title": "セキュリティ",
+      "descPassword": "ログインに使うパスワードを変更します。",
+      "descResetOnly": "アカウントにパスワードログインを追加します。",
+      "descNoEmail": "アカウントのログイン方法。",
+      "resetExplainer": "現在はパスワードなしでログインしています。パスワードリセットメールを送信するとパスワードを設定でき、今後はメールとパスワードでもログインできるようになります。",
+      "sendReset": "パスワードリセットメールを送信",
+      "sending": "送信中…",
+      "resetSent": "{{email}}にリセットメールを送信しました。リンクからパスワードログインを追加してください。",
+      "noEmailBody": "このアカウントにはパスワードもメールもありません。ログインはparry.ggプロフィール認証で行います。連携の管理は<integrationsLink>連携</integrationsLink>ページから。"
+    },
+    "password": {
+      "currentLabel": "現在のパスワード",
+      "newLabel": "新しいパスワード",
+      "confirmLabel": "新しいパスワード（確認）",
+      "submit": "パスワードを変更",
+      "updating": "更新中…",
+      "updated": "パスワードを更新しました！",
+      "currentRequired": "現在のパスワードを入力してください",
+      "minLength": "パスワードは6文字以上にしてください",
+      "confirmRequired": "新しいパスワードを確認してください",
+      "mismatch": "パスワードが一致しません",
+      "wrongCurrent": "現在のパスワードが正しくありません。",
+      "weak": "パスワードは6文字以上にしてください。",
+      "requiresRecentLogin": "セキュリティのため、一度ログアウトして再ログインしてからお試しください。",
+      "genericError": "問題が発生しました。もう一度お試しください。"
+    },
+    "connected": {
+      "title": "連携アカウント",
+      "description": "試合の自動インポートに使うstart.ggとparry.ggの連携。",
+      "linked": "連携済み",
+      "notLinked": "未連携",
+      "manage": "連携ページで管理"
+    },
+    "fighters": {
+      "title": "ファイター",
+      "description": "スマブラSPのメインとサブのファイター。",
+      "loading": "ファイターを読み込み中...",
+      "primary": "メイン",
+      "secondary": "サブ",
+      "none": "未選択",
+      "edit": "ファイターを編集"
+    },
+    "favoriteStages": {
+      "title": "お気に入りステージ",
+      "description": "試合を記録するときにステージ選択の先頭に固定されます。いつものクイックプレイ/VIPマッチのローテーションに便利です。",
+      "loading": "お気に入りステージを読み込み中...",
+      "empty": "お気に入りステージはまだありません。",
+      "removeAria": "{{name}}をお気に入りから削除",
+      "add": "お気に入りステージを追加...",
+      "addAria": "お気に入りステージを追加",
+      "searchPlaceholder": "ステージを検索...",
+      "noStage": "ステージが見つかりません。",
+      "saveError": "お気に入りステージを保存できませんでした。もう一度お試しください。"
+    },
+    "billing": {
+      "title": "課金",
+      "description": "AIスカウティングレポート用のクレジット。",
+      "freeAccess": "無料アクセス",
+      "credits_one": "{{count}}クレジット",
+      "credits_other": "{{count}}クレジット",
+      "packsStartAt_one": "パックは{{price}}（レポート{{count}}件分）からです。",
+      "packsStartAt_other": "パックは{{price}}（レポート{{count}}件分）からです。",
+      "buyCredits": "クレジットを購入"
+    },
+    "data": {
+      "title": "あなたのデータ",
+      "description": "smash-trackerに記録されているあなたのデータ。",
+      "totalMatches": "総試合数",
+      "fromStartgg": "start.ggから",
+      "fromParrygg": "parry.ggから",
+      "manual": "手動で記録",
+      "groupsJoined": "参加グループ",
+      "aiReports": "生成したAIレポート"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "メインファイターを選択",
+    "primaryDescription": "まずはメインのファイターを選びましょう。下の入力欄で検索できます。キャラクターを外すには、もう一度クリックしてください。選び終わったら「保存」を押してください。",
+    "secondaryHeading": "サブファイターを選択",
+    "secondaryDescription": "まずはサブのファイターを選びましょう。下の入力欄で検索できます。キャラクターを外すには、もう一度クリックしてください。選び終わったら「保存」を押してSmash Trackerを使い始めましょう！",
+    "saveAndSecondaries": "保存してサブを選ぶ",
+    "saveAndDashboard": "保存してダッシュボードへ",
+    "saveAndPrimaries": "保存してメインを選ぶ",
+    "loading": "ファイターを読み込み中...",
+    "selected_one": "選択中（{{count}}）",
+    "selected_other": "選択中（{{count}}）",
+    "emptySelected": "ファイターはまだ選択されていません。下のファイターをクリックして追加しましょう。",
+    "filterPlaceholder": "名前で絞り込み...",
+    "saved": "ファイターを保存しました！",
+    "saveFailed": "ファイターを保存できませんでした。もう一度お試しください。"
   }
 }

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -1048,5 +1048,110 @@
       "verifiedToast": "Conta do parry.gg verificada!",
       "codeNotFound": "Código de verificação ainda não encontrado. Tente novamente."
     }
+  },
+  "profile": {
+    "title": "Perfil",
+    "account": {
+      "title": "Conta",
+      "description": "Sua identidade no smash-tracker.",
+      "parryggNoEmailLinked": "Conta do parry.gg (sem e-mail) — vinculada a {{tag}}",
+      "parryggNoEmail": "Conta do parry.gg (sem e-mail)",
+      "memberSince": "Membro desde {{date}}",
+      "signInMethods": "Métodos de login",
+      "methodEmailPassword": "E-mail e senha",
+      "methodParrygg": "Verificação do parry.gg",
+      "methodCustom": "Login personalizado"
+    },
+    "security": {
+      "title": "Segurança",
+      "descPassword": "Altere a senha que você usa para entrar.",
+      "descResetOnly": "Adicione o login com senha à sua conta.",
+      "descNoEmail": "Como sua conta faz login.",
+      "resetExplainer": "Atualmente você entra sem senha. Enviar um e-mail de redefinição permite configurar uma, para que você também possa entrar com seu e-mail e uma senha daqui em diante.",
+      "sendReset": "Enviar e-mail de redefinição de senha",
+      "sending": "Enviando…",
+      "resetSent": "E-mail de redefinição enviado para {{email}}. Siga o link para adicionar o login com senha.",
+      "noEmailBody": "Sua conta não tem senha nem e-mail — o login funciona pela verificação do perfil do parry.gg. Gerencie esse vínculo em <integrationsLink>Integrações</integrationsLink>."
+    },
+    "password": {
+      "currentLabel": "Senha atual",
+      "newLabel": "Nova senha",
+      "confirmLabel": "Confirmar nova senha",
+      "submit": "Alterar senha",
+      "updating": "Atualizando…",
+      "updated": "Senha atualizada!",
+      "currentRequired": "A senha atual é obrigatória",
+      "minLength": "A senha deve ter pelo menos 6 caracteres",
+      "confirmRequired": "Confirme sua nova senha",
+      "mismatch": "As senhas não coincidem",
+      "wrongCurrent": "A senha atual está incorreta.",
+      "weak": "A senha deve ter pelo menos 6 caracteres.",
+      "requiresRecentLogin": "Para sua segurança, saia e entre novamente, depois tente de novo.",
+      "genericError": "Algo deu errado. Tente novamente."
+    },
+    "connected": {
+      "title": "Contas conectadas",
+      "description": "Vínculos com start.gg e parry.gg para importação automática de partidas.",
+      "linked": "Vinculada",
+      "notLinked": "Não vinculada",
+      "manage": "Gerenciar em Integrações"
+    },
+    "fighters": {
+      "title": "Lutadores",
+      "description": "Seus lutadores principais e secundários de Smash Ultimate.",
+      "loading": "Carregando seus lutadores...",
+      "primary": "Principais",
+      "secondary": "Secundários",
+      "none": "Nenhum selecionado",
+      "edit": "Editar lutadores"
+    },
+    "favoriteStages": {
+      "title": "Stages favoritos",
+      "description": "Fixados no topo dos seletores de stage ao registrar partidas — útil para a rotação habitual de quickplay/Elite Smash.",
+      "loading": "Carregando seus stages favoritos...",
+      "empty": "Nenhum stage favorito ainda.",
+      "removeAria": "Remover {{name}} dos favoritos",
+      "add": "Adicionar um stage favorito...",
+      "addAria": "Adicionar um stage favorito",
+      "searchPlaceholder": "Buscar stages...",
+      "noStage": "Nenhum stage encontrado.",
+      "saveError": "Não foi possível salvar seus stages favoritos. Tente novamente."
+    },
+    "billing": {
+      "title": "Cobrança",
+      "description": "Créditos para relatórios de scouting de IA.",
+      "freeAccess": "Acesso gratuito",
+      "credits_one": "{{count}} crédito",
+      "credits_other": "{{count}} créditos",
+      "packsStartAt_one": "Os pacotes começam em {{price}} por {{count}} relatório.",
+      "packsStartAt_other": "Os pacotes começam em {{price}} por {{count}} relatórios.",
+      "buyCredits": "Comprar créditos"
+    },
+    "data": {
+      "title": "Seus dados",
+      "description": "O que o smash-tracker tem registrado sobre você.",
+      "totalMatches": "Partidas no total",
+      "fromStartgg": "Do start.gg",
+      "fromParrygg": "Do parry.gg",
+      "manual": "Registradas manualmente",
+      "groupsJoined": "Grupos participados",
+      "aiReports": "Relatórios de IA gerados"
+    }
+  },
+  "characterSelect": {
+    "primaryHeading": "Escolha seus principais",
+    "primaryDescription": "Comece selecionando seus lutadores principais. Você pode buscar usando o campo abaixo. Para remover um personagem, basta clicar nele novamente. Quando terminar, pressione Salvar.",
+    "secondaryHeading": "Escolha seus secundários",
+    "secondaryDescription": "Comece selecionando seus lutadores secundários. Você pode buscar usando o campo abaixo. Para remover um personagem, basta clicar nele novamente. Quando terminar, pressione Salvar para começar a usar o Smash Tracker!",
+    "saveAndSecondaries": "Salvar e escolher secundários",
+    "saveAndDashboard": "Salvar e ir para o Painel",
+    "saveAndPrimaries": "Salvar e escolher principais",
+    "loading": "Carregando seus lutadores...",
+    "selected_one": "Selecionados ({{count}})",
+    "selected_other": "Selecionados ({{count}})",
+    "emptySelected": "Nenhum lutador selecionado ainda. Clique em um lutador abaixo para adicioná-lo.",
+    "filterPlaceholder": "Filtrar por nome...",
+    "saved": "Lutadores salvos!",
+    "saveFailed": "Não foi possível salvar os lutadores. Tente novamente."
   }
 }

--- a/apps/web/src/pages/CharacterSelect/CharacterSelectScreen.tsx
+++ b/apps/web/src/pages/CharacterSelect/CharacterSelectScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -36,6 +37,7 @@ export function CharacterSelectScreen({
   description,
   destinations,
 }: CharacterSelectScreenProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { data: fighters, isLoading } = useFighters();
   const saveFighters = useSaveFighters();
@@ -82,15 +84,15 @@ export function CharacterSelectScreen({
         : { primary: fighters?.primary ?? [], secondary: selectedIds };
     try {
       await saveFighters.mutateAsync(input);
-      toast.success('Fighters saved!');
+      toast.success(t('characterSelect.saved'));
       navigate(destination.href);
     } catch {
-      toast.error('Failed to save fighters. Please try again.');
+      toast.error(t('characterSelect.saveFailed'));
     }
   }
 
   if (isLoading) {
-    return <div className="text-muted-foreground">Loading your fighters...</div>;
+    return <div className="text-muted-foreground">{t('characterSelect.loading')}</div>;
   }
 
   return (
@@ -102,12 +104,12 @@ export function CharacterSelectScreen({
 
       <div className="flex flex-col gap-3 rounded-lg border p-4">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className="text-lg font-medium">Selected ({selectedSprites.length})</h2>
+          <h2 className="text-lg font-medium">
+            {t('characterSelect.selected', { count: selectedSprites.length })}
+          </h2>
         </div>
         {selectedSprites.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No fighters selected yet. Click a fighter below to add them.
-          </p>
+          <p className="text-sm text-muted-foreground">{t('characterSelect.emptySelected')}</p>
         ) : (
           <div className="flex flex-wrap gap-2">
             {selectedSprites.map((sprite) => (
@@ -124,7 +126,7 @@ export function CharacterSelectScreen({
           <Input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter by name..."
+            placeholder={t('characterSelect.filterPlaceholder')}
             className="max-w-xs"
           />
           <div className="flex flex-1 flex-wrap justify-end gap-2">

--- a/apps/web/src/pages/CharacterSelect/ChoosePrimaryPage.tsx
+++ b/apps/web/src/pages/CharacterSelect/ChoosePrimaryPage.tsx
@@ -1,18 +1,17 @@
+import { useTranslation } from 'react-i18next';
 import { CharacterSelectScreen } from './CharacterSelectScreen';
 
 /** Ports legacy/src/screens/CharacterSelect/PrimarySelect. */
 export function ChoosePrimaryPage() {
+  const { t } = useTranslation();
   return (
     <CharacterSelectScreen
       slot="primary"
-      heading="Choose Your Primaries"
-      description={
-        'Begin by selecting your primary fighters. You can search using the input below. ' +
-        "To remove a character, simply click it again. When you're finished, press Save."
-      }
+      heading={t('characterSelect.primaryHeading')}
+      description={t('characterSelect.primaryDescription')}
       destinations={[
-        { label: 'Save and Choose Secondaries', href: '/choose-secondary' },
-        { label: 'Save and go to Dashboard', href: '/dashboard' },
+        { label: t('characterSelect.saveAndSecondaries'), href: '/choose-secondary' },
+        { label: t('characterSelect.saveAndDashboard'), href: '/dashboard' },
       ]}
     />
   );

--- a/apps/web/src/pages/CharacterSelect/ChooseSecondaryPage.tsx
+++ b/apps/web/src/pages/CharacterSelect/ChooseSecondaryPage.tsx
@@ -1,19 +1,17 @@
+import { useTranslation } from 'react-i18next';
 import { CharacterSelectScreen } from './CharacterSelectScreen';
 
 /** Ports legacy/src/screens/CharacterSelect/SecondarySelect. */
 export function ChooseSecondaryPage() {
+  const { t } = useTranslation();
   return (
     <CharacterSelectScreen
       slot="secondary"
-      heading="Choose Your Secondaries"
-      description={
-        'Begin by selecting your secondary fighters. You can search using the input below. ' +
-        "To remove a character, simply click it again. When you're finished, press Save " +
-        'to begin using Smash Tracker!'
-      }
+      heading={t('characterSelect.secondaryHeading')}
+      description={t('characterSelect.secondaryDescription')}
       destinations={[
-        { label: 'Save and go to Dashboard', href: '/dashboard' },
-        { label: 'Save and choose Primary Fighters', href: '/choose-primary' },
+        { label: t('characterSelect.saveAndDashboard'), href: '/dashboard' },
+        { label: t('characterSelect.saveAndPrimaries'), href: '/choose-primary' },
       ]}
     />
   );

--- a/apps/web/src/pages/Profile/ProfilePage.tsx
+++ b/apps/web/src/pages/Profile/ProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { useStartggStatus } from '@/hooks/useStartgg';
 import { useParryggStatus } from '@/hooks/useParrygg';
@@ -19,6 +20,7 @@ import { YourDataCard } from './components/YourDataCard';
  * change, sign-out-everywhere, avatar upload.
  */
 export function ProfilePage() {
+  const { t } = useTranslation();
   const { user } = useAuth();
   const startgg = useStartggStatus();
   const parrygg = useParryggStatus();
@@ -29,7 +31,7 @@ export function ProfilePage() {
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
+      <h1 className="text-2xl font-semibold tracking-tight">{t('profile.title')}</h1>
 
       <AccountCard
         user={user}

--- a/apps/web/src/pages/Profile/accountInfo.test.ts
+++ b/apps/web/src/pages/Profile/accountInfo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { UserInfo } from 'firebase/auth';
+import i18n from '@/i18n';
 import { describeSignInMethods, formatMemberSince, getSecurityState } from './accountInfo';
 
 /** Minimal `UserInfo`-shaped provider entry for `providerData` arrays in tests. */
@@ -39,36 +40,53 @@ describe('describeSignInMethods', () => {
       describeSignInMethods(
         { providerData: [provider('password'), provider('google.com')] },
         { startggLinked: false, parryggLinked: false },
+        i18n.t,
       ),
     ).toBe('Email & password, Google');
   });
 
   it('infers start.gg when providerData is empty but a start.gg account is linked', () => {
     expect(
-      describeSignInMethods({ providerData: [] }, { startggLinked: true, parryggLinked: false }),
+      describeSignInMethods(
+        { providerData: [] },
+        { startggLinked: true, parryggLinked: false },
+        i18n.t,
+      ),
     ).toBe('start.gg');
   });
 
   it('infers parry.gg verification when providerData is empty but parry.gg is linked', () => {
     expect(
-      describeSignInMethods({ providerData: [] }, { startggLinked: false, parryggLinked: true }),
+      describeSignInMethods(
+        { providerData: [] },
+        { startggLinked: false, parryggLinked: true },
+        i18n.t,
+      ),
     ).toBe('parry.gg verification');
   });
 
   it('falls back to "Custom sign-in" when nothing is known or linked', () => {
     expect(
-      describeSignInMethods({ providerData: [] }, { startggLinked: false, parryggLinked: false }),
+      describeSignInMethods(
+        { providerData: [] },
+        { startggLinked: false, parryggLinked: false },
+        i18n.t,
+      ),
     ).toBe('Custom sign-in');
   });
 });
 
 describe('formatMemberSince', () => {
   it('formats a creationTime string as "Month Year"', () => {
-    expect(formatMemberSince('Mon, 05 Jan 2026 00:00:00 GMT')).toBe('January 2026');
+    expect(formatMemberSince('Mon, 05 Jan 2026 00:00:00 GMT', 'en')).toBe('January 2026');
+  });
+
+  it('formats with the given locale', () => {
+    expect(formatMemberSince('Mon, 05 Jan 2026 00:00:00 GMT', 'es')).toBe('enero de 2026');
   });
 
   it('returns null when creationTime is missing or unparseable', () => {
-    expect(formatMemberSince(undefined)).toBeNull();
-    expect(formatMemberSince('not a date')).toBeNull();
+    expect(formatMemberSince(undefined, 'en')).toBeNull();
+    expect(formatMemberSince('not a date', 'en')).toBeNull();
   });
 });

--- a/apps/web/src/pages/Profile/accountInfo.ts
+++ b/apps/web/src/pages/Profile/accountInfo.ts
@@ -1,4 +1,5 @@
 import type { User as FirebaseUser } from 'firebase/auth';
+import type { TFunction } from 'i18next';
 
 /** Which of the three mutually-exclusive Security card states applies to the signed-in user. */
 export type SecurityState = 'password' | 'reset-only' | 'no-email';
@@ -36,10 +37,11 @@ export function getSecurityState(
 export function describeSignInMethods(
   user: Pick<FirebaseUser, 'providerData'>,
   links: { startggLinked: boolean; parryggLinked: boolean },
+  t: TFunction,
 ): string {
   const known = user.providerData
     .map((p): string | null => {
-      if (p.providerId === 'password') return 'Email & password';
+      if (p.providerId === 'password') return t('profile.account.methodEmailPassword');
       if (p.providerId === 'google.com') return 'Google';
       return null;
     })
@@ -53,13 +55,13 @@ export function describeSignInMethods(
     return 'start.gg';
   }
   if (links.parryggLinked) {
-    return 'parry.gg verification';
+    return t('profile.account.methodParrygg');
   }
-  return 'Custom sign-in';
+  return t('profile.account.methodCustom');
 }
 
-/** "Member since <month year>" from Firebase's `metadata.creationTime` (a `Date`-parseable string), or null if absent. */
-export function formatMemberSince(creationTime: string | undefined): string | null {
+/** "<Month year>" from Firebase's `metadata.creationTime` (a `Date`-parseable string), or null if absent. */
+export function formatMemberSince(creationTime: string | undefined, locale: string): string | null {
   if (!creationTime) {
     return null;
   }
@@ -67,5 +69,5 @@ export function formatMemberSince(creationTime: string | undefined): string | nu
   if (Number.isNaN(date.getTime())) {
     return null;
   }
-  return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  return date.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
 }

--- a/apps/web/src/pages/Profile/components/AccountCard.tsx
+++ b/apps/web/src/pages/Profile/components/AccountCard.tsx
@@ -1,4 +1,5 @@
 import type { User as FirebaseUser } from 'firebase/auth';
+import { useTranslation } from 'react-i18next';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { describeSignInMethods, formatMemberSince } from '../accountInfo';
@@ -24,19 +25,20 @@ export function AccountCard({
   parryggLinked: boolean;
   parryggGamerTag: string | undefined;
 }) {
-  const memberSince = formatMemberSince(user.metadata.creationTime);
-  const signInMethods = describeSignInMethods(user, { startggLinked, parryggLinked });
+  const { t, i18n } = useTranslation();
+  const memberSince = formatMemberSince(user.metadata.creationTime, i18n.language);
+  const signInMethods = describeSignInMethods(user, { startggLinked, parryggLinked }, t);
   const identity = user.email
     ? user.email
     : parryggGamerTag
-      ? `parry.gg account (no email) — linked to ${parryggGamerTag}`
-      : 'parry.gg account (no email)';
+      ? t('profile.account.parryggNoEmailLinked', { tag: parryggGamerTag })
+      : t('profile.account.parryggNoEmail');
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Account</CardTitle>
-        <CardDescription>Your smash-tracker identity.</CardDescription>
+        <CardTitle>{t('profile.account.title')}</CardTitle>
+        <CardDescription>{t('profile.account.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
@@ -46,12 +48,14 @@ export function AccountCard({
           <div className="flex flex-col">
             <span className="font-medium">{identity}</span>
             {memberSince && (
-              <span className="text-sm text-muted-foreground">Member since {memberSince}</span>
+              <span className="text-sm text-muted-foreground">
+                {t('profile.account.memberSince', { date: memberSince })}
+              </span>
             )}
           </div>
         </div>
         <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
-          <dt className="text-muted-foreground">Sign-in methods</dt>
+          <dt className="text-muted-foreground">{t('profile.account.signInMethods')}</dt>
           <dd className="font-medium">{signInMethods}</dd>
         </dl>
       </CardContent>

--- a/apps/web/src/pages/Profile/components/BillingCard.tsx
+++ b/apps/web/src/pages/Profile/components/BillingCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -6,8 +7,8 @@ import { BuyCreditsDialog } from '@/components/billing/BuyCreditsDialog';
 import { useCredits } from '@/hooks/useBilling';
 import { useReportsConfig } from '@/hooks/useScoutReports';
 
-function formatUsd(amountCents: number): string {
-  return (amountCents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+function formatUsd(amountCents: number, locale: string): string {
+  return (amountCents / 100).toLocaleString(locale, { style: 'currency', currency: 'USD' });
 }
 
 /**
@@ -17,6 +18,7 @@ function formatUsd(amountCents: number): string {
  * ScoutPage uses to hide its own report-generation UI.
  */
 export function BillingCard() {
+  const { t, i18n } = useTranslation();
   const reportsConfig = useReportsConfig();
   const credits = useCredits();
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
@@ -34,23 +36,27 @@ export function BillingCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Billing</CardTitle>
-        <CardDescription>AI scouting report credits.</CardDescription>
+        <CardTitle>{t('profile.billing.title')}</CardTitle>
+        <CardDescription>{t('profile.billing.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         {freeAccess ? (
           <Badge variant="success" className="self-start">
-            Free access
+            {t('profile.billing.freeAccess')}
           </Badge>
         ) : (
           <>
             <div className="flex items-center gap-2">
-              <span className="text-lg font-semibold">{creditsData?.balance ?? 0} credits</span>
+              <span className="text-lg font-semibold">
+                {t('profile.billing.credits', { count: creditsData?.balance ?? 0 })}
+              </span>
             </div>
             {cheapestPack && (
               <p className="text-sm text-muted-foreground">
-                Packs start at {formatUsd(cheapestPack.amountCents)} for {cheapestPack.credits}{' '}
-                reports.
+                {t('profile.billing.packsStartAt', {
+                  price: formatUsd(cheapestPack.amountCents, i18n.language),
+                  count: cheapestPack.credits,
+                })}
               </p>
             )}
             {canBuyCredits && (
@@ -60,7 +66,7 @@ export function BillingCard() {
                 className="self-start"
                 onClick={() => setBuyCreditsOpen(true)}
               >
-                Buy credits
+                {t('profile.billing.buyCredits')}
               </Button>
             )}
           </>

--- a/apps/web/src/pages/Profile/components/ChangePasswordForm.tsx
+++ b/apps/web/src/pages/Profile/components/ChangePasswordForm.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,34 +17,37 @@ import {
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/useAuth';
 
-const changePasswordSchema = z
-  .object({
-    currentPassword: z.string().min(1, 'Current password is required'),
-    newPassword: z.string().min(6, 'Password should be at least 6 characters'),
-    confirmPassword: z.string().min(1, 'Please confirm your new password'),
-  })
-  .refine((values) => values.newPassword === values.confirmPassword, {
-    message: "Passwords don't match",
-    path: ['confirmPassword'],
-  });
+/** A factory (not a module constant) so validation messages come out of the active locale — same pattern as `buildMatchFormSchema`. */
+function buildChangePasswordSchema(t: TFunction) {
+  return z
+    .object({
+      currentPassword: z.string().min(1, t('profile.password.currentRequired')),
+      newPassword: z.string().min(6, t('profile.password.minLength')),
+      confirmPassword: z.string().min(1, t('profile.password.confirmRequired')),
+    })
+    .refine((values) => values.newPassword === values.confirmPassword, {
+      message: t('profile.password.mismatch'),
+      path: ['confirmPassword'],
+    });
+}
 
-type ChangePasswordValues = z.infer<typeof changePasswordSchema>;
+type ChangePasswordValues = z.infer<ReturnType<typeof buildChangePasswordSchema>>;
 
 /** Maps the Firebase Auth error codes this flow can hit to a friendly inline message. */
-function describePasswordChangeError(error: unknown): string {
+function describePasswordChangeError(error: unknown, t: TFunction): string {
   const code = hasCode(error) ? error.code : undefined;
   switch (code) {
     case 'auth/wrong-password':
     case 'auth/invalid-credential':
-      return 'Current password is incorrect.';
+      return t('profile.password.wrongCurrent');
     case 'auth/weak-password':
-      return 'Password should be at least 6 characters.';
+      return t('profile.password.weak');
     case 'auth/requires-recent-login':
-      return 'For your security, please sign out and sign back in, then try again.';
+      return t('profile.password.requiresRecentLogin');
     default:
       return error instanceof Error && error.message
         ? error.message
-        : 'Something went wrong. Please try again.';
+        : t('profile.password.genericError');
   }
 }
 
@@ -62,12 +67,13 @@ function hasCode(error: unknown): error is { code: string } {
  * `updatePassword`), then reset the form on success.
  */
 export function ChangePasswordForm() {
+  const { t } = useTranslation();
   const { changePassword } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm<ChangePasswordValues>({
-    resolver: zodResolver(changePasswordSchema),
+    resolver: zodResolver(buildChangePasswordSchema(t)),
     defaultValues: { currentPassword: '', newPassword: '', confirmPassword: '' },
   });
 
@@ -76,10 +82,10 @@ export function ChangePasswordForm() {
     setSubmitting(true);
     try {
       await changePassword(values.currentPassword, values.newPassword);
-      toast.success('Password updated!');
+      toast.success(t('profile.password.updated'));
       form.reset();
     } catch (error) {
-      setFormError(describePasswordChangeError(error));
+      setFormError(describePasswordChangeError(error, t));
     } finally {
       setSubmitting(false);
     }
@@ -93,7 +99,7 @@ export function ChangePasswordForm() {
           name="currentPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Current password</FormLabel>
+              <FormLabel>{t('profile.password.currentLabel')}</FormLabel>
               <FormControl>
                 <Input type="password" autoComplete="current-password" {...field} />
               </FormControl>
@@ -106,7 +112,7 @@ export function ChangePasswordForm() {
           name="newPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>New password</FormLabel>
+              <FormLabel>{t('profile.password.newLabel')}</FormLabel>
               <FormControl>
                 <Input type="password" autoComplete="new-password" {...field} />
               </FormControl>
@@ -119,7 +125,7 @@ export function ChangePasswordForm() {
           name="confirmPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Confirm new password</FormLabel>
+              <FormLabel>{t('profile.password.confirmLabel')}</FormLabel>
               <FormControl>
                 <Input type="password" autoComplete="new-password" {...field} />
               </FormControl>
@@ -129,7 +135,7 @@ export function ChangePasswordForm() {
         />
         {formError && <p className="text-sm text-destructive">{formError}</p>}
         <Button type="submit" disabled={submitting} className="self-start">
-          {submitting ? 'Updating…' : 'Change password'}
+          {submitting ? t('profile.password.updating') : t('profile.password.submit')}
         </Button>
       </form>
     </Form>

--- a/apps/web/src/pages/Profile/components/ConnectedAccountsCard.tsx
+++ b/apps/web/src/pages/Profile/components/ConnectedAccountsCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useStartggStatus } from '@/hooks/useStartgg';
@@ -11,14 +12,15 @@ import { useParryggStatus } from '@/hooks/useParrygg';
  * mutations of its own.
  */
 export function ConnectedAccountsCard() {
+  const { t } = useTranslation();
   const startgg = useStartggStatus();
   const parrygg = useParryggStatus();
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Connected accounts</CardTitle>
-        <CardDescription>start.gg and parry.gg links for automatic match import.</CardDescription>
+        <CardTitle>{t('profile.connected.title')}</CardTitle>
+        <CardDescription>{t('profile.connected.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2 text-sm">
@@ -26,10 +28,10 @@ export function ConnectedAccountsCard() {
           {startgg.data?.linked ? (
             <span className="flex items-center gap-2">
               {startgg.data.gamerTag}
-              <Badge variant="success">Linked</Badge>
+              <Badge variant="success">{t('profile.connected.linked')}</Badge>
             </span>
           ) : (
-            <span className="text-muted-foreground">Not linked</span>
+            <span className="text-muted-foreground">{t('profile.connected.notLinked')}</span>
           )}
         </div>
         <div className="flex items-center justify-between gap-2 text-sm">
@@ -38,18 +40,20 @@ export function ConnectedAccountsCard() {
             <span className="flex items-center gap-2">
               {parrygg.data.gamerTag}
               <Badge variant={parrygg.data.verified ? 'success' : 'outline'}>
-                {parrygg.data.verified ? 'Verified' : 'Unverified'}
+                {parrygg.data.verified
+                  ? t('integrations.parrygg.verified')
+                  : t('integrations.parrygg.unverified')}
               </Badge>
             </span>
           ) : (
-            <span className="text-muted-foreground">Not linked</span>
+            <span className="text-muted-foreground">{t('profile.connected.notLinked')}</span>
           )}
         </div>
         <Link
           to="/settings/integrations"
           className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
         >
-          Manage on Integrations
+          {t('profile.connected.manage')}
         </Link>
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Profile/components/FavoriteStagesCard.tsx
+++ b/apps/web/src/pages/Profile/components/FavoriteStagesCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { ChevronsUpDown, X } from 'lucide-react';
 import type { Stage } from '@smash-tracker/shared';
@@ -26,6 +27,7 @@ import { useStageFavorites, useUpdateStageFavorites } from '@/hooks/useStageFavo
  * order they were added in, which is the order pickers show them.
  */
 export function FavoriteStagesCard() {
+  const { t } = useTranslation();
   const { data: favorites, isLoading } = useStageFavorites();
   const update = useUpdateStageFavorites();
   const [addOpen, setAddOpen] = useState(false);
@@ -40,7 +42,7 @@ export function FavoriteStagesCard() {
     update.mutate(
       { stageIds: nextIds },
       {
-        onError: () => toast.error('Could not save your favorite stages. Please try again.'),
+        onError: () => toast.error(t('profile.favoriteStages.saveError')),
       },
     );
   }
@@ -48,17 +50,14 @@ export function FavoriteStagesCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Favorite Stages</CardTitle>
-        <CardDescription>
-          Pinned to the top of stage pickers when logging matches — handy for the usual
-          quickplay/Elite Smash rotation.
-        </CardDescription>
+        <CardTitle>{t('profile.favoriteStages.title')}</CardTitle>
+        <CardDescription>{t('profile.favoriteStages.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Loading your favorite stages...</p>
+          <p className="text-sm text-muted-foreground">{t('profile.favoriteStages.loading')}</p>
         ) : favoriteStages.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No favorite stages yet.</p>
+          <p className="text-sm text-muted-foreground">{t('profile.favoriteStages.empty')}</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {favoriteStages.map((stage) => (
@@ -71,7 +70,7 @@ export function FavoriteStagesCard() {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  aria-label={`Remove ${stage.name} from favorites`}
+                  aria-label={t('profile.favoriteStages.removeAria', { name: stage.name })}
                   disabled={update.isPending}
                   onClick={() => save(stageIds.filter((id) => id !== stage.id))}
                 >
@@ -90,20 +89,20 @@ export function FavoriteStagesCard() {
               role="combobox"
               // Combobox is not a name-from-content role, so the visible
               // text doesn't become the accessible name on its own.
-              aria-label="Add a favorite stage"
+              aria-label={t('profile.favoriteStages.addAria')}
               aria-expanded={addOpen}
               disabled={isLoading || update.isPending}
               className="justify-between font-normal"
             >
-              Add a favorite stage...
+              {t('profile.favoriteStages.add')}
               <ChevronsUpDown className="opacity-50" />
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
             <Command>
-              <CommandInput placeholder="Search stages..." />
+              <CommandInput placeholder={t('profile.favoriteStages.searchPlaceholder')} />
               <CommandList>
-                <CommandEmpty>No stage found.</CommandEmpty>
+                <CommandEmpty>{t('profile.favoriteStages.noStage')}</CommandEmpty>
                 <CommandGroup>
                   {addableStages.map((stage) => (
                     <CommandItem

--- a/apps/web/src/pages/Profile/components/FightersCard.tsx
+++ b/apps/web/src/pages/Profile/components/FightersCard.tsx
@@ -1,12 +1,14 @@
 import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useFighters } from '@/hooks/useFighters';
 import { SpriteList } from '@/data/sprites';
 
 function FighterSprites({ ids }: { ids: number[] }) {
+  const { t } = useTranslation();
   const sprites = ids.map((id) => SpriteList.find((s) => s.id === id)).filter((s) => s != null);
   if (sprites.length === 0) {
-    return <span className="text-sm text-muted-foreground">None selected</span>;
+    return <span className="text-sm text-muted-foreground">{t('profile.fighters.none')}</span>;
   }
   return (
     <div className="flex flex-wrap gap-2">
@@ -27,25 +29,30 @@ function FighterSprites({ ids }: { ids: number[] }) {
  * changing either half of the selection.
  */
 export function FightersCard() {
+  const { t } = useTranslation();
   const { data: fighters, isLoading } = useFighters();
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Fighters</CardTitle>
-        <CardDescription>Your primary and secondary Smash Ultimate fighters.</CardDescription>
+        <CardTitle>{t('profile.fighters.title')}</CardTitle>
+        <CardDescription>{t('profile.fighters.description')}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Loading your fighters...</p>
+          <p className="text-sm text-muted-foreground">{t('profile.fighters.loading')}</p>
         ) : (
           <>
             <div className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-muted-foreground">Primary</span>
+              <span className="text-sm font-medium text-muted-foreground">
+                {t('profile.fighters.primary')}
+              </span>
               <FighterSprites ids={fighters?.primary ?? []} />
             </div>
             <div className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-muted-foreground">Secondary</span>
+              <span className="text-sm font-medium text-muted-foreground">
+                {t('profile.fighters.secondary')}
+              </span>
               <FighterSprites ids={fighters?.secondary ?? []} />
             </div>
           </>
@@ -54,7 +61,7 @@ export function FightersCard() {
           to="/choose-primary"
           className="self-start text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
         >
-          Edit fighters
+          {t('profile.fighters.edit')}
         </Link>
       </CardContent>
     </Card>

--- a/apps/web/src/pages/Profile/components/SecurityCard.tsx
+++ b/apps/web/src/pages/Profile/components/SecurityCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { User as FirebaseUser } from 'firebase/auth';
 import { Link } from 'react-router';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
@@ -19,16 +20,17 @@ import { ChangePasswordForm } from './ChangePasswordForm';
  *    email and no providers at all; no password flow is possible.
  */
 export function SecurityCard({ user }: { user: FirebaseUser }) {
+  const { t } = useTranslation();
   const state = getSecurityState(user);
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Security</CardTitle>
+        <CardTitle>{t('profile.security.title')}</CardTitle>
         <CardDescription>
-          {state === 'password' && 'Change the password you use to sign in.'}
-          {state === 'reset-only' && 'Add password sign-in to your account.'}
-          {state === 'no-email' && 'How your account signs in.'}
+          {state === 'password' && t('profile.security.descPassword')}
+          {state === 'reset-only' && t('profile.security.descResetOnly')}
+          {state === 'no-email' && t('profile.security.descNoEmail')}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -42,6 +44,7 @@ export function SecurityCard({ user }: { user: FirebaseUser }) {
 
 /** Google / start.gg-provisioned accounts: no `password` provider, so offer a reset email instead of a change form. */
 function ResetOnlySecurity({ email }: { email: string }) {
+  const { t } = useTranslation();
   const { sendPasswordReset } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
@@ -53,7 +56,7 @@ function ResetOnlySecurity({ email }: { email: string }) {
       await sendPasswordReset(email);
       setResult({
         kind: 'success',
-        message: `Reset email sent to ${email}. Follow the link to add password sign-in.`,
+        message: t('profile.security.resetSent', { email }),
       });
     } catch (error) {
       setResult({ kind: 'error', message: getAuthErrorMessage(error) });
@@ -64,12 +67,9 @@ function ResetOnlySecurity({ email }: { email: string }) {
 
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-sm text-muted-foreground">
-        You currently sign in without a password. Sending a password reset email lets you set one
-        up, so you can also sign in with your email and a password going forward.
-      </p>
+      <p className="text-sm text-muted-foreground">{t('profile.security.resetExplainer')}</p>
       <Button type="button" onClick={handleSend} disabled={submitting} className="self-start">
-        {submitting ? 'Sending…' : 'Send password reset email'}
+        {submitting ? t('profile.security.sending') : t('profile.security.sendReset')}
       </Button>
       {result && (
         <p className={`text-sm ${result.kind === 'error' ? 'text-destructive' : ''}`}>
@@ -84,12 +84,14 @@ function ResetOnlySecurity({ email }: { email: string }) {
 function NoEmailSecurity() {
   return (
     <p className="text-sm text-muted-foreground">
-      Your account has no password or email — sign-in works through parry.gg profile verification.
-      Manage that link from{' '}
-      <Link to="/settings/integrations" className="underline underline-offset-4">
-        Integrations
-      </Link>
-      .
+      <Trans
+        i18nKey="profile.security.noEmailBody"
+        components={{
+          integrationsLink: (
+            <Link to="/settings/integrations" className="underline underline-offset-4" />
+          ),
+        }}
+      />
     </p>
   );
 }

--- a/apps/web/src/pages/Profile/components/YourDataCard.tsx
+++ b/apps/web/src/pages/Profile/components/YourDataCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useMatches } from '@/hooks/useMatches';
 import { useGroups } from '@/hooks/useGroups';
@@ -21,6 +22,7 @@ function StatBox({ label, value }: { label: string; value: number }) {
  * feature entirely when it's off.
  */
 export function YourDataCard() {
+  const { t } = useTranslation();
   const { data: matches = [] } = useMatches();
   const { data: groups = [] } = useGroups();
   const reportsConfig = useReportsConfig();
@@ -34,17 +36,17 @@ export function YourDataCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Your data</CardTitle>
-        <CardDescription>What smash-tracker has on file for you.</CardDescription>
+        <CardTitle>{t('profile.data.title')}</CardTitle>
+        <CardDescription>{t('profile.data.description')}</CardDescription>
       </CardHeader>
       <CardContent className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-        <StatBox label="Total matches" value={matches.length} />
-        <StatBox label="From start.gg" value={startggMatches} />
-        <StatBox label="From parry.gg" value={parryggMatches} />
-        <StatBox label="Manually entered" value={manualMatches} />
-        <StatBox label="Groups joined" value={groups.length} />
+        <StatBox label={t('profile.data.totalMatches')} value={matches.length} />
+        <StatBox label={t('profile.data.fromStartgg')} value={startggMatches} />
+        <StatBox label={t('profile.data.fromParrygg')} value={parryggMatches} />
+        <StatBox label={t('profile.data.manual')} value={manualMatches} />
+        <StatBox label={t('profile.data.groupsJoined')} value={groups.length} />
         {reportsEnabled && (
-          <StatBox label="AI reports generated" value={pastReports.data?.length ?? 0} />
+          <StatBox label={t('profile.data.aiReports')} value={pastReports.data?.length ?? 0} />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
Final part of the localization phase-2 series, based on master (which now includes #151).

Extracts every remaining hardcoded string on `/profile`, `/choose-primary`, and `/choose-secondary` into `profile.*` and `characterSelect.*` namespaces — 85 new keys, each translated into es/fr/de/pt/ja with full key parity across all six locales. **This completes the phase-2 page list**: every authenticated page is now localized (public SEO pages stay English by design).

## Highlights

- **Profile / Account**: `describeSignInMethods` now takes `t` (brand names Google/start.gg stay literal); `formatMemberSince` takes the active locale instead of hardcoded `en-US`; parry.gg no-email identity lines are interpolated keys.
- **Profile / Security**: all three mutually-exclusive states localized; the parry.gg no-email body keeps its inline Integrations link via `<Trans>`.
- **Change-password form**: schema converted to a `buildChangePasswordSchema(t)` factory (same pattern as `buildMatchFormSchema`) so zod validation messages localize; the Firebase error-code mapper takes `t`, still falling back to the raw Firebase message for unknown codes.
- **Connected accounts** reuses `integrations.parrygg.verified`/`unverified` for badge parity with the Integrations page.
- **Billing card**: credits count and pack-price line are plural-aware keys; USD prices format with the active locale (currency stays USD).
- **Favorite Stages / Fighters / Your data**: full extraction including aria-labels ("Remove {{name}} from favorites") and stat labels.
- **Character Select**: shared screen plus both page wrappers (headings, descriptions, save-destination button labels, selected-count plural, empty state, filter placeholder, toasts).

## Checks

- `pnpm --filter @smash-tracker/web lint` — 0 errors
- `pnpm --filter @smash-tracker/web typecheck` — clean
- `pnpm --filter @smash-tracker/web test` — 942/942 passing (includes the locale key-parity test and a new es-locale `formatMemberSince` case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)