### PR TITLE
Query defaults: never retry 4xx, 60s staleTime

### DIFF
--- a/apps/web/src/lib/queryClient.test.ts
+++ b/apps/web/src/lib/queryClient.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from './api';
+import { createQueryClient, shouldRetryQuery } from './queryClient';
+
+describe('shouldRetryQuery', () => {
+  it('never retries a 4xx ApiError (deterministic answer, not transient)', () => {
+    for (const status of [400, 401, 404, 409]) {
+      expect(shouldRetryQuery(0, new ApiError(status, 'nope'))).toBe(false);
+    }
+  });
+
+  it('retries 5xx ApiErrors up to the budget', () => {
+    const error = new ApiError(503, 'unavailable');
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(true);
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+
+  it('retries network-level errors up to the budget', () => {
+    const error = new TypeError('Failed to fetch');
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+});
+
+describe('createQueryClient', () => {
+  it('applies the retry predicate and a nonzero staleTime as defaults', () => {
+    const client = createQueryClient();
+    const defaults = client.getDefaultOptions().queries!;
+    expect(defaults.retry).toBe(shouldRetryQuery);
+    expect(defaults.staleTime).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,0 +1,43 @@
+import { QueryClient } from '@tanstack/react-query';
+import { ApiError } from './api';
+
+/** Max automatic retries for transient failures (network blips, 5xx). */
+const MAX_RETRIES = 3;
+
+/** How long fetched data stays fresh before a window focus / remount refetches it. */
+const STALE_TIME_MS = 60_000;
+
+/**
+ * Never retry a 4xx: it's a deterministic answer about THIS request (bad
+ * input, missing auth, missing route), not a transient failure — the same
+ * request will 4xx again. Incident that bought this rule: a web deploy
+ * briefly outran the API deploy carrying /api/gsp-readings, and the default
+ * 3-retry exponential backoff on the resulting 404 blocked the GSP page for
+ * ~8 seconds — re-triggered on every window focus and route re-entry. (The
+ * API attaches a freshly-minted Firebase token per request, so even 401s
+ * aren't retryable-transient here.) Network errors and 5xx keep the normal
+ * retry budget.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+    return false;
+  }
+  return failureCount < MAX_RETRIES;
+}
+
+/**
+ * App-wide QueryClient defaults. `staleTime` keeps tab switches from
+ * refetching every query on the page (mutations invalidate their queries
+ * explicitly throughout the app, so a 60s freshness window is safe); the
+ * retry predicate is documented above.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: shouldRetryQuery,
+        staleTime: STALE_TIME_MS,
+      },
+    },
+  });
+}

--- a/apps/web/src/providers/AppProviders.tsx
+++ b/apps/web/src/providers/AppProviders.tsx
@@ -1,12 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 import { Toaster } from 'sonner';
 import { AuthProvider } from '@/context/AuthContext';
 import { AnalyticsFilterProvider } from '@/context/AnalyticsFilterContext';
+import { createQueryClient } from '@/lib/queryClient';
 
-/** Top-level providers: TanStack Query + Firebase auth context + global analytics filter + sonner toaster. */
+/** Top-level providers: TanStack Query + Firebase auth context + global analytics filter + sonner toaster. Query defaults (no-4xx-retry, staleTime) live in lib/queryClient.ts. */
 export function AppProviders({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(() => createQueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary
Follow-up to the GSP page slow-load report: the visible 8s load (and the reload-on-tab-switch) was TanStack Query retrying a deterministic 404 (`/api/gsp-readings` before rev 00028 landed) 3 times with exponential backoff, re-triggered on focus/remount.

- `shouldRetryQuery`: 4xx `ApiError`s are never retried (deterministic; the client attaches a fresh Firebase token per request so 401s aren't transient either); network errors/5xx keep the 3-retry budget
- App-wide `staleTime: 60s`: tab switches no longer refetch every query on the page; mutations already invalidate their queries explicitly

## Testing
- 966 web tests pass (4 new for the retry predicate + client defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)