### PR TITLE
feat(api): vodStartSeconds — per-match VOD start time (shared schema + passthrough)

### DIFF
--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -304,6 +304,48 @@ describe('POST /api/matches', () => {
     });
   });
 
+  it('accepts and stores vodStartSeconds', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodStartSeconds: 5025,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({ vodStartSeconds: 5025 });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({ vodStartSeconds: 5025 });
+  });
+
+  it('omits vodStartSeconds from the stored record when not provided', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput, vodUrl: 'https://youtube.com/watch?v=abc123' },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).not.toHaveProperty('vodStartSeconds');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).not.toHaveProperty('vodStartSeconds');
+  });
+
   it('rejects source/externalId from client input (server-only fields)', async () => {
     const { app } = buildTestApp();
 
@@ -644,6 +686,88 @@ describe('PATCH /api/matches/:id', () => {
     const stored = matches[TEST_UID]!.existingKey!;
     expect(stored).not.toHaveProperty('vodUrl');
     expect(stored).not.toHaveProperty('vodTimestamps');
+  });
+
+  it('sets vodStartSeconds', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodStartSeconds: 5025,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ vodStartSeconds: 5025 });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    expect(matches[TEST_UID]!.existingKey).toMatchObject({ vodStartSeconds: 5025 });
+  });
+
+  it('updates existing vodStartSeconds', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodStartSeconds: 5025,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodStartSeconds: 90,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ vodStartSeconds: 90 });
+  });
+
+  it('clears vodStartSeconds when omitted from the update payload', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      vodUrl: 'https://youtube.com/watch?v=abc123',
+      vodStartSeconds: 5025,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, vodUrl: 'https://youtube.com/watch?v=abc123' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).not.toHaveProperty('vodStartSeconds');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = matches[TEST_UID]!.existingKey!;
+    expect(stored).not.toHaveProperty('vodStartSeconds');
   });
 
   it('returns 400 when vodTimestamps exceeds 20 entries', async () => {

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -170,6 +170,7 @@ export class RtdbService {
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
       ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
+      ...(input.vodStartSeconds !== undefined ? { vodStartSeconds: input.vodStartSeconds } : {}),
       ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
     };
 
@@ -219,15 +220,16 @@ export class RtdbService {
       win: input.win,
       // See createMatch — RTDB rejects `undefined` values, so these are
       // only included when the input actually set them. Omitting
-      // opponent/vodUrl/vodTimestamps/gsp from the input is how a caller
-      // clears them, since this is a full overwrite (`.set()`, not a partial
-      // patch).
+      // opponent/vodUrl/vodTimestamps/vodStartSeconds/gsp from the input is
+      // how a caller clears them, since this is a full overwrite (`.set()`,
+      // not a partial patch).
       ...(input.opponent !== undefined ? { opponent: input.opponent } : {}),
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
       ...(input.tournamentName !== undefined ? { tournamentName: input.tournamentName } : {}),
       ...(input.vodUrl !== undefined ? { vodUrl: input.vodUrl } : {}),
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
+      ...(input.vodStartSeconds !== undefined ? { vodStartSeconds: input.vodStartSeconds } : {}),
       ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
       // Server-set provenance survives the overwrite — the full-overwrite
       // rebuild used to strip these, breaking source badges after a VOD edit.

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -150,6 +150,15 @@ export const matchRecordSchema = z.object({
    */
   vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
   /**
+   * User-set offset (whole seconds) into the match's VOD where this match
+   * begins — takes precedence over any `t=`/`start=` param in `vodUrl` (see
+   * `parseVodStartSeconds` on the web). Lets an entire event recorded as ONE
+   * video be shared by several matches: the player types each match's start
+   * time once instead of hand-editing the URL's query param. Same
+   * user-editable / conditional-spread convention as `vodUrl`/`vodTimestamps`.
+   */
+  vodStartSeconds: z.number().int().nonnegative().optional(),
+  /**
    * Post-match GSP (Global Smash Power) reading, as shown on the in-game
    * results screen (V10). Only meaningful for online matches — GSP is
    * per-fighter, so a series of these across matches sharing `fighter_id`
@@ -237,9 +246,9 @@ const optionalNameInputSchema = z
  * remain server-set only (see `matchRecordSchema`) and are intentionally
  * NOT accepted here.
  *
- * `vodUrl`/`vodTimestamps` (V7-E) are user-editable here too — omitting
- * either field (rather than sending it) is how a caller clears it, following
- * the same full-overwrite + conditional-spread convention as
+ * `vodUrl`/`vodTimestamps`/`vodStartSeconds` (V7-E) are user-editable here
+ * too — omitting a field (rather than sending it) is how a caller clears it,
+ * following the same full-overwrite + conditional-spread convention as
  * `stocksLeft`/`eventName`/`tournamentName` (see `RtdbService.updateMatch`).
  *
  * `gsp` (V10) follows the same convention — omit to leave/clear it.
@@ -257,6 +266,7 @@ export const createMatchInputSchema = z.object({
   tournamentName: optionalNameInputSchema,
   vodUrl: z.string().url().optional(),
   vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
+  vodStartSeconds: z.number().int().nonnegative().optional(),
   gsp: z.number().int().min(0).optional(),
 });
 export type CreateMatchInput = z.infer<typeof createMatchInputSchema>;


### PR DESCRIPTION
## Summary

Adds the optional `vodStartSeconds` field to the match schema (`matchRecordSchema` + create/update input schemas) with conditional-spread passthrough in `createMatch`/`updateMatch` — cherry-picked from the Phase 1 VOD Manager branch so the production API accepts the field **before** the phase's web UI ships.

Why now: the phase's preview-channel verification runs against the production API; without this, zod strips the unknown key and the user's typed start times silently vanish (found live during checkpoint testing).

Additive + backward compatible: optional field, omitted when absent (RTDB null-stripping rule), current production web neither sends nor reads it.

## Tests

5 new route tests (create stores/omits; update sets/updates/clears by omission). Suite: shared 206 / api 460, typecheck clean.

## Deploy

Needs API deploy after merge (rev 00033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)