### PR TITLE
feat: combine start.gg + parry.gg stats for scouting and AI reports

### DIFF
--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -973,6 +973,142 @@ describe('POST /api/reports (parry.gg, V9-B, allowlisted)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// V13: reports generated from combined start.gg + parry.gg scout data.
+// ---------------------------------------------------------------------------
+
+describe('POST /api/reports (V13 combined)', () => {
+  const combinedPayload = {
+    query: 'user/07dc2239',
+    source: 'startgg' as const,
+    combineWith: { query: PARRY_USER_ID, source: 'parrygg' as const },
+  };
+
+  it('generates and stores a report from a combined-source scout', async () => {
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      player: {
+        source: 'combined',
+        id: 1802316,
+        parryUserId: PARRY_USER_ID,
+        gamerTag: 'Pandem1c',
+      },
+    });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const scoutReports = dump.scoutReports as Record<string, Record<string, unknown>>;
+    const stored = Object.values(scoutReports[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({
+      player: { source: 'combined', id: 1802316, parryUserId: PARRY_USER_ID },
+    });
+  });
+
+  it('falls back to the single source that resolves (parry.gg not found), no 400/404', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.player.id).toBe(1802316);
+    expect(body.player.source).not.toBe('combined');
+  });
+
+  it('does not 400 on a malformed start.gg handle when the parry.gg side resolves', async () => {
+    const { app } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: scoutFetchMock(),
+      reports: REPORTS_CONFIG,
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: {
+        query: 'not a valid start.gg reference',
+        source: 'startgg' as const,
+        combineWith: { query: PARRY_USER_ID, source: 'parrygg' as const },
+      },
+    });
+    // Malformed start.gg side is dropped; parry.gg carries the report.
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ player: { source: 'parrygg' } });
+  });
+
+  it('refunds the credit when a combined scout resolves nothing on either site', async () => {
+    const noPlayerFetch = (async () => gqlResponse({ user: null })) as typeof fetch;
+    const { app, database } = buildTestApp({
+      startgg: STARTGG_CONFIG,
+      startggFetch: noPlayerFetch,
+      reports: {
+        anthropicApiKey: 'sk-test-key',
+        allowedUids: new Set(['someone-else']),
+      },
+      stripe: { secretKey: 'sk-test-123', webhookSecret: 'whsec-test-456' },
+      reportsClient: stubClient(async () => ({
+        stop_reason: 'end_turn',
+        parsed_output: VALID_REPORT,
+      })),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    database.seed(`credits/${TEST_UID}/balance`, 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+
+    expect(response.statusCode).toBe(404);
+    const balance = await database.ref(`credits/${TEST_UID}/balance`).get();
+    expect(balance.val()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // V9-B production fixes: RTDB null-stripping resilience + billing-enabled
 // read access.
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -12,6 +12,7 @@ import { StartggApiError } from '../startgg/client.js';
 import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
 import { parseParryProfileUrl, ParryScoutCache, scoutParryPlayer } from '../parrygg/scout.js';
 import type { ParryggClients } from '../parrygg/client.js';
+import { resolveCombinedScout } from '../scout/combine.js';
 import {
   assembleReportPayload,
   Anthropic,
@@ -167,14 +168,23 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
         ? 'parrygg'
         : (request.body.source ?? 'startgg');
 
-      if (effectiveSource === 'parrygg' && !parryggConfig) {
+      // V13 combined scouting: a second lookup on the OTHER site is merged into
+      // the report's data. combineWith targeting the SAME site is ignored (the
+      // UI never produces it). Combined mode deliberately SKIPS the
+      // single-source 503/400 pre-checks below: an unconfigured or malformed
+      // side is gracefully dropped by the resolver so the other side can still
+      // carry the report (locked "succeed with whatever resolves" behavior).
+      const combineWith = request.body.combineWith;
+      const combined = Boolean(combineWith) && combineWith!.source !== effectiveSource;
+
+      if (!combined && effectiveSource === 'parrygg' && !parryggConfig) {
         return reply.code(503).send({
           error: 'Service Unavailable',
           message: 'parry.gg integration is not configured on this server',
           statusCode: 503,
         });
       }
-      if (effectiveSource === 'startgg' && !startggConfig) {
+      if (!combined && effectiveSource === 'startgg' && !startggConfig) {
         return reply.code(503).send({
           error: 'Service Unavailable',
           message: 'start.gg integration is not configured on this server',
@@ -183,7 +193,7 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       }
 
       let input;
-      if (effectiveSource === 'startgg') {
+      if (!combined && effectiveSource === 'startgg') {
         try {
           input = parseScoutInput(rawQuery);
         } catch (err) {
@@ -224,7 +234,35 @@ const reportsRoutes: FastifyPluginAsyncZod<ReportsRoutesOptions> = async (app, o
       }
 
       let scout;
-      if (effectiveSource === 'parrygg') {
+      if (combined) {
+        const result = await resolveCombinedScout(
+          [{ query: rawQuery, source: effectiveSource }, combineWith!],
+          {
+            startggConfig,
+            parryggConfig: parryggConfig ?? null,
+            fetchImpl,
+            parryggClients: options.parryggClients,
+            scoutCache,
+            parryScoutCache,
+          },
+        );
+        if (!result.ok) {
+          await refundIfSpent();
+          if (result.kind === 'rateLimited') {
+            return reply.code(429).send({
+              error: 'Too Many Requests',
+              message: 'start.gg is rate-limiting requests right now — try again shortly',
+              statusCode: 429,
+            });
+          }
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: 'No player found for that query on either start.gg or parry.gg',
+            statusCode: 404,
+          });
+        }
+        scout = result.report;
+      } else if (effectiveSource === 'parrygg') {
         scout = await scoutParryPlayer(
           parryggConfig!.apiKey,
           rawQuery,

--- a/apps/api/src/routes/scout.test.ts
+++ b/apps/api/src/routes/scout.test.ts
@@ -332,3 +332,92 @@ describe('POST /api/scout (parry.gg, V9-B)', () => {
     expect(response.json()).toMatchObject({ player: { id: 1802316 } });
   });
 });
+
+// ---------------------------------------------------------------------------
+// V13: combine start.gg + parry.gg into one scout via `combineWith`.
+// ---------------------------------------------------------------------------
+
+describe('POST /api/scout (V13 combined)', () => {
+  const combinedPayload = {
+    query: 'user/07dc2239',
+    source: 'startgg' as const,
+    combineWith: { query: PARRY_USER_ID, source: 'parrygg' as const },
+  };
+
+  it('merges both sites into a single combined identity when both resolve', async () => {
+    const { app } = buildTestApp({
+      startgg: CONFIG,
+      startggFetch: scoutFetchMock(),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({
+        getUser: () => ({ id: PARRY_USER_ID, gamerTag: 'Pandem1c' }),
+      }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      player: {
+        source: 'combined',
+        id: 1802316,
+        parryUserId: PARRY_USER_ID,
+        gamerTag: 'Pandem1c',
+      },
+    });
+  });
+
+  it('falls back to the single source that resolves (parry.gg not found)', async () => {
+    const { app } = buildTestApp({
+      startgg: CONFIG,
+      startggFetch: scoutFetchMock(),
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+    expect(response.statusCode).toBe(200);
+    // Only start.gg resolved → single-source report, NOT a combined identity.
+    const body = response.json();
+    expect(body.player.id).toBe(1802316);
+    expect(body.player.source).not.toBe('combined');
+    expect(body.player.parryUserId).toBeUndefined();
+  });
+
+  it('falls back to start.gg when parry.gg is not configured on this deployment', async () => {
+    const { app } = buildTestApp({ startgg: CONFIG, startggFetch: scoutFetchMock() });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+    // No 503 for the combined request — the unconfigured side is dropped.
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ player: { id: 1802316 } });
+  });
+
+  it('returns 404 when neither site resolves the player', async () => {
+    const noPlayerFetch = (async () => gqlResponse({ user: null })) as typeof fetch;
+    const { app } = buildTestApp({
+      startgg: CONFIG,
+      startggFetch: noPlayerFetch,
+      parrygg: { apiKey: 'parry-key' },
+      parryggClients: parryClients({ getUser: () => null }),
+    });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/scout',
+      headers: authHeader(),
+      payload: combinedPayload,
+    });
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/routes/scout.ts
+++ b/apps/api/src/routes/scout.ts
@@ -9,6 +9,7 @@ import { StartggApiError } from '../startgg/client.js';
 import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
 import { parseParryProfileUrl, ParryScoutCache, scoutParryPlayer } from '../parrygg/scout.js';
 import type { ParryggClients } from '../parrygg/client.js';
+import { resolveCombinedScout } from '../scout/combine.js';
 
 export interface ScoutRoutesOptions {
   config: StartggConfig | null;
@@ -82,6 +83,41 @@ const scoutRoutes: FastifyPluginAsyncZod<ScoutRoutesOptions> = async (app, optio
       const effectiveSource = parseParryProfileUrl(rawQuery)
         ? 'parrygg'
         : (request.body.source ?? 'startgg');
+
+      // V13 combined scouting: a second lookup on the OTHER site merges into
+      // one report. combineWith targeting the SAME site as the primary is
+      // ignored (the UI never produces it) and falls through to the normal
+      // single-source path below. Graceful per source-gating: an unconfigured
+      // side is simply skipped inside the resolver, never a 503 here.
+      const combineWith = request.body.combineWith;
+      if (combineWith && combineWith.source !== effectiveSource) {
+        const result = await resolveCombinedScout(
+          [{ query: rawQuery, source: effectiveSource }, combineWith],
+          {
+            startggConfig: config,
+            parryggConfig: parryggConfig ?? null,
+            fetchImpl,
+            parryggClients: options.parryggClients,
+            scoutCache: cache,
+            parryScoutCache: parryCache,
+          },
+        );
+        if (!result.ok) {
+          if (result.kind === 'rateLimited') {
+            return reply.code(429).send({
+              error: 'Too Many Requests',
+              message: 'start.gg is rate-limiting requests right now — try again shortly',
+              statusCode: 429,
+            });
+          }
+          return reply.code(404).send({
+            error: 'Not Found',
+            message: 'No player found for that query on either start.gg or parry.gg',
+            statusCode: 404,
+          });
+        }
+        return result.report;
+      }
 
       if (effectiveSource === 'parrygg') {
         if (!parryggConfig) {

--- a/apps/api/src/scout/combine.ts
+++ b/apps/api/src/scout/combine.ts
@@ -1,0 +1,123 @@
+import { mergeScoutReports, type ScoutReportData, type ScoutSource } from '@smash-tracker/shared';
+import type { ParryggConfig, StartggConfig } from '../config/env.js';
+import type { ParryggClients } from '../parrygg/client.js';
+import { ParryScoutCache, scoutParryPlayer } from '../parrygg/scout.js';
+import { StartggApiError } from '../startgg/client.js';
+import { parseScoutInput, ScoutCache, ScoutInputError, scoutPlayer } from '../startgg/scout.js';
+
+/**
+ * V13 — "combine start.gg + parry.gg" scouting.
+ *
+ * `resolveCombinedScout` scouts a player across BOTH sites (two lookups the
+ * caller has asserted are the same person) and merges the results into one
+ * combined `ScoutReportData`. It reuses the existing per-source scout functions
+ * (`scoutPlayer` / `scoutParryPlayer`) and their in-memory caches verbatim —
+ * this is purely orchestration on top, no new external calls.
+ *
+ * Design decision (locked with the product owner): **succeed with whatever
+ * resolves**. If only one side is found — because the other site has no such
+ * player, the handle was malformed, or that source isn't configured on this
+ * deployment — the single-source report is returned unchanged (still flagged by
+ * its own `player.source`). `notFound` is only returned when NEITHER side
+ * yields a report; `rateLimited` is preferred over `notFound` when a side was
+ * rate-limited and no side succeeded (it's the retryable signal).
+ */
+
+export interface ScoutLookup {
+  query: string;
+  source: ScoutSource;
+}
+
+export interface CombinedScoutDeps {
+  startggConfig: StartggConfig | null;
+  parryggConfig: ParryggConfig | null;
+  fetchImpl: typeof fetch;
+  parryggClients?: ParryggClients;
+  scoutCache: ScoutCache;
+  parryScoutCache: ParryScoutCache;
+}
+
+export type CombinedScoutResult =
+  { ok: true; report: ScoutReportData } | { ok: false; kind: 'notFound' | 'rateLimited' };
+
+type SingleScoutOutcome =
+  { status: 'ok'; report: ScoutReportData } | { status: 'notFound' } | { status: 'rateLimited' };
+
+/**
+ * Scouts ONE lookup. Never throws for the "expected" ways a side can produce
+ * nothing (source unconfigured, player not found, malformed start.gg query,
+ * start.gg rate limit) — those collapse to `notFound`/`rateLimited` so the
+ * other side can still carry the combine. Genuinely unexpected errors still
+ * propagate.
+ */
+async function scoutOne(lookup: ScoutLookup, deps: CombinedScoutDeps): Promise<SingleScoutOutcome> {
+  if (lookup.source === 'parrygg') {
+    // Unconfigured source is treated as "not found" (graceful fallback), not a
+    // 503 — the single-source routes keep their own explicit 503s untouched.
+    if (!deps.parryggConfig) {
+      return { status: 'notFound' };
+    }
+    const report = await scoutParryPlayer(
+      deps.parryggConfig.apiKey,
+      lookup.query,
+      deps.parryScoutCache,
+      deps.parryggClients,
+    );
+    return report ? { status: 'ok', report } : { status: 'notFound' };
+  }
+
+  if (!deps.startggConfig) {
+    return { status: 'notFound' };
+  }
+  let input;
+  try {
+    input = parseScoutInput(lookup.query);
+  } catch (err) {
+    // A malformed start.gg handle on ONE side must not sink the whole combine.
+    if (err instanceof ScoutInputError) {
+      return { status: 'notFound' };
+    }
+    throw err;
+  }
+  try {
+    const report = await scoutPlayer(
+      deps.startggConfig.apiToken,
+      input,
+      deps.fetchImpl,
+      deps.scoutCache,
+    );
+    return report ? { status: 'ok', report } : { status: 'notFound' };
+  } catch (err) {
+    if (err instanceof StartggApiError && err.status === 429) {
+      return { status: 'rateLimited' };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Resolves and merges the given lookups (the caller passes exactly two, one per
+ * site). Runs both in parallel, then folds every side that produced a report:
+ * 2 → merged, 1 → that single report unchanged, 0 → `notFound` (or
+ * `rateLimited` if a side was rate-limited).
+ */
+export async function resolveCombinedScout(
+  lookups: ScoutLookup[],
+  deps: CombinedScoutDeps,
+): Promise<CombinedScoutResult> {
+  const outcomes = await Promise.all(lookups.map((lookup) => scoutOne(lookup, deps)));
+  const reports = outcomes.flatMap((outcome) => (outcome.status === 'ok' ? [outcome.report] : []));
+
+  // The domain is exactly two sites, so there are at most two reports here.
+  const [first, second] = reports;
+  if (first && second) {
+    return { ok: true, report: mergeScoutReports(first, second) };
+  }
+  if (first) {
+    return { ok: true, report: first };
+  }
+  if (outcomes.some((outcome) => outcome.status === 'rateLimited')) {
+    return { ok: false, kind: 'rateLimited' };
+  }
+  return { ok: false, kind: 'notFound' };
+}

--- a/apps/web/src/hooks/useScoutPlayer.ts
+++ b/apps/web/src/hooks/useScoutPlayer.ts
@@ -1,11 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
-import type { ScoutSource } from '@smash-tracker/shared';
+import type { CombineWithLookup, ScoutSource } from '@smash-tracker/shared';
 import { api } from '@/lib/api';
 
 export interface ScoutPlayerInput {
   query: string;
   /** V9-B Feature 4: which site to resolve a bare tag/slug/id against; a pasted parry.gg profile URL auto-detects server-side regardless of this. */
   source?: ScoutSource;
+  /** V13: an additional lookup on the OTHER site to merge into one combined scout. */
+  combineWith?: CombineWithLookup;
 }
 
 /**

--- a/apps/web/src/i18n/locales/de.json
+++ b/apps/web/src/i18n/locales/de.json
@@ -866,7 +866,14 @@
       "source": "Quelle:",
       "sourceAria": "Scouting-Quelle",
       "detectedParry": "parry.gg-Profil-URL erkannt.",
-      "pending": "Öffentliche Turnier-Historie wird abgerufen — das kann ein paar Sekunden dauern."
+      "pending": "Öffentliche Turnier-Historie wird abgerufen — das kann ein paar Sekunden dauern.",
+      "combineBoth": "Beide",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "parry.gg-Profil-URL oder Gamertag",
+      "parryPlaceholder": "parry.gg-Profil-URL oder Gamertag",
+      "combineHint": "Gib diesen Spieler auf beiden Seiten ein, um die Historien zu kombinieren. Fülle nur eines aus, um eine einzelne Seite zu scouten.",
+      "startggFieldAria": "start.gg-Profil-URL, Slug oder Spieler-ID"
     },
     "report": {
       "generate": "KI-Bericht generieren",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "{{name}} auf {{source}} ansehen",
       "profile": "{{source}}-Profil",
-      "sample": "Öffentliche {{source}}-Daten · Stichprobe der letzten {{sets}} Sets ({{games}} Spiele)"
+      "sample": "Öffentliche {{source}}-Daten · Stichprobe der letzten {{sets}} Sets ({{games}} Spiele)",
+      "sampleCombined": "Öffentliche start.gg- + parry.gg-Daten · Stichprobe der letzten {{sets}} Sets ({{games}} Spiele)"
     },
     "characters": {
       "title": "Charakternutzung",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -866,7 +866,14 @@
       "source": "Source:",
       "sourceAria": "Scouting source",
       "detectedParry": "Detected a parry.gg profile URL.",
-      "pending": "Pulling their public tournament history — this can take a few seconds."
+      "pending": "Pulling their public tournament history — this can take a few seconds.",
+      "combineBoth": "Both",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "parry.gg profile URL or gamer tag",
+      "parryPlaceholder": "parry.gg profile URL or gamer tag",
+      "combineHint": "Enter this player on each site to combine their histories. Fill in just one to scout a single site.",
+      "startggFieldAria": "start.gg profile URL, slug, or player id"
     },
     "report": {
       "generate": "Generate AI report",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "View {{name}} on {{source}}",
       "profile": "{{source}} profile",
-      "sample": "Public {{source}} data · sampled last {{sets}} sets ({{games}} games)"
+      "sample": "Public {{source}} data · sampled last {{sets}} sets ({{games}} games)",
+      "sampleCombined": "Public start.gg + parry.gg data · sampled last {{sets}} sets ({{games}} games)"
     },
     "characters": {
       "title": "Character Usage",

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -866,7 +866,14 @@
       "source": "Fuente:",
       "sourceAria": "Fuente de scouting",
       "detectedParry": "Se detectó una URL de perfil de parry.gg.",
-      "pending": "Obteniendo su historial público de torneos — puede tardar unos segundos."
+      "pending": "Obteniendo su historial público de torneos — puede tardar unos segundos.",
+      "combineBoth": "Ambos",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "URL de perfil o gamertag de parry.gg",
+      "parryPlaceholder": "URL de perfil o gamertag de parry.gg",
+      "combineHint": "Introduce a este jugador en cada sitio para combinar sus historiales. Rellena solo uno para explorar un único sitio.",
+      "startggFieldAria": "URL de perfil de start.gg, slug o id de jugador"
     },
     "report": {
       "generate": "Generar informe con IA",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "Ver a {{name}} en {{source}}",
       "profile": "Perfil de {{source}}",
-      "sample": "Datos públicos de {{source}} · muestra de los últimos {{sets}} sets ({{games}} partidas)"
+      "sample": "Datos públicos de {{source}} · muestra de los últimos {{sets}} sets ({{games}} partidas)",
+      "sampleCombined": "Datos públicos de start.gg + parry.gg · muestra de los últimos {{sets}} sets ({{games}} partidas)"
     },
     "characters": {
       "title": "Uso de personajes",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -866,7 +866,14 @@
       "source": "Source :",
       "sourceAria": "Source de scouting",
       "detectedParry": "URL de profil parry.gg détectée.",
-      "pending": "Récupération de son historique public de tournois — cela peut prendre quelques secondes."
+      "pending": "Récupération de son historique public de tournois — cela peut prendre quelques secondes.",
+      "combineBoth": "Les deux",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "URL de profil parry.gg ou tag de joueur",
+      "parryPlaceholder": "URL de profil parry.gg ou tag de joueur",
+      "combineHint": "Saisis ce joueur sur chaque site pour combiner leurs historiques. N'en remplis qu'un seul pour scouter un seul site.",
+      "startggFieldAria": "URL de profil start.gg, slug ou id de joueur"
     },
     "report": {
       "generate": "Générer un rapport IA",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "Voir {{name}} sur {{source}}",
       "profile": "Profil {{source}}",
-      "sample": "Données publiques {{source}} · échantillon des {{sets}} derniers sets ({{games}} matchs)"
+      "sample": "Données publiques {{source}} · échantillon des {{sets}} derniers sets ({{games}} matchs)",
+      "sampleCombined": "Données publiques start.gg + parry.gg · échantillon des {{sets}} derniers sets ({{games}} matchs)"
     },
     "characters": {
       "title": "Personnages utilisés",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -866,7 +866,14 @@
       "source": "ソース:",
       "sourceAria": "スカウティングのソース",
       "detectedParry": "parry.ggのプロフィールURLを検出しました。",
-      "pending": "公開大会履歴を取得中 — 数秒かかることがあります。"
+      "pending": "公開大会履歴を取得中 — 数秒かかることがあります。",
+      "combineBoth": "両方",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "parry.gg のプロフィールURL またはゲーマータグ",
+      "parryPlaceholder": "parry.gg のプロフィールURL またはゲーマータグ",
+      "combineHint": "両方のサイトでこのプレイヤーを入力すると履歴を統合できます。片方だけ入力すると単一サイトを偵察します。",
+      "startggFieldAria": "start.ggのプロフィールURL・スラッグ・プレイヤーID"
     },
     "report": {
       "generate": "AIレポートを生成",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "{{name}}を{{source}}で見る",
       "profile": "{{source}}プロフィール",
-      "sample": "{{source}}の公開データ · 直近{{sets}}セット（{{games}}ゲーム）のサンプル"
+      "sample": "{{source}}の公開データ · 直近{{sets}}セット（{{games}}ゲーム）のサンプル",
+      "sampleCombined": "start.gg + parry.gg の公開データ · 直近{{sets}}セット（{{games}}ゲーム）のサンプル"
     },
     "characters": {
       "title": "キャラクター使用状況",

--- a/apps/web/src/i18n/locales/pt.json
+++ b/apps/web/src/i18n/locales/pt.json
@@ -866,7 +866,14 @@
       "source": "Fonte:",
       "sourceAria": "Fonte de scouting",
       "detectedParry": "URL de perfil do parry.gg detectada.",
-      "pending": "Obtendo o histórico público de torneios — pode levar alguns segundos."
+      "pending": "Obtendo o histórico público de torneios — pode levar alguns segundos.",
+      "combineBoth": "Ambos",
+      "startggField": "start.gg",
+      "parryField": "parry.gg",
+      "parryFieldAria": "URL de perfil do parry.gg ou gamertag",
+      "parryPlaceholder": "URL de perfil do parry.gg ou gamertag",
+      "combineHint": "Insira este jogador em cada site para combinar os históricos. Preencha apenas um para explorar um único site.",
+      "startggFieldAria": "URL de perfil do start.gg, slug ou id de jogador"
     },
     "report": {
       "generate": "Gerar relatório com IA",
@@ -890,7 +897,8 @@
     "header": {
       "viewOn": "Ver {{name}} no {{source}}",
       "profile": "Perfil no {{source}}",
-      "sample": "Dados públicos do {{source}} · amostra dos últimos {{sets}} sets ({{games}} partidas)"
+      "sample": "Dados públicos do {{source}} · amostra dos últimos {{sets}} sets ({{games}} partidas)",
+      "sampleCombined": "Dados públicos do start.gg + parry.gg · amostra dos últimos {{sets}} sets ({{games}} partidas)"
     },
     "characters": {
       "title": "Uso de personagens",

--- a/apps/web/src/pages/Reports/ReportsPage.tsx
+++ b/apps/web/src/pages/Reports/ReportsPage.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
-import { scoutIdentityKey, type ScoutReportRecord } from '@smash-tracker/shared';
+import {
+  scoutIdentityKey,
+  type ScoutIdentitySource,
+  type ScoutReportRecord,
+} from '@smash-tracker/shared';
 import { useReportsConfig, useScoutReportsList } from '@/hooks/useScoutReports';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -10,12 +14,15 @@ import { ScoutAiReportCard } from '@/pages/Scout/components/ScoutAiReportCard';
 interface ReportGroup {
   key: string;
   gamerTag: string;
-  source: 'startgg' | 'parrygg';
+  source: ScoutIdentitySource;
   /** Newest-first, mirroring GET /api/reports' own ordering. */
   reports: ScoutReportRecord[];
 }
 
-function sourceLabel(source: 'startgg' | 'parrygg'): string {
+function sourceLabel(source: ScoutIdentitySource): string {
+  if (source === 'combined') {
+    return 'start.gg + parry.gg';
+  }
   return source === 'parrygg' ? 'parry.gg' : 'start.gg';
 }
 

--- a/apps/web/src/pages/Scout/ScoutPage.test.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.test.tsx
@@ -34,6 +34,14 @@ vi.mock('@/lib/firebase', async () => {
   return mock.firebaseLibMock();
 });
 
+// parry.gg status drives whether the source toggle (and the V13 "Both" mode)
+// is shown. Default false so the single-source tests keep the parry-free input
+// aria; the combined test flips it true for its duration.
+const parryStatus = vi.hoisted(() => ({ isSuccess: false }));
+vi.mock('@/hooks/useParrygg', () => ({
+  useParryggStatus: () => parryStatus,
+}));
+
 const scoutLookup = vi.fn();
 const matchesList = vi.fn().mockResolvedValue([]);
 const upsertMe = vi.fn().mockResolvedValue({ uid: 'test-uid', email: 'test@example.com' });
@@ -354,6 +362,48 @@ describe('ScoutPage — AI reports feature enabled', () => {
     reportsList.mockResolvedValue([]);
     billingCredits.mockResolvedValue({ freeAccess: false, balance: 0, packs: [] });
     setMockUser(makeMockUser());
+  });
+
+  afterEach(() => {
+    parryStatus.isSuccess = false;
+  });
+
+  it('V13: plumbs a combined "Both" request through to scout and report generation', async () => {
+    parryStatus.isSuccess = true;
+    const user = userEvent.setup();
+    const combinedReport = {
+      ...REPORT,
+      player: {
+        source: 'combined' as const,
+        id: 1802316,
+        userSlug: 'user/07dc2239',
+        parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+        gamerTag: 'Pandem1c',
+      },
+    };
+    scoutLookup.mockResolvedValue(combinedReport);
+    reportsGenerate.mockResolvedValue(GENERATED_RECORD);
+
+    renderPage();
+    await user.click(screen.getByRole('radio', { name: 'Both' }));
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.type(screen.getByLabelText(/parry\.gg profile URL/), 'Pandem1c');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    const combinedRequest = {
+      query: 'user/07dc2239',
+      source: 'startgg',
+      combineWith: { query: 'Pandem1c', source: 'parrygg' },
+    };
+    await waitFor(() => expect(scoutLookup).toHaveBeenCalledWith(combinedRequest));
+
+    // The combined header renders both site labels and the combined caption.
+    expect(await screen.findByText('Pandem1c')).toBeInTheDocument();
+    expect(screen.getByText(/Public start\.gg \+ parry\.gg data/)).toBeInTheDocument();
+
+    // Regenerate re-uses the exact combined request (lastQuery plumbing).
+    await user.click(screen.getByRole('button', { name: /Generate AI report/ }));
+    await waitFor(() => expect(reportsGenerate).toHaveBeenCalledWith(combinedRequest));
   });
 
   it('shows the "Generate AI report" button once a scout result is on screen', async () => {

--- a/apps/web/src/pages/Scout/ScoutPage.tsx
+++ b/apps/web/src/pages/Scout/ScoutPage.tsx
@@ -8,7 +8,6 @@ import {
   scoutIdentityKey,
   type ScoutReportData,
   type ScoutReportRecord,
-  type ScoutSource,
 } from '@smash-tracker/shared';
 import { ApiError } from '@/lib/api';
 import { useScoutPlayer } from '@/hooks/useScoutPlayer';
@@ -18,7 +17,7 @@ import { useCredits } from '@/hooks/useBilling';
 import { useParryggStatus } from '@/hooks/useParrygg';
 import { getOpponentProfile } from '@/lib/stats';
 import { Button } from '@/components/ui/button';
-import { ScoutSearchForm } from './components/ScoutSearchForm';
+import { ScoutSearchForm, type ScoutSubmitRequest } from './components/ScoutSearchForm';
 import { ScoutReportHeader } from './components/ScoutReportHeader';
 import { ScoutCharactersCard } from './components/ScoutCharactersCard';
 import { ScoutStagesCard } from './components/ScoutStagesCard';
@@ -110,7 +109,9 @@ export function ScoutPage() {
   // status fetch, rather than assuming enabled on an ambiguous error.
   const parryggEnabled = parryggStatus.isSuccess;
 
-  const [lastQuery, setLastQuery] = useState<{ query: string; source: ScoutSource } | null>(null);
+  // The exact request behind what's on screen — carries the optional
+  // `combineWith` (V13) so Regenerate re-runs the same combined lookup.
+  const [lastQuery, setLastQuery] = useState<ScoutSubmitRequest | null>(null);
   const [selectedRecord, setSelectedRecord] = useState<ScoutReportRecord | null>(null);
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
   // V9-B Feature 1: which of the CURRENT player's stored reports the history
@@ -190,12 +191,12 @@ export function ScoutPage() {
   const storedRecordForCurrentPlayer =
     reportsForCurrentPlayer[historyIndex ?? 0] ?? reportsForCurrentPlayer[0] ?? null;
 
-  const handleSubmit = (query: string, source: ScoutSource) => {
+  const handleSubmit = (request: ScoutSubmitRequest) => {
     setSelectedRecord(null);
     setHistoryIndex(null);
     generateReport.reset();
-    setLastQuery({ query, source });
-    scout.mutate({ query, source });
+    setLastQuery(request);
+    scout.mutate(request);
   };
 
   // Clicking a past-reports row toggles it: selecting the same record again

--- a/apps/web/src/pages/Scout/components/ScoutReportHeader.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHeader.test.tsx
@@ -50,4 +50,32 @@ describe('ScoutReportHeader', () => {
     render(<ScoutReportHeader report={baseReport({ userSlug: undefined })} />);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
+
+  it('V13: a combined report links to BOTH sites and shows the combined caption', () => {
+    const report: ScoutReportData = {
+      player: {
+        source: 'combined',
+        id: 1802316,
+        userSlug: 'user/07dc2239',
+        parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+        gamerTag: 'Pandem1c',
+      },
+      sampledSets: 5,
+      sampledGames: 12,
+      characters: [],
+      stages: [],
+      recentEvents: [],
+      commonOpponents: [],
+    };
+    render(<ScoutReportHeader report={report} />);
+    expect(screen.getByRole('link', { name: /View Pandem1c on start\.gg/ })).toHaveAttribute(
+      'href',
+      'https://start.gg/user/07dc2239',
+    );
+    expect(screen.getByRole('link', { name: /View Pandem1c on parry\.gg/ })).toHaveAttribute(
+      'href',
+      'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
+    );
+    expect(screen.getByText(/Public start\.gg \+ parry\.gg data/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutReportHeader.tsx
@@ -14,48 +14,66 @@ import type { ScoutReportData } from '@smash-tracker/shared';
  * `userSlug` (that field is start.gg-only), so their profile link is built
  * from `parryUserId` instead — the verified `https://parry.gg/profile/{id}`
  * shape (see apps/api/src/parrygg/scout.ts).
+ *
+ * V13: a `'combined'` identity spans BOTH sites, so it renders BOTH profile
+ * links and a combined sample caption. Each link is only shown when its id
+ * field is present.
  */
 export function ScoutReportHeader({ report }: { report: ScoutReportData }) {
   const { t } = useTranslation();
   const source = report.player.source ?? 'startgg';
-  const profileUrl =
-    source === 'parrygg'
-      ? report.player.parryUserId
-        ? `https://parry.gg/profile/${report.player.parryUserId}`
-        : null
-      : report.player.userSlug
-        ? `https://start.gg/${report.player.userSlug}`
-        : null;
-  const sourceLabel = source === 'parrygg' ? 'parry.gg' : 'start.gg';
+
+  const startggUrl = report.player.userSlug ? `https://start.gg/${report.player.userSlug}` : null;
+  const parryUrl = report.player.parryUserId
+    ? `https://parry.gg/profile/${report.player.parryUserId}`
+    : null;
+
+  // Which profile link(s) to show, in display order, each with its site label.
+  const profileLinks: Array<{ url: string; label: string }> = [];
+  if (source === 'combined') {
+    if (startggUrl) profileLinks.push({ url: startggUrl, label: 'start.gg' });
+    if (parryUrl) profileLinks.push({ url: parryUrl, label: 'parry.gg' });
+  } else if (source === 'parrygg') {
+    if (parryUrl) profileLinks.push({ url: parryUrl, label: 'parry.gg' });
+  } else if (startggUrl) {
+    profileLinks.push({ url: startggUrl, label: 'start.gg' });
+  }
+
+  const sampleText =
+    source === 'combined'
+      ? t('scout.header.sampleCombined', {
+          sets: report.sampledSets,
+          games: report.sampledGames,
+        })
+      : t('scout.header.sample', {
+          source: source === 'parrygg' ? 'parry.gg' : 'start.gg',
+          sets: report.sampledSets,
+          games: report.sampledGames,
+        });
 
   return (
     <Card>
       <CardContent className="flex flex-col gap-1">
         <div className="flex flex-wrap items-center gap-2">
           <h2 className="text-2xl font-semibold tracking-tight">{report.player.gamerTag}</h2>
-          {profileUrl && (
+          {profileLinks.map((link) => (
             <a
-              href={profileUrl}
+              key={link.label}
+              href={link.url}
               target="_blank"
               rel="noreferrer"
               aria-label={t('scout.header.viewOn', {
                 name: report.player.gamerTag,
-                source: sourceLabel,
+                source: link.label,
               })}
               className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
             >
               <ExternalLink className="size-3.5" />
-              {t('scout.header.profile', { source: sourceLabel })}
+              {t('scout.header.profile', { source: link.label })}
             </a>
-          )}
+          ))}
         </div>
-        <p className="text-sm text-muted-foreground">
-          {t('scout.header.sample', {
-            source: sourceLabel,
-            sets: report.sampledSets,
-            games: report.sampledGames,
-          })}
-        </p>
+        <p className="text-sm text-muted-foreground">{sampleText}</p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/pages/Scout/components/ScoutSearchForm.test.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutSearchForm.test.tsx
@@ -14,7 +14,7 @@ describe('ScoutSearchForm', () => {
     await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
     await user.click(screen.getByRole('button', { name: 'Scout' }));
 
-    expect(onSubmit).toHaveBeenCalledWith('user/07dc2239', 'startgg');
+    expect(onSubmit).toHaveBeenCalledWith({ query: 'user/07dc2239', source: 'startgg' });
   });
 
   it('shows the source toggle when parrygg is enabled, and submits the selected source', async () => {
@@ -26,7 +26,7 @@ describe('ScoutSearchForm', () => {
     await user.click(screen.getByRole('radio', { name: 'parry.gg' }));
     await user.click(screen.getByRole('button', { name: 'Scout' }));
 
-    expect(onSubmit).toHaveBeenCalledWith('PowPow', 'parrygg');
+    expect(onSubmit).toHaveBeenCalledWith({ query: 'PowPow', source: 'parrygg' });
   });
 
   it('auto-detects a pasted parry.gg profile URL and overrides the toggle', async () => {
@@ -48,10 +48,10 @@ describe('ScoutSearchForm', () => {
     expect(screen.getByRole('radio', { name: 'parry.gg' })).toBeDisabled();
 
     await user.click(screen.getByRole('button', { name: 'Scout' }));
-    expect(onSubmit).toHaveBeenCalledWith(
-      'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
-      'parrygg',
-    );
+    expect(onSubmit).toHaveBeenCalledWith({
+      query: 'https://parry.gg/profile/019ce9ba-debd-7e11-84a2-77258f52644e',
+      source: 'parrygg',
+    });
   });
 
   it('does not submit an empty query', async () => {
@@ -62,5 +62,37 @@ describe('ScoutSearchForm', () => {
     expect(screen.getByRole('button', { name: 'Scout' })).toBeDisabled();
     await user.click(screen.getByRole('button', { name: 'Scout' }));
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('V13: "Both" mode submits a combined request when both fields are filled', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} parryggEnabled />);
+
+    await user.click(screen.getByRole('radio', { name: 'Both' }));
+    await user.type(screen.getByLabelText(/start\.gg profile URL/), 'user/07dc2239');
+    await user.type(screen.getByLabelText(/parry\.gg profile URL/), 'Pandem1c');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      query: 'user/07dc2239',
+      source: 'startgg',
+      combineWith: { query: 'Pandem1c', source: 'parrygg' },
+    });
+  });
+
+  it('V13: "Both" mode with only one field filled submits a single-source request', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<ScoutSearchForm onSubmit={onSubmit} isPending={false} parryggEnabled />);
+
+    await user.click(screen.getByRole('radio', { name: 'Both' }));
+    await user.type(screen.getByLabelText(/parry\.gg profile URL/), 'Pandem1c');
+    await user.click(screen.getByRole('button', { name: 'Scout' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ query: 'Pandem1c', source: 'parrygg' });
+    expect(onSubmit).not.toHaveBeenCalledWith(
+      expect.objectContaining({ combineWith: expect.anything() }),
+    );
   });
 });

--- a/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
+++ b/apps/web/src/pages/Scout/components/ScoutSearchForm.tsx
@@ -7,6 +7,17 @@ import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
+/** What the form hands back on submit — a single-source query, or (V13) a combined one. */
+export interface ScoutSubmitRequest {
+  query: string;
+  source: ScoutSource;
+  /** V13: a second lookup on the OTHER site to merge in. Present only in "Both" mode with both fields filled. */
+  combineWith?: { query: string; source: ScoutSource };
+}
+
+/** The three source modes the toggle offers when parry.gg is enabled. */
+type ScoutMode = ScoutSource | 'both';
+
 /**
  * Client-side hint only — a lightweight mirror of the server's own
  * `parseParryProfileUrl` detection (apps/api/src/parrygg/scout.ts), used
@@ -14,7 +25,8 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
  * unambiguously a parry.gg profile URL. The SERVER re-detects and overrides
  * regardless of what `source` is sent, so this never needs to be exhaustive
  * — a false negative here just means the toggle doesn't visually flip before
- * submit, not an incorrect scout.
+ * submit, not an incorrect scout. Only relevant in the single-source modes;
+ * "Both" mode has an explicit field per site.
  */
 function looksLikeParryProfileUrl(value: string): boolean {
   return /parry\.gg\/profile\//i.test(value.trim());
@@ -25,23 +37,57 @@ export function ScoutSearchForm({
   isPending,
   parryggEnabled = false,
 }: {
-  onSubmit: (query: string, source: ScoutSource) => void;
+  onSubmit: (request: ScoutSubmitRequest) => void;
   isPending: boolean;
-  /** Hides the source toggle entirely when parry.gg isn't configured on this deployment (V9-B Feature 4). */
+  /** Hides the source toggle (and the "Both" mode) entirely when parry.gg isn't configured on this deployment (V9-B Feature 4). */
   parryggEnabled?: boolean;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
-  const [source, setSource] = useState<ScoutSource>('startgg');
+  // V13 "Both" mode keeps an explicit field per site (no auto-detect needed).
+  const [startggQuery, setStartggQuery] = useState('');
+  const [parryQuery, setParryQuery] = useState('');
+  const [mode, setMode] = useState<ScoutMode>('startgg');
 
-  const detectedParryUrl = useMemo(() => looksLikeParryProfileUrl(query), [query]);
-  const effectiveSource: ScoutSource = detectedParryUrl ? 'parrygg' : source;
+  const combineMode = mode === 'both';
+  const detectedParryUrl = useMemo(
+    () => !combineMode && looksLikeParryProfileUrl(query),
+    [combineMode, query],
+  );
+  // Single-source effective source honors the pasted-parry-URL override.
+  const singleSource: ScoutSource = detectedParryUrl
+    ? 'parrygg'
+    : mode === 'parrygg'
+      ? 'parrygg'
+      : 'startgg';
+  // The toggle reflects the detected-parry override in single mode, else the raw mode.
+  const toggleValue: ScoutMode = detectedParryUrl ? 'parrygg' : mode;
+
+  const canSubmit = combineMode
+    ? startggQuery.trim().length > 0 || parryQuery.trim().length > 0
+    : query.trim().length > 0;
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
+    if (combineMode) {
+      const sgg = startggQuery.trim();
+      const pgg = parryQuery.trim();
+      if (sgg && pgg) {
+        onSubmit({
+          query: sgg,
+          source: 'startgg',
+          combineWith: { query: pgg, source: 'parrygg' },
+        });
+      } else if (sgg) {
+        onSubmit({ query: sgg, source: 'startgg' });
+      } else if (pgg) {
+        onSubmit({ query: pgg, source: 'parrygg' });
+      }
+      return;
+    }
     const trimmed = query.trim();
     if (trimmed) {
-      onSubmit(trimmed, effectiveSource);
+      onSubmit({ query: trimmed, source: singleSource });
     }
   };
 
@@ -55,7 +101,38 @@ export function ScoutSearchForm({
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <div className="flex flex-col gap-3 sm:flex-row">
+          {combineMode ? (
+            // V13 combined scouting: an explicit handle per site. Either alone
+            // scouts a single site; both together merge into one report.
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="scout-startgg" className="text-sm font-medium">
+                  {t('scout.form.startggField')}
+                </label>
+                <Input
+                  id="scout-startgg"
+                  value={startggQuery}
+                  onChange={(event) => setStartggQuery(event.target.value)}
+                  placeholder={t('scout.form.placeholder')}
+                  disabled={isPending}
+                  aria-label={t('scout.form.startggFieldAria')}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="scout-parrygg" className="text-sm font-medium">
+                  {t('scout.form.parryField')}
+                </label>
+                <Input
+                  id="scout-parrygg"
+                  value={parryQuery}
+                  onChange={(event) => setParryQuery(event.target.value)}
+                  placeholder={t('scout.form.parryPlaceholder')}
+                  disabled={isPending}
+                  aria-label={t('scout.form.parryFieldAria')}
+                />
+              </div>
+            </div>
+          ) : (
             <div className="relative flex-1">
               <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
@@ -73,23 +150,20 @@ export function ScoutSearchForm({
                 }
               />
             </div>
-            <Button type="submit" disabled={isPending || query.trim().length === 0}>
-              {isPending ? t('scout.form.scouting') : t('scout.form.scout')}
-            </Button>
-          </div>
+          )}
 
           {parryggEnabled && (
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <span className="text-sm text-muted-foreground">{t('scout.form.source')}</span>
               <ToggleGroup
                 type="single"
                 variant="outline"
                 size="sm"
-                value={effectiveSource}
+                value={toggleValue}
                 disabled={detectedParryUrl}
                 onValueChange={(value) => {
-                  if (value === 'startgg' || value === 'parrygg') {
-                    setSource(value);
+                  if (value === 'startgg' || value === 'parrygg' || value === 'both') {
+                    setMode(value);
                   }
                 }}
                 aria-label={t('scout.form.sourceAria')}
@@ -100,6 +174,9 @@ export function ScoutSearchForm({
                 <ToggleGroupItem value="parrygg" aria-label="parry.gg">
                   parry.gg
                 </ToggleGroupItem>
+                <ToggleGroupItem value="both" aria-label={t('scout.form.combineBoth')}>
+                  {t('scout.form.combineBoth')}
+                </ToggleGroupItem>
               </ToggleGroup>
               {detectedParryUrl && (
                 <span className="text-xs text-muted-foreground">
@@ -108,6 +185,14 @@ export function ScoutSearchForm({
               )}
             </div>
           )}
+
+          {combineMode && (
+            <p className="text-xs text-muted-foreground">{t('scout.form.combineHint')}</p>
+          )}
+
+          <Button type="submit" disabled={isPending || !canSubmit} className="w-fit">
+            {isPending ? t('scout.form.scouting') : t('scout.form.scout')}
+          </Button>
         </form>
         {isPending && (
           <p className="mt-2 text-sm text-muted-foreground">{t('scout.form.pending')}</p>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,6 +27,7 @@ export * from './match.js';
 export * from './opponent.js';
 export * from './error.js';
 export * from './startgg.js';
+export * from './scoutMerge.js';
 export * from './parrygg.js';
 export * from './fighterData.js';
 export * from './stageData.js';

--- a/packages/shared/src/reports.test.ts
+++ b/packages/shared/src/reports.test.ts
@@ -99,6 +99,26 @@ describe('scoutReportRecordSchema back-compat', () => {
     expect(parsed.report.headToHead).toBeUndefined();
   });
 
+  it('V13: parses a stored record with a combined-source player (both ids present)', () => {
+    const record = {
+      id: 'report-4',
+      createdAt: 1_700_000_000_000,
+      model: 'claude-opus-4-8',
+      player: {
+        source: 'combined',
+        id: 1802316,
+        userSlug: 'user/07dc2239',
+        parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+        gamerTag: 'Pandem1c',
+      },
+      report: FULL_REPORT,
+    };
+    const parsed = scoutReportRecordSchema.parse(record);
+    expect(parsed.player.source).toBe('combined');
+    expect(parsed.player.id).toBe(1802316);
+    expect(parsed.player.parryUserId).toBe('019ce9ba-debd-7e11-84a2-77258f52644e');
+  });
+
   it('V9-B: still parses an explicit headToHead: null (records seeded/written before the null-strip fix, read via a null-preserving path)', () => {
     const record = {
       id: 'report-3',

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { scoutPlayerIdentitySchema, scoutSourceSchema } from './startgg.js';
+import {
+  combineWithLookupSchema,
+  scoutPlayerIdentitySchema,
+  scoutSourceSchema,
+} from './startgg.js';
 
 /**
  * V7-B: AI-generated pre-bracket scouting reports, powered by the Claude API,
@@ -107,11 +111,14 @@ export type ScoutReportRecord = z.infer<typeof scoutReportRecordSchema>;
 /**
  * POST /api/reports request body — same input semantics as POST /api/scout,
  * including the same optional `source` (V9-B Feature 4) for bare-query
- * disambiguation between start.gg and parry.gg.
+ * disambiguation between start.gg and parry.gg, and the same optional
+ * `combineWith` (V13) that merges a second-site scout into the report's data
+ * (see `scoutQuerySchema`).
  */
 export const generateReportRequestSchema = z.object({
   query: z.string().min(1),
   source: scoutSourceSchema.optional(),
+  combineWith: combineWithLookupSchema.optional(),
 });
 export type GenerateReportRequest = z.infer<typeof generateReportRequestSchema>;
 

--- a/packages/shared/src/scoutMerge.test.ts
+++ b/packages/shared/src/scoutMerge.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { mergeScoutReports } from './scoutMerge.js';
+import { isCombinedIdentity, type ScoutReportData } from './startgg.js';
+
+const startggReport: ScoutReportData = {
+  player: { id: 1802316, gamerTag: 'Pandem1c', userSlug: 'user/07dc2239', source: 'startgg' },
+  sampledSets: 10,
+  sampledGames: 24,
+  characters: [
+    { fighterId: 67, games: 18, wins: 12 },
+    { fighterId: 41, games: 6, wins: 2 },
+  ],
+  stages: [
+    { stageId: 1, games: 14, wins: 9 },
+    { stageId: 2, games: 10, wins: 5 },
+  ],
+  recentEvents: [
+    { eventName: 'Big House', lastSetAt: 3000, source: 'startgg', slug: 't/bh/e/singles' },
+    { eventName: 'Genesis', lastSetAt: 1000 },
+  ],
+  commonOpponents: [
+    { gamerTag: 'PowPow', sets: 4 },
+    { gamerTag: 'Zackray', sets: 2 },
+  ],
+  games: [
+    {
+      time: 3000,
+      win: true,
+      fighterId: 67,
+      opponentFighterId: 41,
+      opponentTag: 'PowPow',
+    },
+  ],
+};
+
+const parryReport: ScoutReportData = {
+  player: {
+    gamerTag: 'pandem1c',
+    source: 'parrygg',
+    parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+  },
+  sampledSets: 5,
+  sampledGames: 11,
+  characters: [
+    { fighterId: 67, games: 8, wins: 6 }, // same fighter as start.gg → sums
+    { fighterId: 30, games: 3, wins: 1 },
+  ],
+  stages: [
+    { stageId: 1, games: 7, wins: 5 }, // same stage → sums
+    { stageId: 3, games: 4, wins: 2 },
+  ],
+  recentEvents: [
+    { eventName: 'Local Weekly', lastSetAt: 2000, source: 'parrygg', slug: 'my-tourney/singles' },
+  ],
+  commonOpponents: [
+    { gamerTag: 'powpow', sets: 3 }, // same person, different casing → merges
+    { gamerTag: 'Sparg0', sets: 1 },
+  ],
+  games: [
+    {
+      time: 2000,
+      win: false,
+      fighterId: 67,
+      opponentFighterId: 30,
+      opponentTag: 'Sparg0',
+    },
+  ],
+};
+
+describe('mergeScoutReports', () => {
+  it('sums sampled counts across both sources', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    expect(merged.sampledSets).toBe(15);
+    expect(merged.sampledGames).toBe(35);
+  });
+
+  it('sums per-character usage by fighterId, most games first', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    // fighterId 67: 18+8 games, 12+6 wins.
+    expect(merged.characters[0]).toEqual({ fighterId: 67, games: 26, wins: 18 });
+    // Remaining characters unique to each source appear once.
+    expect(merged.characters).toContainEqual({ fighterId: 41, games: 6, wins: 2 });
+    expect(merged.characters).toContainEqual({ fighterId: 30, games: 3, wins: 1 });
+    // Sorted by games desc.
+    const games = merged.characters.map((c) => c.games);
+    expect(games).toEqual([...games].sort((a, b) => b - a));
+  });
+
+  it('sums per-stage usage by stageId', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    expect(merged.stages).toContainEqual({ stageId: 1, games: 21, wins: 14 });
+    expect(merged.stages).toContainEqual({ stageId: 2, games: 10, wins: 5 });
+    expect(merged.stages).toContainEqual({ stageId: 3, games: 4, wins: 2 });
+  });
+
+  it('merges common opponents case-insensitively, keeping first-seen display', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    // PowPow (4) + powpow (3) → one row of 7, display from the first side seen.
+    const powpow = merged.commonOpponents.find((o) => o.gamerTag.toLowerCase() === 'powpow');
+    expect(powpow).toEqual({ gamerTag: 'PowPow', sets: 7 });
+    expect(merged.commonOpponents[0]).toEqual({ gamerTag: 'PowPow', sets: 7 });
+  });
+
+  it('concatenates recent events newest-first', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    expect(merged.recentEvents.map((e) => e.lastSetAt)).toEqual([3000, 2000, 1000]);
+    // Provenance survives — each event keeps its own source (the oldest event
+    // had none, mirroring a pre-V9-B start.gg event).
+    expect(merged.recentEvents.map((e) => e.source)).toEqual(['startgg', 'parrygg', undefined]);
+  });
+
+  it('concatenates per-game records from both sources', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    expect(merged.games).toHaveLength(2);
+    expect(merged.games?.map((g) => g.opponentTag)).toEqual(['PowPow', 'Sparg0']);
+  });
+
+  it('builds a combined identity carrying both ids, start.gg display tag + slug', () => {
+    const merged = mergeScoutReports(startggReport, parryReport);
+    expect(isCombinedIdentity(merged.player)).toBe(true);
+    expect(merged.player).toEqual({
+      source: 'combined',
+      id: 1802316,
+      parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+      userSlug: 'user/07dc2239',
+      gamerTag: 'Pandem1c', // start.gg casing preferred over parry.gg's "pandem1c"
+    });
+  });
+
+  it('is order-independent (parry-first yields the same combined identity)', () => {
+    const a = mergeScoutReports(startggReport, parryReport);
+    const b = mergeScoutReports(parryReport, startggReport);
+    expect(b.player).toEqual(a.player);
+    expect(b.sampledGames).toBe(a.sampledGames);
+  });
+
+  it('omits games entirely when neither source carried any', () => {
+    const merged = mergeScoutReports(
+      { ...startggReport, games: undefined },
+      { ...parryReport, games: undefined },
+    );
+    expect(merged.games).toBeUndefined();
+  });
+
+  it('does not mutate the input reports', () => {
+    const startggClone = JSON.parse(JSON.stringify(startggReport));
+    const parryClone = JSON.parse(JSON.stringify(parryReport));
+    mergeScoutReports(startggReport, parryReport);
+    expect(startggReport).toEqual(startggClone);
+    expect(parryReport).toEqual(parryClone);
+  });
+});

--- a/packages/shared/src/scoutMerge.ts
+++ b/packages/shared/src/scoutMerge.ts
@@ -1,0 +1,135 @@
+import {
+  isParryggIdentity,
+  isStartggIdentity,
+  type ScoutCharacterUsage,
+  type ScoutCommonOpponent,
+  type ScoutGame,
+  type ScoutPlayerIdentity,
+  type ScoutRecentEvent,
+  type ScoutReportData,
+  type ScoutStageUsage,
+} from './startgg.js';
+
+/**
+ * V13 — combine start.gg + parry.gg scouting.
+ *
+ * `mergeScoutReports` folds two single-source `ScoutReportData`s (one scouted
+ * from start.gg, one from parry.gg, for a player the user has asserted is the
+ * same person) into ONE combined report. This is a PURE function — no I/O — and
+ * relies on the fact that both scout engines (`apps/api/src/startgg/scout.ts`
+ * and `apps/api/src/parrygg/scout.ts`) already emit the exact same
+ * `ScoutReportData` shape using THIS app's own roster fighter ids and stage
+ * ids, so their per-character / per-stage aggregates add together directly.
+ *
+ * Everything downstream (the Scout page cards, `assembleReportPayload`'s
+ * `vsTopCharacters` / `matchupAdvisor`, the AI report payload) consumes the
+ * merged result unchanged — it's just a `ScoutReportData` with a `'combined'`
+ * identity.
+ */
+
+// Same caps both single-source scout engines apply in their own `toReport`.
+const MAX_RECENT_EVENTS = 10;
+const MAX_COMMON_OPPONENTS = 10;
+
+/** Sum two arrays of `{ <idKey>, games, wins }` rows by their id, most games first. */
+function mergeUsage<T extends { games: number; wins: number }>(
+  a: readonly T[],
+  b: readonly T[],
+  idOf: (row: T) => number,
+): T[] {
+  const byId = new Map<number, T>();
+  for (const row of [...a, ...b]) {
+    const key = idOf(row);
+    const existing = byId.get(key);
+    if (existing) {
+      existing.games += row.games;
+      existing.wins += row.wins;
+    } else {
+      // Clone so we never mutate the caller's input rows.
+      byId.set(key, { ...row });
+    }
+  }
+  return [...byId.values()].sort((x, y) => y.games - x.games);
+}
+
+/**
+ * Builds the `'combined'` identity from whichever input is the start.gg scout
+ * and whichever is the parry.gg scout. Prefers the start.gg display gamerTag
+ * (the two sites can spell a tag differently; start.gg is this app's original
+ * canonical source). Conditional-spreads `userSlug` so the merged identity
+ * carries no `undefined`/null fields (production-gap #3 — nulls corrupt RTDB
+ * reads once this identity is stored on a report record).
+ */
+function combineIdentity(
+  startgg: ScoutPlayerIdentity | undefined,
+  parry: ScoutPlayerIdentity | undefined,
+  fallback: ScoutPlayerIdentity,
+): ScoutPlayerIdentity {
+  const id = startgg?.id ?? fallback.id;
+  const parryUserId = parry?.parryUserId ?? fallback.parryUserId;
+  const userSlug = startgg?.userSlug;
+  const gamerTag = startgg?.gamerTag ?? parry?.gamerTag ?? fallback.gamerTag;
+  return {
+    source: 'combined',
+    ...(id !== undefined ? { id } : {}),
+    ...(parryUserId !== undefined ? { parryUserId } : {}),
+    ...(userSlug ? { userSlug } : {}),
+    gamerTag,
+  };
+}
+
+/**
+ * Merges two single-source scout reports into one combined report. Order
+ * independent — `a`/`b` may be passed start.gg-first or parry.gg-first; the
+ * identity is assembled by inspecting each report's `player.source`. The caller
+ * (the API's combined resolver) guarantees one start.gg + one parry.gg report.
+ */
+export function mergeScoutReports(a: ScoutReportData, b: ScoutReportData): ScoutReportData {
+  const startggReport = [a, b].find((r) => isStartggIdentity(r.player));
+  const parryReport = [a, b].find((r) => isParryggIdentity(r.player));
+
+  const characters: ScoutCharacterUsage[] = mergeUsage(
+    a.characters,
+    b.characters,
+    (c) => c.fighterId,
+  );
+  const stages: ScoutStageUsage[] = mergeUsage(a.stages, b.stages, (s) => s.stageId);
+
+  // Recent events: each event keeps its own `source`/`slug`, so provenance
+  // survives the merge — just re-sort the combined set newest-first and re-cap.
+  const recentEvents: ScoutRecentEvent[] = [...a.recentEvents, ...b.recentEvents]
+    .sort((x, y) => y.lastSetAt - x.lastSetAt)
+    .slice(0, MAX_RECENT_EVENTS);
+
+  // Common opponents: the same person can appear on both sites spelled with
+  // different casing, so merge case-insensitively while keeping the first-seen
+  // display casing.
+  const opponentsByKey = new Map<string, ScoutCommonOpponent>();
+  for (const opponent of [...a.commonOpponents, ...b.commonOpponents]) {
+    const key = opponent.gamerTag.toLowerCase();
+    const existing = opponentsByKey.get(key);
+    if (existing) {
+      existing.sets += opponent.sets;
+    } else {
+      opponentsByKey.set(key, { ...opponent });
+    }
+  }
+  const commonOpponents: ScoutCommonOpponent[] = [...opponentsByKey.values()]
+    .sort((x, y) => y.sets - x.sets)
+    .slice(0, MAX_COMMON_OPPONENTS);
+
+  // Per-game records (web "Full analysis"): concat — the client stats engine
+  // tolerates any ordering. Only present when at least one side had games.
+  const games: ScoutGame[] = [...(a.games ?? []), ...(b.games ?? [])];
+
+  return {
+    player: combineIdentity(startggReport?.player, parryReport?.player, a.player),
+    sampledSets: a.sampledSets + b.sampledSets,
+    sampledGames: a.sampledGames + b.sampledGames,
+    characters,
+    stages,
+    recentEvents,
+    commonOpponents,
+    ...(games.length > 0 ? { games } : {}),
+  };
+}

--- a/packages/shared/src/startgg.test.ts
+++ b/packages/shared/src/startgg.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isCombinedIdentity,
   isParryggIdentity,
   isStartggIdentity,
   scoutGameSchema,
   scoutIdentityKey,
   scoutPlayerIdentitySchema,
+  scoutQuerySchema,
   scoutRecentEventSchema,
   scoutReportDataSchema,
   type ScoutPlayerIdentity,
@@ -50,6 +52,34 @@ describe('scoutPlayerIdentitySchema — V9-B back-compat + parry.gg identity des
       scoutPlayerIdentitySchema.parse({ gamerTag: 'Pandem1c', source: 'startgg' }),
     ).toThrow();
   });
+
+  it('parses a V13 combined identity carrying BOTH a numeric id and a parryUserId', () => {
+    const parsed = scoutPlayerIdentitySchema.parse({
+      id: 1802316,
+      gamerTag: 'Pandem1c',
+      userSlug: 'user/07dc2239',
+      source: 'combined',
+      parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+    });
+    expect(isCombinedIdentity(parsed)).toBe(true);
+    // A combined identity is neither an exclusively-startgg nor an
+    // exclusively-parrygg identity.
+    expect(isStartggIdentity(parsed)).toBe(false);
+    expect(isParryggIdentity(parsed)).toBe(false);
+  });
+
+  it('rejects a combined identity missing either id or parryUserId', () => {
+    expect(() =>
+      scoutPlayerIdentitySchema.parse({
+        gamerTag: 'Pandem1c',
+        source: 'combined',
+        parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+      }),
+    ).toThrow();
+    expect(() =>
+      scoutPlayerIdentitySchema.parse({ id: 1802316, gamerTag: 'Pandem1c', source: 'combined' }),
+    ).toThrow();
+  });
 });
 
 describe('scoutIdentityKey', () => {
@@ -71,6 +101,45 @@ describe('scoutIdentityKey', () => {
     const startgg: ScoutPlayerIdentity = { id: 42, gamerTag: 'A' };
     const parrygg: ScoutPlayerIdentity = { gamerTag: 'B', source: 'parrygg', parryUserId: '42' };
     expect(scoutIdentityKey(startgg)).not.toBe(scoutIdentityKey(parrygg));
+  });
+
+  it('keys a combined identity by BOTH ids, distinct from either single-source key', () => {
+    const combined: ScoutPlayerIdentity = {
+      id: 1802316,
+      gamerTag: 'Pandem1c',
+      source: 'combined',
+      parryUserId: '019ce9ba-debd-7e11-84a2-77258f52644e',
+    };
+    expect(scoutIdentityKey(combined)).toBe(
+      'combined:startgg=1802316:parrygg=019ce9ba-debd-7e11-84a2-77258f52644e',
+    );
+    // A combined report and a start.gg-only report for the same player must not
+    // group together — different data scopes.
+    expect(scoutIdentityKey(combined)).not.toBe(
+      scoutIdentityKey({ id: 1802316, gamerTag: 'Pandem1c' }),
+    );
+  });
+});
+
+describe('scoutQuerySchema — V13 combineWith', () => {
+  it('parses a single-source query with no combineWith (unchanged default)', () => {
+    const parsed = scoutQuerySchema.parse({ query: 'user/07dc2239', source: 'startgg' });
+    expect(parsed.combineWith).toBeUndefined();
+  });
+
+  it('parses a combined query carrying a second-site lookup', () => {
+    const parsed = scoutQuerySchema.parse({
+      query: 'user/07dc2239',
+      source: 'startgg',
+      combineWith: { query: 'Pandem1c', source: 'parrygg' },
+    });
+    expect(parsed.combineWith).toEqual({ query: 'Pandem1c', source: 'parrygg' });
+  });
+
+  it('requires combineWith.source (the second lookup must name its site)', () => {
+    expect(() =>
+      scoutQuerySchema.parse({ query: 'user/07dc2239', combineWith: { query: 'Pandem1c' } }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/src/startgg.ts
+++ b/packages/shared/src/startgg.ts
@@ -115,9 +115,20 @@ export type TournamentEntryList = z.infer<typeof tournamentEntryListSchema>;
 // V7-A: scout any start.gg player (server-aggregated public history)
 // ---------------------------------------------------------------------------
 
-/** Which tournament site a scouting query/identity/event resolves against (V9-B Feature 4). Reused everywhere this app needs the same two-value enum. */
+/** Which tournament site a scouting query/individual event resolves against (V9-B Feature 4). Reused everywhere this app needs the same two-value enum — a query targets ONE site, and a single event always belongs to ONE site. */
 export const scoutSourceSchema = z.enum(['startgg', 'parrygg']);
 export type ScoutSource = z.infer<typeof scoutSourceSchema>;
+
+/**
+ * The site(s) a resolved scout IDENTITY draws from — the two-value
+ * `scoutSourceSchema` plus `'combined'` (V13), used only where a scout can span
+ * BOTH sites at once: a `ScoutReportData.player` merged from a start.gg AND a
+ * parry.gg profile the user asserted are the same person. Deliberately a
+ * SEPARATE enum from `scoutSourceSchema` so `'combined'` can never leak into a
+ * request `source` or a per-event `source`, where it's meaningless.
+ */
+export const scoutIdentitySourceSchema = z.enum(['startgg', 'parrygg', 'combined']);
+export type ScoutIdentitySource = z.infer<typeof scoutIdentitySourceSchema>;
 
 /**
  * The identity resolved from the caller's scouting query — start.gg OR (V9-B
@@ -133,31 +144,41 @@ export type ScoutSource = z.infer<typeof scoutSourceSchema>;
  *   not by the field's own optionality, since old records may have `source`
  *   absent while still trivially satisfying "id present").
  * - `parryUserId` (parry.gg's UUID v7 user id) is optional and is the
- *   parry.gg equivalent key: present exactly when `source === 'parrygg'`.
+ *   parry.gg equivalent key: present when `source === 'parrygg'` OR (V13)
+ *   `source === 'combined'`.
+ * - (V13) `source: 'combined'` is a scout merged from BOTH sites for one
+ *   asserted-same person, so it carries BOTH `id` (+ `userSlug` when the
+ *   start.gg side had one) AND `parryUserId`.
  *
- * The `.refine` below is the single place that enforces "exactly one of
- * (id, parryUserId) is present, matching `source`" — every other consumer
- * can just read `source ?? 'startgg'` and the matching id field without
- * re-deriving this invariant.
+ * The `.refine`s below are the single place that enforces "the id field(s)
+ * present match `source`" — every other consumer can just read
+ * `source ?? 'startgg'` and the matching id field without re-deriving this
+ * invariant.
  */
 export const scoutPlayerIdentitySchema = z
   .object({
-    /** start.gg player id — the key used for the sets query. Present iff source is start.gg (or absent, pre-V9-B). */
+    /** start.gg player id — the key used for the sets query. Present for start.gg (or absent, pre-V9-B) and combined identities. */
     id: z.number().int().positive().optional(),
     gamerTag: z.string().min(1),
     /** start.gg profile slug, e.g. "user/07dc2239", when start.gg provides one. */
     userSlug: z.string().optional(),
-    /** Which site resolved this identity. Absent means start.gg (every identity stored before V9-B). */
-    source: scoutSourceSchema.optional(),
-    /** parry.gg user id (UUID v7) — the key used for the matches query. Present iff source is 'parrygg'. */
+    /** Which site(s) resolved this identity. Absent means start.gg (every identity stored before V9-B); `'combined'` (V13) spans both. */
+    source: scoutIdentitySourceSchema.optional(),
+    /** parry.gg user id (UUID v7) — the key used for the matches query. Present for 'parrygg' and (V13) 'combined' identities. */
     parryUserId: z.string().min(1).optional(),
   })
-  .refine((identity) => (identity.source === 'parrygg' ? Boolean(identity.parryUserId) : true), {
-    message: 'parrygg identities must carry parryUserId',
-    path: ['parryUserId'],
-  })
+  .refine(
+    (identity) =>
+      identity.source === 'parrygg' || identity.source === 'combined'
+        ? Boolean(identity.parryUserId)
+        : true,
+    {
+      message: 'parrygg and combined identities must carry parryUserId',
+      path: ['parryUserId'],
+    },
+  )
   .refine((identity) => (identity.source !== 'parrygg' ? identity.id !== undefined : true), {
-    message: 'startgg identities must carry a numeric id',
+    message: 'startgg and combined identities must carry a numeric id',
     path: ['id'],
   });
 export type ScoutPlayerIdentity = z.infer<typeof scoutPlayerIdentitySchema>;
@@ -169,11 +190,18 @@ export function isStartggIdentity(
   return (identity.source ?? 'startgg') === 'startgg';
 }
 
-/** True when `identity` resolves to a parry.gg player. */
+/** True when `identity` resolves to a parry.gg player (single-source, not combined). */
 export function isParryggIdentity(
   identity: Pick<ScoutPlayerIdentity, 'source'>,
 ): identity is ScoutPlayerIdentity & { source: 'parrygg'; parryUserId: string } {
   return identity.source === 'parrygg';
+}
+
+/** True when `identity` (V13) spans BOTH sites — a scout merged from a start.gg AND a parry.gg profile. */
+export function isCombinedIdentity(
+  identity: Pick<ScoutPlayerIdentity, 'source'>,
+): identity is ScoutPlayerIdentity & { source: 'combined'; id: number; parryUserId: string } {
+  return identity.source === 'combined';
 }
 
 /**
@@ -187,6 +215,12 @@ export function isParryggIdentity(
  * so this never throws on a malformed record.
  */
 export function scoutIdentityKey(identity: ScoutPlayerIdentity): string {
+  // (V13) A combined identity is a distinct data scope from either single
+  // source, so it gets its own key composing BOTH ids — a combined report and
+  // a start.gg-only report for the same player intentionally don't collide.
+  if (isCombinedIdentity(identity)) {
+    return `combined:startgg=${identity.id}:parrygg=${identity.parryUserId}`;
+  }
   if (isParryggIdentity(identity)) {
     return `parrygg:${identity.parryUserId}`;
   }
@@ -330,9 +364,22 @@ export type ScoutReportData = z.infer<typeof scoutReportDataSchema>;
  * (non-URL) query; it defaults to `'startgg'` for back-compat with pre-V9-B
  * clients that never sent it. A pasted URL always auto-detects its own site
  * (start.gg vs. parry.gg) and overrides `source` — see `parseScoutInput`.
+ *
+ * (V13) `combineWith` is an OPTIONAL second lookup on the OTHER site: when
+ * present, the server scouts BOTH `{query, source}` and `combineWith`, then
+ * merges the two `ScoutReportData`s (see `mergeScoutReports`) into one combined
+ * scout — the mechanism behind "combine start.gg + parry.gg" scouting. Absent
+ * for every single-source query (the default, unchanged behavior).
  */
+export const combineWithLookupSchema = z.object({
+  query: z.string().min(1),
+  source: scoutSourceSchema,
+});
+export type CombineWithLookup = z.infer<typeof combineWithLookupSchema>;
+
 export const scoutQuerySchema = z.object({
   query: z.string().min(1),
   source: scoutSourceSchema.optional(),
+  combineWith: combineWithLookupSchema.optional(),
 });
 export type ScoutQuery = z.infer<typeof scoutQuerySchema>;


### PR DESCRIPTION
## What & why

Scouting (and the AI report built from it) was sourced from **exactly one** site — you picked start.gg *or* parry.gg. But a player often competes on both, and each site holds only a slice of their history, so the AI report only ever saw a partial sample.

This adds a **"Both"** scouting mode: enter a player's start.gg handle *and* their parry.gg handle, and the server scouts each site and **merges the two public histories into one** `ScoutReportData` that feeds both the Scout page and the AI report.

Both scout engines already emit the same `ScoutReportData` using the same roster/stage IDs, so this is mostly a pure merge + a combined-identity model + a two-input UI — **no new external calls**.

## Product decisions (confirmed with the owner)

- **Two explicit inputs** — you assert which two profiles are the same person; no fragile auto-matching by gamer tag (which could conflate two different people).
- **Succeed with whatever resolves** — if only one site finds the player (bad handle, site down, source unconfigured), you get that single-source report, flagged as such; `404` only when *neither* resolves. For the paid report, a nothing-found combine **refunds the credit**.
- **Merge everywhere** — combined data drives the on-screen cards *and* the report, so what you see matches what's analyzed.

## How it's built

**shared**
- `scoutIdentitySourceSchema` adds a `'combined'` identity source (carries both `id` and `parryUserId`); refines updated so a combined identity requires both.
- `combineWith` optional field on the scout + report request schemas.
- New pure `mergeScoutReports()` engine — sums per-character/per-stage usage by shared fighter/stage IDs, case-insensitive opponent merge, event/game concat, no-null identity (conditional spreads).

**api**
- New `resolveCombinedScout()` helper: scouts each configured side (reusing the existing cached `scoutPlayer` / `scoutParryPlayer`), merges if both resolve, returns the single one if only one does, `404`/`429` otherwise. Wired into `POST /api/scout` and `POST /api/reports`; the report's credit spend/refund path is unchanged.
- `reports/generate.ts` needs no change — H2H and matchup advisor read the merged fields automatically.

**web**
- `ScoutSearchForm` gains a **Both** toggle revealing a start.gg field and a parry.gg field.
- `ScoutReportHeader` renders both profile links + a combined caption for a combined report.
- `combineWith` plumbed through so **Regenerate** re-runs the same combined lookup; Reports library groups the combined source; i18n across all 6 locales.

## Reviewer notes

- **Canonical side:** when both resolve, the merged display tag + identity key key off **start.gg** (the app's original source). Easy to flip in `mergeScoutReports` if you'd rather prefer parry.gg or show both tags.
- **Back-compat:** every existing single-source scout/report path is untouched; `'combined'` is additive and pre-existing stored records still parse.
- **Production-gap checklist:** no new `buildApp` option (both routes already receive both configs); the combined identity is conditional-spread so **no nulls hit RTDB**.

## Tests

New coverage in shared (`mergeScoutReports`, combined identity/key, `combineWith` schema), api (both-found → merged; one-found → single flagged; neither → 404; unconfigured side → fallback; combined-404 credit refund), and web (Both-mode submit shapes; full ScoutPage combined flow; combined header). Full suite green: **shared 206 · api 451 · web 977**, typecheck + lint clean, web production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)