### PR TITLE
Pin standard online stages in the GSP Quick Logger picker

### DIFF
--- a/apps/web/src/components/StageSelectGroups.tsx
+++ b/apps/web/src/components/StageSelectGroups.tsx
@@ -23,9 +23,10 @@ export function StageSelectValue({ stageId }: { stageId: number }) {
 /**
  * The option list every stage `<Select>` renders (match forms, set wizard,
  * stage breakdown filter): the "no selection" sentinel first, then the
- * user's pinned Favorites, then Most played, then All stages. Groups repeat
- * stages on purpose — see `getGroupedStageOptions`. Must be rendered inside
- * a `<SelectContent>`.
+ * user's pinned Favorites, then Standard (the online trio, where the picker
+ * asks for it), then Most played, then All stages. Groups repeat stages on
+ * purpose — see `getGroupedStageOptions`. Must be rendered inside a
+ * `<SelectContent>`.
  *
  * When `onToggleFavorite` is given, every stage row gets a heart button that
  * favorites/unfavorites it in place — without selecting the row or closing
@@ -41,7 +42,7 @@ export function StageSelectGroups({
   onToggleFavorite?: (stageId: number) => void;
 }) {
   const { t } = useTranslation();
-  const { favorites, mostPlayed, all } = groups;
+  const { favorites, standard, mostPlayed, all } = groups;
   const favoriteIds = new Set(favorites.map((s) => s.id));
 
   const heartFor = (stage: Stage) =>
@@ -61,6 +62,16 @@ export function StageSelectGroups({
           <SelectLabel>{t('matchForm.favorites')}</SelectLabel>
           {favorites.map((s) => (
             <SelectItem key={`favorite-${s.id}`} value={String(s.id)} trailing={heartFor(s)}>
+              <StageOption stage={s} />
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      )}
+      {standard.length > 0 && (
+        <SelectGroup>
+          <SelectLabel>{t('matchForm.standardStages')}</SelectLabel>
+          {standard.map((s) => (
+            <SelectItem key={`standard-${s.id}`} value={String(s.id)} trailing={heartFor(s)}>
               <StageOption stage={s} />
             </SelectItem>
           ))}

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -203,6 +203,7 @@
     "map": "Stage",
     "favorites": "Favoriten",
     "mostPlayed": "Meistgespielt",
+    "standardStages": "Standard",
     "allStages": "Alle Stages",
     "addFavorite": "{{stage}} zu Favoriten hinzufügen",
     "removeFavorite": "{{stage}} aus Favoriten entfernen",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -203,6 +203,7 @@
     "map": "Map",
     "favorites": "Favorites",
     "mostPlayed": "Most played",
+    "standardStages": "Standard",
     "allStages": "All stages",
     "addFavorite": "Add {{stage}} to favorites",
     "removeFavorite": "Remove {{stage}} from favorites",

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -203,6 +203,7 @@
     "map": "Escenario",
     "favorites": "Favoritos",
     "mostPlayed": "Más jugados",
+    "standardStages": "Estándar",
     "allStages": "Todos los escenarios",
     "addFavorite": "Añadir {{stage}} a favoritos",
     "removeFavorite": "Quitar {{stage}} de favoritos",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -203,6 +203,7 @@
     "map": "Stage",
     "favorites": "Favoris",
     "mostPlayed": "Les plus joués",
+    "standardStages": "Standard",
     "allStages": "Tous les stages",
     "addFavorite": "Ajouter {{stage}} aux favoris",
     "removeFavorite": "Retirer {{stage}} des favoris",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -203,6 +203,7 @@
     "map": "ステージ",
     "favorites": "お気に入り",
     "mostPlayed": "よく遊ぶステージ",
+    "standardStages": "基本ステージ",
     "allStages": "すべてのステージ",
     "addFavorite": "{{stage}}をお気に入りに追加",
     "removeFavorite": "{{stage}}をお気に入りから削除",

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -203,6 +203,7 @@
     "map": "Stage",
     "favorites": "Favoritos",
     "mostPlayed": "Mais jogados",
+    "standardStages": "Padrão",
     "allStages": "Todos os stages",
     "addFavorite": "Adicionar {{stage}} aos favoritos",
     "removeFavorite": "Remover {{stage}} dos favoritos",

--- a/apps/web/src/lib/stageOptions.test.ts
+++ b/apps/web/src/lib/stageOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Match } from '@smash-tracker/shared';
-import { alphaStageList, getGroupedStageOptions } from './stageOptions';
+import { STANDARD_ONLINE_STAGE_IDS, alphaStageList, getGroupedStageOptions } from './stageOptions';
 
 function makeMatch(mapId: number, mapName: string, id: string): Match {
   return {
@@ -68,5 +68,27 @@ describe('getGroupedStageOptions', () => {
     const groups = getGroupedStageOptions(matches, [1, 3]);
 
     expect(groups.all).toBe(alphaStageList);
+  });
+
+  it('has no standard group unless the picker asks for one', () => {
+    const groups = getGroupedStageOptions(matches, [1]);
+
+    expect(groups.standard).toEqual([]);
+  });
+
+  it('returns the standard online trio in game order (Small Battlefield between its siblings)', () => {
+    const groups = getGroupedStageOptions(matches, [], STANDARD_ONLINE_STAGE_IDS);
+
+    expect(groups.standard.map((s) => s.name)).toEqual([
+      'Battlefield',
+      'Small Battlefield',
+      'Final Destination',
+    ]);
+  });
+
+  it('excludes favorited stages from the standard group (they are already pinned)', () => {
+    const groups = getGroupedStageOptions(matches, [113], STANDARD_ONLINE_STAGE_IDS);
+
+    expect(groups.standard.map((s) => s.name)).toEqual(['Battlefield', 'Final Destination']);
   });
 });

--- a/apps/web/src/lib/stageOptions.ts
+++ b/apps/web/src/lib/stageOptions.ts
@@ -12,31 +12,48 @@ export const stageOptions = [NO_SELECTION_STAGE, ...alphaStageList];
 
 const MOST_PLAYED_LIMIT = 8;
 
+/**
+ * The three stages online quickplay's preferred-rules matchmaking actually
+ * resolves to (Battlefield, Small Battlefield, Final Destination), in game
+ * order. Alphabetical sorting strands Small Battlefield deep in the S's while
+ * its two siblings sit near the top — pinning the trio as a "Standard" group
+ * fixes the every-match scroll in online-focused pickers (GSP quick logger).
+ */
+export const STANDARD_ONLINE_STAGE_IDS = [1, 113, 3];
+
 export interface GroupedStageOptions {
   /** The user's favorited stages, in the order they favorited them — pinned above everything else. */
   favorites: Stage[];
+  /** The standard online trio (see `STANDARD_ONLINE_STAGE_IDS`), favorites excluded — they're already pinned. Empty unless the picker asks for it. */
+  standard: Stage[];
   /** Top stages by usage (count > 0, favorites excluded — they're already pinned), most-used first, capped at `MOST_PLAYED_LIMIT`. */
   mostPlayed: Stage[];
-  /** Every real stage, alphabetical — intentionally repeats entries already in `favorites`/`mostPlayed` for scannability. */
+  /** Every real stage, alphabetical — intentionally repeats entries already in `favorites`/`standard`/`mostPlayed` for scannability. */
   all: Stage[];
 }
 
 /**
- * Builds the "Favorites" (user-pinned, saved order) + "Most played"
- * (usage-ordered, from the user's unfiltered matches) + "All stages"
- * (alphabetical) grouping shown in stage pickers. `matches` should be the
- * user's full, unfiltered match history — usage ordering isn't meant to
- * react to the global analytics filter. Unknown ids in `favoriteStageIds`
- * are skipped rather than thrown on (stale data can't break the picker).
+ * Builds the "Favorites" (user-pinned, saved order) + optional "Standard"
+ * (the online trio) + "Most played" (usage-ordered, from the user's
+ * unfiltered matches) + "All stages" (alphabetical) grouping shown in stage
+ * pickers. `matches` should be the user's full, unfiltered match history —
+ * usage ordering isn't meant to react to the global analytics filter.
+ * Unknown ids in `favoriteStageIds`/`standardStageIds` are skipped rather
+ * than thrown on (stale data can't break the picker).
  */
 export function getGroupedStageOptions(
   matches: Match[],
   favoriteStageIds: number[] = [],
+  standardStageIds: number[] = [],
 ): GroupedStageOptions {
   const favorites = favoriteStageIds
     .map((id) => stagesById.get(id))
     .filter((stage): stage is Stage => stage != null);
   const favoriteIds = new Set(favorites.map((stage) => stage.id));
+
+  const standard = standardStageIds
+    .map((id) => stagesById.get(id))
+    .filter((stage): stage is Stage => stage != null && !favoriteIds.has(stage.id));
 
   const usage = getStageUsage(matches);
   const mostPlayed = alphaStageList
@@ -46,5 +63,5 @@ export function getGroupedStageOptions(
     .slice(0, MOST_PLAYED_LIMIT)
     .map((entry) => entry.stage);
 
-  return { favorites, mostPlayed, all: alphaStageList };
+  return { favorites, standard, mostPlayed, all: alphaStageList };
 }

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -308,8 +308,10 @@ describe('GspPage', () => {
     await user.click(screen.getByRole('combobox', { name: 'Stage (optional)' }));
 
     expect(await screen.findByText('Favorites')).toBeInTheDocument();
-    // Once under Favorites and once under All stages; the Quick Logger
-    // intentionally has no "Most played" group (no matches dependency).
+    // Once under Favorites and once under All stages; favoriting Final
+    // Destination also removes it from the Standard trio (already pinned).
+    // The Quick Logger intentionally has no "Most played" group (no matches
+    // dependency).
     // Exact name: /Final Destination/ would also catch "(Gen. Final Destination)".
     expect(screen.getAllByRole('option', { name: 'Final Destination' })).toHaveLength(2);
     expect(screen.queryByText('Most played')).not.toBeInTheDocument();
@@ -340,13 +342,16 @@ describe('GspPage', () => {
     await screen.findByText('Quick Logger');
 
     await user.click(screen.getByRole('combobox', { name: 'Stage (optional)' }));
+    // Final Destination renders under Standard AND All stages (a heart each);
+    // either heart toggles the same favorite.
     await user.click(
-      await screen.findByRole('button', { name: 'Add Final Destination to favorites' }),
+      (await screen.findAllByRole('button', { name: 'Add Final Destination to favorites' }))[0]!,
     );
 
     expect(updateStageFavorites).toHaveBeenCalledWith({ stageIds: [3] });
     // The picker stays open and the stage is now pinned under Favorites —
-    // rendered there and again under All stages, both hearts filled.
+    // rendered there and again under All stages (favoriting removes it from
+    // Standard), both hearts filled.
     expect(await screen.findByText('Favorites')).toBeInTheDocument();
     expect(
       screen.getAllByRole('button', { name: 'Remove Final Destination from favorites' }),
@@ -358,6 +363,24 @@ describe('GspPage', () => {
     expect(screen.getByRole('combobox', { name: 'Stage (optional)' })).toHaveTextContent(
       'no selection',
     );
+  });
+
+  it('pins the standard online trio in the Quick Logger stage picker', async () => {
+    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+    const user = userEvent.setup();
+
+    renderGspPage();
+    await screen.findByText('Quick Logger');
+
+    await user.click(screen.getByRole('combobox', { name: 'Stage (optional)' }));
+
+    expect(await screen.findByText('Standard')).toBeInTheDocument();
+    // Each of the trio appears once under Standard and once under All stages.
+    // Exact names: /Battlefield/ would also catch Big/Small/(Gen.) variants.
+    expect(screen.getAllByRole('option', { name: 'Battlefield' })).toHaveLength(2);
+    expect(screen.getAllByRole('option', { name: 'Small Battlefield' })).toHaveLength(2);
+    expect(screen.getAllByRole('option', { name: 'Final Destination' })).toHaveLength(2);
   });
 
   it('requires an opponent character and result before submitting from the Quick Logger', async () => {

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -15,7 +15,11 @@ import {
 } from '@/components/ui/select';
 import { alphaSpriteList } from '@/components/match-form/MatchForm';
 import { NO_SELECTION_STAGE } from '@/data/stages';
-import { getGroupedStageOptions, stageOptions } from '@/lib/stageOptions';
+import {
+  STANDARD_ONLINE_STAGE_IDS,
+  getGroupedStageOptions,
+  stageOptions,
+} from '@/lib/stageOptions';
 import { StageSelectGroups, StageSelectValue } from '@/components/StageSelectGroups';
 import { useStageFavorites, useToggleStageFavorite } from '@/hooks/useStageFavorites';
 import { useCreateMatch } from '@/hooks/useCreateMatch';
@@ -55,8 +59,11 @@ export function QuickLogger({
   // No matches passed (so no "Most played" group): the quick logger has no
   // match-history dependency today, and pulling one in just for usage
   // ordering isn't worth the extra query on this deliberately light form.
+  // The standard online trio IS pinned — quickplay's preferred-rules
+  // matchmaking lands on BF/SBF/FD, and Small Battlefield alphabetizes far
+  // from its siblings.
   const stageGroups = useMemo(
-    () => getGroupedStageOptions([], favoriteStageIds),
+    () => getGroupedStageOptions([], favoriteStageIds, STANDARD_ONLINE_STAGE_IDS),
     [favoriteStageIds],
   );
   const [opponentFighterId, setOpponentFighterId] = useState<number | undefined>(undefined);


### PR DESCRIPTION
## Summary
Community feedback: *"It is SO silly that on the GSP match entry page, FD and BF are at the top of the list, but Small Battlefield is not. Pain in the butt to scroll down to SBF every time."*

- `getGroupedStageOptions` gains an optional **Standard** group (Battlefield, Small Battlefield, Final Destination in game order); favorites keep the top spot and absorb any overlap
- `StageSelectGroups` renders it between Favorites and Most played
- Only the GSP Quick Logger opts in — quickplay's preferred-rules matchmaking is what lands on this trio
- `matchForm.standardStages` added to all 6 locales

## Testing
- 945 web tests pass (4 new: standard-group builder cases + a GspPage picker test)
- Web typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)