### PR TITLE
Auto-run the first start.gg sync after linking or signing up

### DIFF
--- a/apps/web/src/hooks/useStartgg.ts
+++ b/apps/web/src/hooks/useStartgg.ts
@@ -1,4 +1,7 @@
+import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { api } from '@/lib/api';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -35,6 +38,46 @@ export function useStartggSync() {
       ]);
     },
   });
+}
+
+/**
+ * Fires the FIRST sync automatically for a freshly-linked start.gg account:
+ * linked with no `lastSyncAt` yet — the API stamps `lastSyncAt` after every
+ * sync, even one that imports nothing, so this triggers at most once per
+ * link. Community feedback: after "sign up with start.gg" nothing imported
+ * until people discovered Settings → Integrations → "Sync now". Mounting
+ * this once in MainLayout covers both entry points — the login flow (which
+ * lands on the dashboard) and linking from the Integrations page. A failed
+ * attempt doesn't retry until the next full page load; the manual "Sync
+ * now" button remains the recovery path.
+ */
+export function useStartggAutoSync() {
+  const { t } = useTranslation();
+  const { data: status } = useStartggStatus();
+  // v5 mutate functions are referentially stable; the ref guard below is
+  // what actually prevents re-fires (status refetches re-run the effect).
+  const { mutateAsync: runSync } = useStartggSync();
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current || status == null || !status.linked || status.lastSyncAt != null) {
+      return;
+    }
+    attempted.current = true;
+    toast.info(t('integrations.startgg.autoSyncStarted'));
+    runSync()
+      .then((summary) => {
+        toast.success(
+          t('integrations.startgg.autoSyncDone', {
+            imported: summary.imported,
+            sets: summary.sets,
+          }),
+        );
+      })
+      .catch(() => {
+        toast.error(t('integrations.startgg.autoSyncFailed'));
+      });
+  }, [status, runSync, t]);
 }
 
 export function useStartggUnlink() {

--- a/apps/web/src/hooks/useStartggAutoSync.test.tsx
+++ b/apps/web/src/hooks/useStartggAutoSync.test.tsx
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '@/context/AuthContext';
+import { useStartggAutoSync } from './useStartgg';
+import { resetAuthMock, setMockUser, makeMockUser } from '@/test/mockAuth';
+
+const toastInfo = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    info: (...args: unknown[]) => toastInfo(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+vi.mock('firebase/auth', async () => {
+  const mock = await import('@/test/mockAuth');
+  return {
+    onAuthStateChanged: mock.onAuthStateChanged,
+    signInWithEmailAndPassword: mock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: mock.createUserWithEmailAndPassword,
+    signInWithPopup: mock.signInWithPopup,
+    signOut: mock.signOut,
+    getAuth: mock.getAuth,
+    GoogleAuthProvider: mock.GoogleAuthProvider,
+  };
+});
+
+vi.mock('@/lib/firebase', async () => {
+  const mock = await import('@/test/mockAuth');
+  return mock.firebaseLibMock();
+});
+
+const status = vi.fn();
+const sync = vi.fn();
+const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    users: { upsertMe: (...args: unknown[]) => upsertMe(...args) },
+    startgg: {
+      status: (...args: unknown[]) => status(...args),
+      sync: (...args: unknown[]) => sync(...args),
+    },
+  },
+}));
+
+const summary = {
+  sets: 4,
+  imported: 9,
+  setsWithoutGames: 0,
+  gamesUnmappedCharacter: 0,
+  gamesMissingSelections: 0,
+  gamesUnknownStage: 0,
+  dqSets: 0,
+};
+
+function Harness() {
+  useStartggAutoSync();
+  return <div>shell</div>;
+}
+
+function renderHarness() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <Harness />
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('useStartggAutoSync', () => {
+  beforeEach(() => {
+    resetAuthMock();
+    vi.clearAllMocks();
+    upsertMe.mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
+    setMockUser(makeMockUser());
+  });
+
+  it('runs one sync for a freshly-linked account that has never synced', async () => {
+    // First status: never synced. The post-sync invalidation refetches it;
+    // the second response carries the stamp, mirroring the real API.
+    status
+      .mockResolvedValueOnce({ linked: true, gamerTag: 'pilot', playerId: 1, slug: 'user/x' })
+      .mockResolvedValue({
+        linked: true,
+        gamerTag: 'pilot',
+        playerId: 1,
+        slug: 'user/x',
+        lastSyncAt: Date.now(),
+      });
+    sync.mockResolvedValue(summary);
+
+    renderHarness();
+
+    await waitFor(() => expect(sync).toHaveBeenCalledTimes(1));
+    expect(toastInfo).toHaveBeenCalledWith('Importing your start.gg tournament matches…');
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith('start.gg import complete: 9 games from 4 sets.'),
+    );
+    // The post-sync status refetch must not re-trigger the sync.
+    await waitFor(() => expect(status.mock.calls.length).toBeGreaterThan(1));
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not sync when the account has synced before', async () => {
+    status.mockResolvedValue({
+      linked: true,
+      gamerTag: 'pilot',
+      playerId: 1,
+      slug: 'user/x',
+      lastSyncAt: 1_700_000_000_000,
+    });
+
+    renderHarness();
+
+    await screen.findByText('shell');
+    await waitFor(() => expect(status).toHaveBeenCalled());
+    expect(sync).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it('does not sync when no account is linked', async () => {
+    status.mockResolvedValue({ linked: false });
+
+    renderHarness();
+
+    await screen.findByText('shell');
+    await waitFor(() => expect(status).toHaveBeenCalled());
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('shows the failure toast when the first sync fails, without retrying', async () => {
+    status.mockResolvedValue({ linked: true, gamerTag: 'pilot', playerId: 1, slug: 'user/x' });
+    sync.mockRejectedValue(new Error('boom'));
+
+    renderHarness();
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        'start.gg import failed. You can retry from Settings → Integrations.',
+      ),
+    );
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -1028,7 +1028,10 @@
       "connect": "start.gg-Konto verbinden",
       "linked": "start.gg-Konto verknüpft!",
       "linkFailed": "start.gg-Verknüpfung fehlgeschlagen ({{reason}})",
-      "unknownError": "unbekannter Fehler"
+      "unknownError": "unbekannter Fehler",
+      "autoSyncStarted": "Deine start.gg-Turniermatches werden importiert…",
+      "autoSyncDone": "start.gg-Import abgeschlossen: {{imported}} Spiele aus {{sets}} Sets.",
+      "autoSyncFailed": "start.gg-Import fehlgeschlagen. Du kannst es unter Einstellungen → Integrationen erneut versuchen."
     },
     "parrygg": {
       "verified": "Verifiziert",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1028,7 +1028,10 @@
       "connect": "Connect start.gg account",
       "linked": "start.gg account linked!",
       "linkFailed": "start.gg linking failed ({{reason}})",
-      "unknownError": "unknown error"
+      "unknownError": "unknown error",
+      "autoSyncStarted": "Importing your start.gg tournament matches…",
+      "autoSyncDone": "start.gg import complete: {{imported}} games from {{sets}} sets.",
+      "autoSyncFailed": "start.gg import failed. You can retry from Settings → Integrations."
     },
     "parrygg": {
       "verified": "Verified",

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -1028,7 +1028,10 @@
       "connect": "Conectar cuenta de start.gg",
       "linked": "¡Cuenta de start.gg vinculada!",
       "linkFailed": "Falló la vinculación con start.gg ({{reason}})",
-      "unknownError": "error desconocido"
+      "unknownError": "error desconocido",
+      "autoSyncStarted": "Importando tus partidas de torneo de start.gg…",
+      "autoSyncDone": "Importación de start.gg completada: {{imported}} partidas de {{sets}} sets.",
+      "autoSyncFailed": "Falló la importación de start.gg. Puedes reintentarlo en Ajustes → Integraciones."
     },
     "parrygg": {
       "verified": "Verificada",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -1028,7 +1028,10 @@
       "connect": "Connecter un compte start.gg",
       "linked": "Compte start.gg lié !",
       "linkFailed": "Échec de la liaison start.gg ({{reason}})",
-      "unknownError": "erreur inconnue"
+      "unknownError": "erreur inconnue",
+      "autoSyncStarted": "Importation de vos matchs de tournoi start.gg…",
+      "autoSyncDone": "Import start.gg terminé : {{imported}} parties depuis {{sets}} sets.",
+      "autoSyncFailed": "Échec de l'import start.gg. Vous pouvez réessayer depuis Réglages → Intégrations."
     },
     "parrygg": {
       "verified": "Vérifié",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1028,7 +1028,10 @@
       "connect": "start.ggアカウントを連携",
       "linked": "start.ggアカウントを連携しました！",
       "linkFailed": "start.ggの連携に失敗しました（{{reason}}）",
-      "unknownError": "不明なエラー"
+      "unknownError": "不明なエラー",
+      "autoSyncStarted": "start.ggのトーナメント戦績をインポート中…",
+      "autoSyncDone": "start.ggのインポートが完了しました：{{sets}}セットから{{imported}}ゲームを取り込みました。",
+      "autoSyncFailed": "start.ggのインポートに失敗しました。設定 → 連携から再試行できます。"
     },
     "parrygg": {
       "verified": "認証済み",

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -1028,7 +1028,10 @@
       "connect": "Conectar conta do start.gg",
       "linked": "Conta do start.gg vinculada!",
       "linkFailed": "Falha ao vincular o start.gg ({{reason}})",
-      "unknownError": "erro desconhecido"
+      "unknownError": "erro desconhecido",
+      "autoSyncStarted": "Importando suas partidas de torneio do start.gg…",
+      "autoSyncDone": "Importação do start.gg concluída: {{imported}} partidas de {{sets}} sets.",
+      "autoSyncFailed": "Falha na importação do start.gg. Você pode tentar novamente em Configurações → Integrações."
     },
     "parrygg": {
       "verified": "Verificada",

--- a/apps/web/src/layouts/MainLayout.test.tsx
+++ b/apps/web/src/layouts/MainLayout.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/context/AuthContext';
 import { AnalyticsFilterProvider } from '@/context/AnalyticsFilterContext';
 import i18n from '@/i18n';
@@ -31,8 +32,29 @@ vi.mock('@/lib/api', () => ({
     users: {
       upsertMe: vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' }),
     },
+    // MainLayout mounts useStartggAutoSync; unlinked = the no-op path.
+    startgg: {
+      status: vi.fn().mockResolvedValue({ linked: false }),
+    },
   },
 }));
+
+function renderLayout() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <AuthProvider>
+          <AnalyticsFilterProvider>
+            <MainLayout>
+              <div>Page content</div>
+            </MainLayout>
+          </AnalyticsFilterProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
 
 describe('MainLayout', () => {
   beforeEach(() => {
@@ -42,17 +64,7 @@ describe('MainLayout', () => {
   });
 
   it('renders the layout with all nav links and the signed-in user email', async () => {
-    render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <AuthProvider>
-          <AnalyticsFilterProvider>
-            <MainLayout>
-              <div>Page content</div>
-            </MainLayout>
-          </AnalyticsFilterProvider>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    renderLayout();
 
     expect(await screen.findByText('Page content')).toBeInTheDocument();
 
@@ -67,17 +79,7 @@ describe('MainLayout', () => {
   });
 
   it('renders the Donorbox donate link below Training Grounds in the sidebar', async () => {
-    render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <AuthProvider>
-          <AnalyticsFilterProvider>
-            <MainLayout>
-              <div>Page content</div>
-            </MainLayout>
-          </AnalyticsFilterProvider>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    renderLayout();
 
     await screen.findByText('Page content');
 

--- a/apps/web/src/layouts/MainLayout.tsx
+++ b/apps/web/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { SUPPORTED_LANGUAGES } from '@/i18n';
+import { useStartggAutoSync } from '@/hooks/useStartgg';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 import { Footer } from './Footer';
@@ -41,6 +42,8 @@ export function MainLayout({ children }: { children: ReactNode }) {
   // page_view reporting lives in routes/RouteAnalytics.tsx (app-wide, public
   // pages included), not here.
   useLanguageDetectionNotice();
+  // First-ever start.gg sync for a freshly-linked account (see the hook doc).
+  useStartggAutoSync();
   return (
     <TooltipProvider>
       <div className="flex min-h-svh flex-col">

--- a/apps/web/src/routes/ProtectedRoute.test.tsx
+++ b/apps/web/src/routes/ProtectedRoute.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as firebaseAuth from 'firebase/auth';
 import { AuthProvider } from '@/context/AuthContext';
 import { AnalyticsFilterProvider } from '@/context/AnalyticsFilterContext';
@@ -30,28 +31,35 @@ vi.mock('@/lib/api', () => ({
     users: {
       upsertMe: vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' }),
     },
+    // MainLayout mounts useStartggAutoSync; unlinked = the no-op path.
+    startgg: {
+      status: vi.fn().mockResolvedValue({ linked: false }),
+    },
   },
 }));
 
 function renderProtected() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter initialEntries={['/dashboard']}>
-      <AuthProvider>
-        <AnalyticsFilterProvider>
-          <Routes>
-            <Route path="/" element={<div>Home page</div>} />
-            <Route
-              path="/dashboard"
-              element={
-                <ProtectedRoute>
-                  <div>Secret dashboard content</div>
-                </ProtectedRoute>
-              }
-            />
-          </Routes>
-        </AnalyticsFilterProvider>
-      </AuthProvider>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <AuthProvider>
+          <AnalyticsFilterProvider>
+            <Routes>
+              <Route path="/" element={<div>Home page</div>} />
+              <Route
+                path="/dashboard"
+                element={
+                  <ProtectedRoute>
+                    <div>Secret dashboard content</div>
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </AnalyticsFilterProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 


### PR DESCRIPTION
## Summary
Community feedback: *"After signing up using start.gg, it's going to make a lot of people scratch their heads when it doesn't auto sync. You have to go to integrations and click the 'sync' button."*

- New `useStartggAutoSync` hook mounted in `MainLayout`: when status is **linked with no `lastSyncAt`**, it fires one sync automatically with progress/success/failure toasts
- `lastSyncAt` is stamped by the API after every sync (even one importing nothing), so this triggers at most once per link; a failure doesn't retry until the next page load — the manual **Sync now** button stays the recovery path
- Covers both entry points: "login with start.gg" (lands on /dashboard) and linking from Integrations
- Toast strings in all 6 locales under `integrations.startgg.autoSync*`

This also mitigates the reported "opponent tags fixed themselves after some time" oddity: sync keys are idempotent (`sgg-{setId}-g{n}`), so any follow-up sync overwrites earlier partial data from start.gg.

## Testing
- 949 web tests pass (4 new hook tests: fires once, respects lastSyncAt, no-op when unlinked, failure toast without retry)
- MainLayout/ProtectedRoute test harnesses gained the QueryClientProvider the layout now needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)