### PR TITLE
Live elite/max GSP thresholds from gsptiers.com (lazy 6h refresh)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import opponentAliasesRoutes from './routes/opponentAliases.js';
 import opponentNotesRoutes from './routes/opponentNotes.js';
 import gspSettingsRoutes from './routes/gspSettings.js';
 import gspReadingsRoutes from './routes/gspReadings.js';
+import gspLiveRoutes from './routes/gspLive.js';
 import stageFavoritesRoutes from './routes/stageFavorites.js';
 import startggRoutes from './routes/startgg.js';
 import parryggRoutes from './routes/parrygg.js';
@@ -36,6 +37,8 @@ export interface BuildAppOptions {
   firebase: FirebaseServices;
   /** One origin, or multiple (e.g. parsed from a comma-separated env var). */
   corsOrigin?: string | string[];
+  /** Overridable fetch for the gsptiers.com live-thresholds call (tests). Defaults to global fetch — no prod config needed. */
+  gspLiveFetch?: typeof fetch;
   /** start.gg integration config; null/omitted disables those routes (503). */
   startgg?: StartggConfig | null;
   /** Overridable fetch for the start.gg OAuth/GraphQL calls (tests). */
@@ -152,6 +155,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(opponentNotesRoutes);
       await api.register(gspSettingsRoutes);
       await api.register(gspReadingsRoutes);
+      await api.register(gspLiveRoutes, { fetchImpl: options.gspLiveFetch });
       await api.register(stageFavoritesRoutes);
       await api.register(tournamentsRoutes);
       await api.register(groupsRoutes);

--- a/apps/api/src/gspLive/service.ts
+++ b/apps/api/src/gspLive/service.ts
@@ -1,0 +1,74 @@
+import type { Database } from 'firebase-admin/database';
+import { gspLiveSchema, gsptiersUpstreamSchema, type GspLive } from '@smash-tracker/shared';
+
+/** Refresh upstream when the cached reading is older than this (~4 fetches/day worst case). */
+export const GSP_LIVE_STALE_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * After a failed upstream attempt, don't re-try upstream for this long
+ * (instance-local): with a stale cache and a down upstream, every incoming
+ * request would otherwise re-hit gsptiers.com.
+ */
+export const GSP_LIVE_FAILURE_BACKOFF_MS = 5 * 60 * 1000;
+
+/** gsptiers.com's own data endpoint — the JSON its client renders from. */
+export const GSPTIERS_ENDPOINT = 'https://gsptiers.com/gsp-thingy/gsp';
+
+/** Identifies us to the upstream operator; deliberate low cadence is enforced by the staleness window. */
+const USER_AGENT = 'grandfinals.gg threshold sync (+https://grandfinals.gg; bsmerbeck@gmail.com)';
+
+/**
+ * V17.1: live elite/max GSP readings, RTDB-cached with lazy refresh.
+ *
+ * Read path: return the `gspLive` singleton if it's fresher than
+ * `GSP_LIVE_STALE_MS`; otherwise fetch gsptiers.com's endpoint, store, and
+ * return. On upstream failure the stale cache is served (a few-hours-old
+ * reading still beats the static drift anchor); `null` only when there has
+ * never been a successful fetch AND upstream is failing. The staleness
+ * window — not a scheduler — is what bounds upstream traffic to a few
+ * requests per day in total, regardless of user count.
+ */
+export class GspLiveService {
+  private lastFailedAttemptAt = 0;
+
+  constructor(
+    private readonly database: Database,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async get(logger?: { warn: (obj: unknown, msg?: string) => void }): Promise<GspLive | null> {
+    const snapshot = await this.database.ref('gspLive').get();
+    const cached = snapshot.exists() ? gspLiveSchema.safeParse(snapshot.val()) : null;
+    const cachedValue = cached?.success ? cached.data : null;
+
+    const now = Date.now();
+    if (cachedValue && now - cachedValue.fetchedAt < GSP_LIVE_STALE_MS) {
+      return cachedValue;
+    }
+    if (now - this.lastFailedAttemptAt < GSP_LIVE_FAILURE_BACKOFF_MS) {
+      return cachedValue;
+    }
+
+    try {
+      const response = await this.fetchImpl(GSPTIERS_ENDPOINT, {
+        headers: { 'user-agent': USER_AGENT },
+      });
+      if (!response.ok) {
+        throw new Error(`upstream responded ${response.status}`);
+      }
+      const body = gsptiersUpstreamSchema.parse(await response.json());
+      const record: GspLive = {
+        elite: Math.round(body.elite),
+        max: Math.round(body.max),
+        fetchedAt: now,
+        source: 'gsptiers.com',
+      };
+      await this.database.ref('gspLive').set(record);
+      return record;
+    } catch (err) {
+      this.lastFailedAttemptAt = now;
+      logger?.warn({ err }, 'gsp live upstream refresh failed; serving stale cache if any');
+      return cachedValue;
+    }
+  }
+}

--- a/apps/api/src/routes/gspLive.test.ts
+++ b/apps/api/src/routes/gspLive.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GSP_LIVE_STALE_MS, GSPTIERS_ENDPOINT } from '../gspLive/service.js';
+import { buildTestApp } from '../test-support/testApp.js';
+
+function upstreamOk(body: unknown = { max: 16_368_515, elite: 14_813_136 }) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response);
+}
+
+function upstreamDown() {
+  return vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED'));
+}
+
+describe('GET /api/gsp-live', () => {
+  it('is public: fetches upstream, stores the reading, and returns it', async () => {
+    const fetchImpl = upstreamOk();
+    const { app, database } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+    const before = Date.now();
+
+    // No auth header on purpose — the endpoint exposes no user data.
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.elite).toBe(14_813_136);
+    expect(body.max).toBe(16_368_515);
+    expect(body.source).toBe('gsptiers.com');
+    expect(body.fetchedAt).toBeGreaterThanOrEqual(before);
+    expect(fetchImpl).toHaveBeenCalledExactlyOnceWith(
+      GSPTIERS_ENDPOINT,
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'user-agent': expect.stringContaining('grandfinals') }),
+      }),
+    );
+    expect(database.dump()).toMatchObject({ gspLive: { elite: 14_813_136 } });
+  });
+
+  it('serves a fresh cache without touching upstream', async () => {
+    const fetchImpl = upstreamOk();
+    const { app, database } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+    database.seed('gspLive', {
+      elite: 14_800_000,
+      max: 16_350_000,
+      fetchedAt: Date.now() - 60_000,
+      source: 'gsptiers.com',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().elite).toBe(14_800_000);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a stale cache from upstream', async () => {
+    const fetchImpl = upstreamOk();
+    const { app, database } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+    database.seed('gspLive', {
+      elite: 14_000_000,
+      max: 16_000_000,
+      fetchedAt: Date.now() - GSP_LIVE_STALE_MS - 1,
+      source: 'gsptiers.com',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().elite).toBe(14_813_136);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the stale cache when upstream is failing', async () => {
+    const fetchImpl = upstreamDown();
+    const { app, database } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+    database.seed('gspLive', {
+      elite: 14_000_000,
+      max: 16_000_000,
+      fetchedAt: Date.now() - GSP_LIVE_STALE_MS - 1,
+      source: 'gsptiers.com',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().elite).toBe(14_000_000);
+  });
+
+  it('404s when there is no cache and upstream is failing, then backs off upstream retries', async () => {
+    const fetchImpl = upstreamDown();
+    const { app } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+
+    const first = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+    const second = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(first.statusCode).toBe(404);
+    expect(second.statusCode).toBe(404);
+    // The instance-local failure backoff means the second request must NOT
+    // have re-hit upstream.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an upstream body that fails schema validation without caching it', async () => {
+    const fetchImpl = upstreamOk({ max: 'garbage' });
+    const { app, database } = buildTestApp({ gspLiveFetch: fetchImpl as unknown as typeof fetch });
+
+    const response = await app.inject({ method: 'GET', url: '/api/gsp-live' });
+
+    expect(response.statusCode).toBe(404);
+    expect(database.dump().gspLive).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/gspLive.ts
+++ b/apps/api/src/routes/gspLive.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { errorResponseSchema, gspLiveSchema } from '@smash-tracker/shared';
+import { GspLiveService } from '../gspLive/service.js';
+
+export interface GspLiveRoutesOptions {
+  /** Overridable fetch for the gsptiers.com call (tests). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * V17.1: GET /api/gsp-live — the cached live elite/max GSP thresholds (see
+ * gspLive/service.ts for the lazy-refresh mechanics). Deliberately PUBLIC:
+ * it exposes zero user data (two community-tracked numbers), and keeping it
+ * auth-free lets the public /gsp-calculator page adopt it later. 404 only
+ * when there has never been a successful upstream fetch and upstream is
+ * currently failing — clients fall back to the model's static anchor.
+ */
+const gspLiveRoutes: FastifyPluginAsyncZod<GspLiveRoutesOptions> = async (app, options) => {
+  const service = new GspLiveService(app.firebase.database, options.fetchImpl ?? fetch);
+
+  app.get(
+    '/gsp-live',
+    {
+      schema: {
+        response: {
+          200: gspLiveSchema,
+          404: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const live = await service.get(request.log);
+      if (!live) {
+        return reply.code(404).send({
+          error: 'Not Found',
+          message: 'No live GSP thresholds available yet',
+          statusCode: 404,
+        });
+      }
+      return live;
+    },
+  );
+};
+
+export default gspLiveRoutes;

--- a/apps/api/src/test-support/testApp.ts
+++ b/apps/api/src/test-support/testApp.ts
@@ -13,6 +13,7 @@ export function buildTestApp(
     Parameters<typeof buildApp>[0],
     | 'startgg'
     | 'startggFetch'
+    | 'gspLiveFetch'
     | 'parrygg'
     | 'parryggClients'
     | 'reports'

--- a/apps/web/src/hooks/useGspLive.ts
+++ b/apps/web/src/hooks/useGspLive.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useAuth } from './useAuth';
+
+export const gspLiveQueryKey = ['gspLive'] as const;
+
+/**
+ * GET /api/gsp-live — the live community elite/max GSP thresholds (V17.1),
+ * cached server-side and refreshed from gsptiers.com a few times a day. A
+ * 404 (nothing fetched upstream yet) is normal early on: consumers fall
+ * back to the model's static anchor / the user's manual calibration, so the
+ * query error is simply absorbed as `data: undefined`. Long staleTime — the
+ * server only refreshes every ~6h, so refetching more often buys nothing.
+ */
+export function useGspLive() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: gspLiveQueryKey,
+    queryFn: () => api.gspLive.get(),
+    enabled: user != null,
+    staleTime: 30 * 60 * 1000,
+  });
+}

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · unter Elite ({{elite}})",
       "recentWinRate": "Aktuelle Winrate",
       "lastNGames_one": "letztes Match",
-      "lastNGames_other": "letzte {{count}} Matches"
+      "lastNGames_other": "letzte {{count}} Matches",
+      "liveCalibrated": "automatisch aktualisiert am {{date}} über gsptiers.com"
     },
     "curve": {
       "title": "GSP-Kurve",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · below Elite ({{elite}})",
       "recentWinRate": "Recent Win Rate",
       "lastNGames_one": "last {{count}} game",
-      "lastNGames_other": "last {{count}} games"
+      "lastNGames_other": "last {{count}} games",
+      "liveCalibrated": "auto-updated {{date}} from gsptiers.com"
     },
     "curve": {
       "title": "GSP Curve",

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · por debajo de Elite ({{elite}})",
       "recentWinRate": "% de victorias reciente",
       "lastNGames_one": "última partida",
-      "lastNGames_other": "últimas {{count}} partidas"
+      "lastNGames_other": "últimas {{count}} partidas",
+      "liveCalibrated": "actualizado automáticamente el {{date}} desde gsptiers.com"
     },
     "curve": {
       "title": "Curva de GSP",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · sous l'Élite ({{elite}})",
       "recentWinRate": "Taux de victoire récent",
       "lastNGames_one": "dernier match",
-      "lastNGames_other": "{{count}} derniers matchs"
+      "lastNGames_other": "{{count}} derniers matchs",
+      "liveCalibrated": "mis à jour automatiquement le {{date}} depuis gsptiers.com"
     },
     "curve": {
       "title": "Courbe GSP",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · VIP基準（{{elite}}）未満",
       "recentWinRate": "直近の勝率",
       "lastNGames_one": "直近{{count}}戦",
-      "lastNGames_other": "直近{{count}}戦"
+      "lastNGames_other": "直近{{count}}戦",
+      "liveCalibrated": "gsptiers.comから{{date}}に自動更新"
     },
     "curve": {
       "title": "GSP推移",

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -306,7 +306,8 @@
       "belowElite": "MMR {{mmr}} · abaixo do Elite ({{elite}})",
       "recentWinRate": "Taxa de vitórias recente",
       "lastNGames_one": "última partida",
-      "lastNGames_other": "últimas {{count}} partidas"
+      "lastNGames_other": "últimas {{count}} partidas",
+      "liveCalibrated": "atualizado automaticamente em {{date}} via gsptiers.com"
     },
     "curve": {
       "title": "Curva de GSP",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,7 @@ import {
   groupLeaderboardSchema,
   groupListSchema,
   groupRecordSchema,
+  gspLiveSchema,
   gspReadingSchema,
   gspSettingsSchema,
   joinGroupRequestSchema,
@@ -414,6 +415,10 @@ export const api = {
     /** PUT /api/gsp-settings */
     update: (input: UpsertGspSettingsInput) =>
       apiRequestParsed('/api/gsp-settings', gspSettingsSchema, { method: 'PUT', body: input }),
+  },
+  gspLive: {
+    /** GET /api/gsp-live — cached live elite/max GSP thresholds (server refreshes from gsptiers.com when stale; 404 until the first successful fetch). */
+    get: () => apiRequestParsed('/api/gsp-live', gspLiveSchema),
   },
   gspReadings: {
     /** GET /api/gsp-readings — the signed-in user's standalone "set GSP" calibration readings (V17). */

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -46,6 +46,7 @@ const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@examp
 const getStageFavorites = vi.fn().mockResolvedValue({ stageIds: [], updatedAt: 0 });
 const updateStageFavorites = vi.fn();
 const listGspReadings = vi.fn();
+const getGspLive = vi.fn();
 const createGspReading = vi.fn();
 const updateGspReading = vi.fn();
 const deleteGspReading = vi.fn();
@@ -67,6 +68,9 @@ vi.mock('@/lib/api', () => ({
     stageFavorites: {
       get: (...args: unknown[]) => getStageFavorites(...args),
       update: (...args: unknown[]) => updateStageFavorites(...args),
+    },
+    gspLive: {
+      get: (...args: unknown[]) => getGspLive(...args),
     },
     gspReadings: {
       list: (...args: unknown[]) => listGspReadings(...args),
@@ -132,6 +136,9 @@ describe('GspPage', () => {
     getFighters.mockResolvedValue({ primary: [], secondary: [] });
     listMatches.mockResolvedValue([]);
     listGspReadings.mockResolvedValue([]);
+    // Default: no live thresholds yet (the endpoint 404s until the first
+    // successful upstream fetch) — components fall back to the static anchor.
+    getGspLive.mockRejectedValue(new Error('404: no live thresholds'));
     getGspSettings.mockResolvedValue({ eliteThreshold: 10_000_000, updatedAt: 0 });
     updateGspSettings.mockResolvedValue({ eliteThreshold: 11_000_000, updatedAt: Date.now() });
     createMatch.mockResolvedValue({
@@ -487,6 +494,66 @@ describe('GspPage', () => {
     // delete path too — it hands off to the page's confirmation dialog.
     await user.click(screen.getByRole('button', { name: 'Delete Match' }));
     expect(await screen.findByText('Delete this GSP entry?')).toBeInTheDocument();
+  });
+
+  describe('live thresholds (gsptiers.com via /api/gsp-live)', () => {
+    it('calibrates the threshold card from the live reading and says so', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_050_000 })]);
+      getGspLive.mockResolvedValue({
+        elite: 14_813_136,
+        max: 16_368_515,
+        fetchedAt: Date.now() - 60_000,
+        source: 'gsptiers.com',
+      });
+
+      renderGspPage();
+
+      // The computed threshold now derives from the live calibration: at
+      // ~1 minute of drift it stays within a whisker of the live value.
+      expect(await screen.findByText(nearNumberMatcher(14_813_136))).toBeInTheDocument();
+      expect(screen.getByText(/auto-updated .+ from gsptiers\.com/)).toBeInTheDocument();
+    });
+
+    it('uses the live max for the tier ladder boundaries', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_050_000 })]);
+      getGspLive.mockResolvedValue({
+        elite: 14_813_136,
+        max: 16_368_515,
+        fetchedAt: Date.now() - 60_000,
+        source: 'gsptiers.com',
+      });
+
+      renderGspPage();
+
+      // 9,050,000 sits in Top 50%; its boundary is exactly 0.5 x the live
+      // max (16,368,515 / 2 rounded), not the ratio-model estimate.
+      expect(await screen.findByText('GSP Tiers')).toBeInTheDocument();
+      // findByText: the tiers card renders before the live query resolves,
+      // then re-renders with the live max.
+      expect(
+        await screen.findByText(Math.round(16_368_515 * 0.5).toLocaleString('en-US')),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the manual edit when it is newer than the live reading', async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_050_000 })]);
+      getGspSettings.mockResolvedValue({ eliteThreshold: 15_000_000, updatedAt: Date.now() });
+      getGspLive.mockResolvedValue({
+        elite: 14_813_136,
+        max: 16_368_515,
+        fetchedAt: Date.now() - 60 * 60 * 1000,
+        source: 'gsptiers.com',
+      });
+
+      renderGspPage();
+
+      expect(await screen.findByText(nearNumberMatcher(15_000_000))).toBeInTheDocument();
+      expect(screen.getByText(/recalibrated \d/)).toBeInTheDocument();
+      expect(screen.queryByText(/auto-updated/)).not.toBeInTheDocument();
+    });
   });
 
   describe('calibration readings (set GSP without a match)', () => {

--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -280,41 +280,48 @@ describe('GspPage', () => {
     expect(screen.getByText(/recalibrated/)).toBeInTheDocument();
   });
 
-  it('logs a match through the Quick Logger and shows the GSP + MMR delta toast', async () => {
-    getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
-    listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
-    const user = userEvent.setup();
+  // 10s budget: this walks the full Radix Select + toggle + type + submit
+  // flow and sat right at CI's 5s default once the page gained the
+  // readings/live-thresholds queries.
+  it(
+    'logs a match through the Quick Logger and shows the GSP + MMR delta toast',
+    { timeout: 10_000 },
+    async () => {
+      getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });
+      listMatches.mockResolvedValue([makeMatch({ id: 'm1', time: 1, win: true, gsp: 9_000_000 })]);
+      const user = userEvent.setup();
 
-    renderGspPage();
+      renderGspPage();
 
-    await screen.findByText('Quick Logger');
+      await screen.findByText('Quick Logger');
 
-    await user.click(screen.getByRole('combobox', { name: 'Opponent Character' }));
-    await user.click(await screen.findByRole('option', { name: luigi.name }));
+      await user.click(screen.getByRole('combobox', { name: 'Opponent Character' }));
+      await user.click(await screen.findByRole('option', { name: luigi.name }));
 
-    await user.click(screen.getByRole('radio', { name: 'Win' }));
+      await user.click(screen.getByRole('radio', { name: 'Win' }));
 
-    const gspInput = screen.getByLabelText('GSP After Match');
-    await user.clear(gspInput);
-    await user.type(gspInput, '9500000');
+      const gspInput = screen.getByLabelText('GSP After Match');
+      await user.clear(gspInput);
+      await user.type(gspInput, '9500000');
 
-    await user.click(screen.getByRole('button', { name: 'Log Match' }));
+      await user.click(screen.getByRole('button', { name: 'Log Match' }));
 
-    await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(1));
-    expect(createMatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fighter_id: mario.id,
-        opponent_id: luigi.id,
-        matchType: 'quickplay',
-        win: true,
-        gsp: 9_500_000,
-      }),
-    );
-    // The toast carries both deltas: raw GSP and the estimated MMR change
-    // (both readings land on the main curve, so the conversion is "clean").
-    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('+500,000 GSP'));
-    expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/≈ \+\d+ MMR/));
-  });
+      await waitFor(() => expect(createMatch).toHaveBeenCalledTimes(1));
+      expect(createMatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fighter_id: mario.id,
+          opponent_id: luigi.id,
+          matchType: 'quickplay',
+          win: true,
+          gsp: 9_500_000,
+        }),
+      );
+      // The toast carries both deltas: raw GSP and the estimated MMR change
+      // (both readings land on the main curve, so the conversion is "clean").
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('+500,000 GSP'));
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/≈ \+\d+ MMR/));
+    },
+  );
 
   it('pins favorited stages atop the Quick Logger stage picker', async () => {
     getFighters.mockResolvedValue({ primary: [mario.id], secondary: [] });

--- a/apps/web/src/pages/Gsp/components/GspCurve.tsx
+++ b/apps/web/src/pages/Gsp/components/GspCurve.tsx
@@ -12,12 +12,13 @@ import {
   type ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import type { GspPoint, GspSettings, TCalibration } from '@smash-tracker/shared';
 import { GSP_MODEL } from '@smash-tracker/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
 import { calibrationFromSettings, computedEliteThreshold, toMmrSeries } from '../lib/gspMmrModel';
+import { useModelCalibration } from '../lib/useModelCalibration';
 import { useNowMs } from '../lib/useNowMs';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
@@ -93,8 +94,9 @@ export function buildMmrCurveData(
   settings: GspSettings,
   t: TFunction,
   locale: string,
+  /** V17.1: pass `useModelCalibration`'s value to fold in the live gsptiers.com reading; defaults to the manual-edit-only calibration. */
+  calibration: TCalibration | undefined = calibrationFromSettings(settings),
 ) {
-  const calibration = calibrationFromSettings(settings);
   const mmrSeries = toMmrSeries(series, calibration);
   return {
     labels: mmrSeries.map((p) => formatPointLabel(p.time, locale)),
@@ -212,7 +214,8 @@ export function GspCurve({
   const [view, setView] = useState<GspCurveView>('gsp');
   const hasEnoughReadings = series.length >= GSP_CURVE_UNLOCK_THRESHOLD;
 
-  const eliteThreshold = computedEliteThreshold(nowMs, calibrationFromSettings(settings));
+  const calibration = useModelCalibration(settings);
+  const eliteThreshold = computedEliteThreshold(nowMs, calibration);
 
   return (
     <Card>
@@ -244,7 +247,7 @@ export function GspCurve({
               <Line
                 data={
                   view === 'mmr'
-                    ? buildMmrCurveData(series, settings, t, i18n.language)
+                    ? buildMmrCurveData(series, settings, t, i18n.language, calibration)
                     : buildGspCurveData(series, eliteThreshold, t, i18n.language)
                 }
                 options={buildGspCurveOptions(series, i18n.language, onPointClick, t)}

--- a/apps/web/src/pages/Gsp/components/GspHero.tsx
+++ b/apps/web/src/pages/Gsp/components/GspHero.tsx
@@ -10,12 +10,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useUpdateGspSettings } from '@/hooks/useGspSettings';
 import { parseGspNumber } from '../lib/parseGspNumber';
-import {
-  GSP_MMR_DOC_URL,
-  calibrationFromSettings,
-  computedEliteThreshold,
-  estimateMmrAt,
-} from '../lib/gspMmrModel';
+import { GSP_MMR_DOC_URL, computedEliteThreshold, estimateMmrAt } from '../lib/gspMmrModel';
+import { useGspLive } from '@/hooks/useGspLive';
+import { useModelCalibration } from '../lib/useModelCalibration';
 import { useNowMs } from '../lib/useNowMs';
 
 const ELITEGSP_URL = 'https://elitegsp.com';
@@ -58,7 +55,7 @@ export function GspHero({ series, settings }: { series: GspPoint[]; settings: Gs
   const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
   const winRate = getRecentGspWinRate(series);
 
-  const calibration = calibrationFromSettings(settings);
+  const calibration = useModelCalibration(settings);
   const estimate =
     lastPoint !== null ? estimateMmrAt(lastPoint.gsp, lastPoint.time, calibration) : null;
   const roundedMmr = estimate !== null ? Math.round(estimate.mmr) : null;
@@ -162,11 +159,18 @@ function EliteThresholdCard({ settings }: { settings: GspSettings }) {
   const updateSettings = useUpdateGspSettings();
 
   const nowMs = useNowMs();
-  const calibration = calibrationFromSettings(settings);
+  const { data: live } = useGspLive();
+  const calibration = useModelCalibration(settings);
   const computed = computedEliteThreshold(nowMs, calibration);
 
-  const calibrationLabel =
-    settings.updatedAt > 0
+  // V17.1: say which observation is actually calibrating the number — the
+  // live gsptiers.com reading wins whenever it's newer than the manual edit
+  // (matching bestCalibration's pick).
+  const liveActive =
+    live != null && (settings.updatedAt <= 0 || live.fetchedAt >= settings.updatedAt);
+  const calibrationLabel = liveActive
+    ? t('gsp.hero.liveCalibrated', { date: new Date(live.fetchedAt).toLocaleDateString() })
+    : settings.updatedAt > 0
       ? t('gsp.hero.recalibrated', { date: new Date(settings.updatedAt).toLocaleDateString() })
       : t('gsp.hero.fromAnchor');
 

--- a/apps/web/src/pages/Gsp/components/GspTiers.tsx
+++ b/apps/web/src/pages/Gsp/components/GspTiers.tsx
@@ -9,7 +9,9 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getRecentGspWinRate } from './GspHero';
-import { calibrationFromSettings, estimateMmrAt } from '../lib/gspMmrModel';
+import { estimateMmrAt } from '../lib/gspMmrModel';
+import { useGspLive } from '@/hooks/useGspLive';
+import { useModelCalibration } from '../lib/useModelCalibration';
 import { useNowMs } from '../lib/useNowMs';
 
 const GSPTIERS_URL = 'https://gsptiers.com';
@@ -34,8 +36,11 @@ export function GspTiers({ series, settings }: { series: GspPoint[]; settings: G
   const nowMs = useNowMs();
   const lastPoint = series.length > 0 ? series[series.length - 1]! : null;
 
-  const calibration = calibrationFromSettings(settings);
-  const ladder = getGspTierLadder(estimateT(nowMs, calibration));
+  const calibration = useModelCalibration(settings);
+  // V17.1: the live upstream max (when the API has one) replaces the
+  // captured-ratio estimate for the ladder's fraction boundaries.
+  const { data: live } = useGspLive();
+  const ladder = getGspTierLadder(estimateT(nowMs, calibration), { maxGsp: live?.max });
   const position = lastPoint !== null ? getGspTierPosition(lastPoint.gsp, ladder) : null;
 
   const tierName = (id: GspTierId) => t(`gsp.tiers.names.${id}`);

--- a/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
+++ b/apps/web/src/pages/Gsp/components/GspVsGlicko.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { chartColors, darkChartOptions, redLineDataset } from '@/lib/chartTheme';
 import { computeRatingHistory } from '@/lib/glicko';
 import { GSP_VS_GLICKO_MIN_POINTS, buildGspVsGlickoData } from '../lib/gspVsGlicko';
-import { calibrationFromSettings } from '../lib/gspMmrModel';
+import { useModelCalibration } from '../lib/useModelCalibration';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -100,17 +100,15 @@ export function GspVsGlicko({
   settings: GspSettings;
 }) {
   const { t, i18n } = useTranslation();
+  // Hook must run before the early return below.
+  const calibration = useModelCalibration(settings);
   const { periods } = computeRatingHistory(allMatches);
 
   if (gspSeries.length < GSP_VS_GLICKO_MIN_POINTS || periods.length < GSP_VS_GLICKO_MIN_POINTS) {
     return null;
   }
 
-  const { mmr, glicko } = buildGspVsGlickoData(
-    gspSeries,
-    periods,
-    calibrationFromSettings(settings),
-  );
+  const { mmr, glicko } = buildGspVsGlickoData(gspSeries, periods, calibration);
 
   return (
     <Card>

--- a/apps/web/src/pages/Gsp/components/QuickLogger.tsx
+++ b/apps/web/src/pages/Gsp/components/QuickLogger.tsx
@@ -33,7 +33,8 @@ import { useStageFavorites, useToggleStageFavorite } from '@/hooks/useStageFavor
 import { useCreateMatch } from '@/hooks/useCreateMatch';
 import { useCreateGspReading } from '@/hooks/useGspReadings';
 import { parseGspNumber } from '../lib/parseGspNumber';
-import { calibrationFromSettings, estimateMmrAt } from '../lib/gspMmrModel';
+import { estimateMmrAt } from '../lib/gspMmrModel';
+import { useModelCalibration } from '../lib/useModelCalibration';
 
 /**
  * Quick-log the core online-quickplay session loop: pick the opponent's
@@ -69,6 +70,7 @@ export function QuickLogger({
   const { t } = useTranslation();
   const lastGsp = lastPoint?.gsp ?? null;
   const createMatch = useCreateMatch();
+  const calibration = useModelCalibration(settings);
   const { data: stageFavorites } = useStageFavorites();
   const toggleStageFavorite = useToggleStageFavorite();
   const favoriteStageIds = stageFavorites?.stageIds;
@@ -149,7 +151,6 @@ export function QuickLogger({
     // its own log time (t drifts). Only shown when BOTH convert "cleanly"
     // (land on the ±1-GSP-accurate main curve); tail readings are too
     // approximate for a single-match delta to mean anything.
-    const calibration = calibrationFromSettings(settings);
     let mmrDeltaLabel = '';
     if (lastPoint !== null) {
       const prev = estimateMmrAt(lastPoint.gsp, lastPoint.time, calibration);

--- a/apps/web/src/pages/Gsp/lib/gspMmrModel.test.ts
+++ b/apps/web/src/pages/Gsp/lib/gspMmrModel.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { GspPoint, GspSettings } from '@smash-tracker/shared';
+import type { GspLive, GspPoint, GspSettings } from '@smash-tracker/shared';
 import { GSP_MODEL, eliteThresholdGsp, estimateT, gspToMmr, mmrToGsp } from '@smash-tracker/shared';
 import {
+  bestCalibration,
   calibrationFromSettings,
   computedEliteThreshold,
   estimateMmrAt,
@@ -107,5 +108,37 @@ describe('toMmrSeries', () => {
 
   it('returns an empty array for an empty series', () => {
     expect(toMmrSeries([])).toEqual([]);
+  });
+});
+
+describe('bestCalibration (V17.1)', () => {
+  const live: GspLive = {
+    elite: 14_813_136,
+    max: 16_368_515,
+    fetchedAt: 2_000,
+    source: 'gsptiers.com',
+  };
+
+  it('returns undefined with neither a manual edit nor a live reading', () => {
+    expect(bestCalibration({ eliteThreshold: 10_000_000, updatedAt: 0 })).toBeUndefined();
+    expect(bestCalibration({ eliteThreshold: 10_000_000, updatedAt: 0 }, null)).toBeUndefined();
+  });
+
+  it('uses the live reading when the user never edited manually', () => {
+    const calibration = bestCalibration({ eliteThreshold: 10_000_000, updatedAt: 0 }, live);
+    expect(calibration).toEqual({ eliteThresholdGsp: live.elite, atMs: live.fetchedAt });
+  });
+
+  it('prefers whichever observation is fresher', () => {
+    const olderManual = bestCalibration({ eliteThreshold: 15_000_000, updatedAt: 1_000 }, live);
+    expect(olderManual).toEqual({ eliteThresholdGsp: live.elite, atMs: live.fetchedAt });
+
+    const newerManual = bestCalibration({ eliteThreshold: 15_000_000, updatedAt: 3_000 }, live);
+    expect(newerManual).toEqual({ eliteThresholdGsp: 15_000_000, atMs: 3_000 });
+  });
+
+  it('falls back to the manual edit when no live reading exists', () => {
+    const calibration = bestCalibration({ eliteThreshold: 15_000_000, updatedAt: 3_000 });
+    expect(calibration).toEqual({ eliteThresholdGsp: 15_000_000, atMs: 3_000 });
   });
 });

--- a/apps/web/src/pages/Gsp/lib/gspMmrModel.ts
+++ b/apps/web/src/pages/Gsp/lib/gspMmrModel.ts
@@ -1,4 +1,4 @@
-import type { GspPoint, GspSettings, GspZone, TCalibration } from '@smash-tracker/shared';
+import type { GspLive, GspPoint, GspSettings, GspZone, TCalibration } from '@smash-tracker/shared';
 import { eliteThresholdGsp, estimateT, gspToMmr } from '@smash-tracker/shared';
 
 /**
@@ -33,6 +33,30 @@ export const GSP_MMR_DOC_URL =
 export function calibrationFromSettings(settings: GspSettings): TCalibration | undefined {
   if (settings.updatedAt <= 0) return undefined;
   return { eliteThresholdGsp: settings.eliteThreshold, atMs: settings.updatedAt };
+}
+
+/**
+ * V17.1: the calibration the model should actually use — the FRESHEST
+ * elite-threshold observation available. Candidates: the user's manual
+ * threshold edit (`calibrationFromSettings`) and the server's live
+ * gsptiers.com reading (`/api/gsp-live`, refreshed a few times a day). The
+ * newer timestamp wins (ties go to live — same instant, but live is an
+ * upstream measurement rather than a hand-typed one). `live` is optional
+ * everywhere: the endpoint 404s until its first successful upstream fetch,
+ * and consumers must keep working from the manual edit / static anchor.
+ */
+export function bestCalibration(
+  settings: GspSettings,
+  live?: GspLive | null,
+): TCalibration | undefined {
+  const manual = calibrationFromSettings(settings);
+  const liveCalibration: TCalibration | undefined = live
+    ? { eliteThresholdGsp: live.elite, atMs: live.fetchedAt }
+    : undefined;
+  if (manual && liveCalibration) {
+    return liveCalibration.atMs >= manual.atMs ? liveCalibration : manual;
+  }
+  return liveCalibration ?? manual;
 }
 
 /**

--- a/apps/web/src/pages/Gsp/lib/useModelCalibration.ts
+++ b/apps/web/src/pages/Gsp/lib/useModelCalibration.ts
@@ -1,0 +1,15 @@
+import type { GspSettings, TCalibration } from '@smash-tracker/shared';
+import { useGspLive } from '@/hooks/useGspLive';
+import { bestCalibration } from './gspMmrModel';
+
+/**
+ * V17.1: the calibration every GSP-page component should feed the model —
+ * `bestCalibration` over the user's manual threshold edit and the live
+ * gsptiers.com reading (one shared TanStack cache entry regardless of how
+ * many components call this). Replaces direct `calibrationFromSettings`
+ * calls in components; pure builders keep taking a `TCalibration` param.
+ */
+export function useModelCalibration(settings: GspSettings): TCalibration | undefined {
+  const { data: live } = useGspLive();
+  return bestCalibration(settings, live);
+}

--- a/packages/shared/src/gspLive.ts
+++ b/packages/shared/src/gspLive.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/**
+ * V17.1: live community GSP thresholds — the current Elite Smash entry GSP
+ * and the current max GSP (the #1 player), cached server-side in the RTDB
+ * singleton `gspLive` and refreshed lazily from gsptiers.com's own data
+ * endpoint (https://gsptiers.com/gsp-thingy/gsp, the JSON its client
+ * renders from) when older than the API's staleness window (~6h — "a few
+ * times a day" across ALL users, not per user).
+ *
+ * Why: the GSP↔MMR model needs a calibration observation for its drifting
+ * `t` parameter. Before this, the anchor was either the doc's static
+ * 2026-06-11 observation or a manual user edit; a fresh upstream reading a
+ * few times a day keeps the computed threshold (and the tier ladder's max)
+ * honest without anyone typing numbers in. The UI keeps attributing
+ * gsptiers.com (which itself credits elitegsp.com).
+ */
+export const gspLiveSchema = z.object({
+  /** Elite Smash entry GSP as reported upstream. */
+  elite: z.number().int().positive(),
+  /** Max (rank-1) GSP as reported upstream. */
+  max: z.number().int().positive(),
+  /** Epoch ms the API fetched this from upstream — doubles as the model-calibration timestamp. */
+  fetchedAt: z.number(),
+  source: z.literal('gsptiers.com'),
+});
+export type GspLive = z.infer<typeof gspLiveSchema>;
+
+/** The upstream endpoint's response shape (unknown extra keys ignored). */
+export const gsptiersUpstreamSchema = z.object({
+  max: z.number().positive(),
+  elite: z.number().positive(),
+});

--- a/packages/shared/src/gspTiers.ts
+++ b/packages/shared/src/gspTiers.ts
@@ -85,8 +85,12 @@ function round1(value: number): number {
  * and top 20%, but sorting by GSP keeps the ladder monotonic even if the
  * threshold ever drifts past a fraction boundary.
  */
-export function getGspTierLadder(t: number): GspTierBoundary[] {
-  const max = estimateMaxGsp(t);
+export function getGspTierLadder(t: number, options?: { maxGsp?: number }): GspTierBoundary[] {
+  // V17.1: a live upstream max reading (see gspLive.ts) replaces the
+  // estimateMaxGsp ratio model when available — an actual observation beats
+  // the captured-ratio estimate, and a few hours of staleness costs only
+  // ~hundreds of GSP against bands tens of thousands wide.
+  const max = options?.maxGsp ?? estimateMaxGsp(t);
   const elite = eliteThresholdGsp(t);
 
   const rows: GspTierBoundary[] = GSP_TIER_FRACTIONS.map(({ id, fraction }) => ({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -41,3 +41,4 @@ export * from './gsp.js';
 export * from './gspReading.js';
 export * from './gspMmr.js';
 export * from './gspTiers.js';
+export * from './gspLive.js';


### PR DESCRIPTION
## Summary
Follow-up to today's feedback: *"Rather than a static anchor, check a few times a day and keep it updated."*

### API
- `GspLiveService`: RTDB singleton `gspLive` = `{elite, max, fetchedAt, source}`, refreshed lazily from **gsptiers.com's own data endpoint** (`/gsp-thingy/gsp` — JSON, no HTML scraping) when a request finds it older than **6h**. That bounds upstream traffic to ~4 requests/day total regardless of user count; requests carry an identifying User-Agent, and a 5-min instance-local backoff prevents hammering a down upstream (stale readings are served instead)
- `GET /api/gsp-live` — public (zero user data; lets the public /gsp-calculator adopt it later); 404 only before the first successful fetch

### Web
- `bestCalibration(settings, live)`: the freshest elite observation wins — live reading vs the user's manual threshold edit; new `useModelCalibration` hook replaces direct `calibrationFromSettings` calls across the GSP page (hero, curve, quick logger, tiers, vs-Glicko)
- Tier ladder uses the **live max** for its fraction boundaries when available (an observation beats the captured-ratio estimate); model fallback stays
- Threshold card caption: *"auto-updated {date} from gsptiers.com"* when live is the active calibration (all 6 locales)
- Graceful degradation everywhere: no live data → manual edit → static anchor

## Testing
- API 443 (6 new: public access + UA, fresh-cache no-fetch, stale refresh, stale-on-failure, 404+backoff, schema-reject-no-cache)
- Web 969 (bestCalibration precedence, live-calibrated caption, live-max ladder boundary, manual-newer-wins)
- Shared 189, typecheck + lint clean

## Deploy note
Needs an **API deploy** (new route) + hosting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)