### PR TITLE
feat(api): optional tags on matches and timestamp notes (schema + passthrough)

### DIFF
--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -346,6 +346,71 @@ describe('POST /api/matches', () => {
     expect(stored).not.toHaveProperty('vodStartSeconds');
   });
 
+  it('accepts and stores match-level tags', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput, tags: ['practice-friendlies', 'my custom tag'] },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({ tags: ['practice-friendlies', 'my custom tag'] });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({ tags: ['practice-friendlies', 'my custom tag'] });
+  });
+
+  it('accepts and stores note-level tags inside vodTimestamps entries', async () => {
+    const { app, database } = buildTestApp();
+
+    const vodTimestamps = [
+      { seconds: 161, note: 'missed punish on shield', tags: ['punish', 'my custom tag'] },
+    ];
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({ vodTimestamps });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({ vodTimestamps });
+  });
+
+  it('omits tags from the stored record when not provided', async () => {
+    const { app, database } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: { ...validCreateInput },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).not.toHaveProperty('tags');
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).not.toHaveProperty('tags');
+  });
+
   it('rejects source/externalId from client input (server-only fields)', async () => {
     const { app } = buildTestApp();
 
@@ -770,6 +835,47 @@ describe('PATCH /api/matches/:id', () => {
     expect(stored).not.toHaveProperty('vodStartSeconds');
   });
 
+  it('drops tags from the stored record when the update payload sends an explicit empty array', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/existingKey`, {
+      fighter_id: 1,
+      opponent_id: 8,
+      time: 1700000000000,
+      win: false,
+      tags: ['practice-friendlies'],
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/existingKey',
+      headers: authHeader(),
+      payload: { ...validCreateInput, tags: [] },
+    });
+
+    // The PATCH response echoes the in-memory record built from the
+    // request (no RTDB round-trip before responding), so it still reflects
+    // the `tags: []` the caller sent.
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ tags: [] });
+
+    // But RTDB silently drops keys holding an empty array on write, so the
+    // persisted record — and any subsequent read — genuinely lacks the
+    // `tags` key. This confirms that behavior rather than relying on
+    // `.optional()` semantics alone.
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = matches[TEST_UID]!.existingKey!;
+    expect(stored).not.toHaveProperty('tags');
+
+    const list = await app.inject({
+      method: 'GET',
+      url: '/api/matches',
+      headers: authHeader(),
+    });
+    const [readBack] = list.json() as Array<Record<string, unknown>>;
+    expect(readBack).not.toHaveProperty('tags');
+  });
+
   it('returns 400 when vodTimestamps exceeds 20 entries', async () => {
     const { app, database } = buildTestApp();
     database.seed(`matches/${TEST_UID}/existingKey`, {
@@ -994,6 +1100,34 @@ describe('PATCH /api/matches/:id', () => {
       externalId: 'sgg:123:g1',
       time: syncedRecord.time,
     });
+  });
+
+  it('allows a tags-only update on a synced match (tags are not sync-owned)', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`matches/${TEST_UID}/sgg-123-g1`, {
+      ...syncedRecord,
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/matches/sgg-123-g1',
+      headers: authHeader(),
+      payload: {
+        ...syncedCarryThroughPayload,
+        tags: ['practice-friendlies'],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      tags: ['practice-friendlies'],
+      source: 'startgg',
+      externalId: 'sgg:123:g1',
+    });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    expect(matches[TEST_UID]!['sgg-123-g1']).toMatchObject({ tags: ['practice-friendlies'] });
   });
 });
 

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -172,6 +172,7 @@ export class RtdbService {
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
       ...(input.vodStartSeconds !== undefined ? { vodStartSeconds: input.vodStartSeconds } : {}),
       ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
+      ...(input.tags !== undefined ? { tags: input.tags } : {}),
     };
 
     const ref = this.database.ref(`matches/${uid}`).push();
@@ -220,9 +221,9 @@ export class RtdbService {
       win: input.win,
       // See createMatch — RTDB rejects `undefined` values, so these are
       // only included when the input actually set them. Omitting
-      // opponent/vodUrl/vodTimestamps/vodStartSeconds/gsp from the input is
-      // how a caller clears them, since this is a full overwrite (`.set()`,
-      // not a partial patch).
+      // opponent/vodUrl/vodTimestamps/vodStartSeconds/gsp/tags from the input
+      // is how a caller clears them, since this is a full overwrite
+      // (`.set()`, not a partial patch).
       ...(input.opponent !== undefined ? { opponent: input.opponent } : {}),
       ...(input.stocksLeft !== undefined ? { stocksLeft: input.stocksLeft } : {}),
       ...(input.eventName !== undefined ? { eventName: input.eventName } : {}),
@@ -231,6 +232,7 @@ export class RtdbService {
       ...(input.vodTimestamps !== undefined ? { vodTimestamps: input.vodTimestamps } : {}),
       ...(input.vodStartSeconds !== undefined ? { vodStartSeconds: input.vodStartSeconds } : {}),
       ...(input.gsp !== undefined ? { gsp: input.gsp } : {}),
+      ...(input.tags !== undefined ? { tags: input.tags } : {}),
       // Server-set provenance survives the overwrite — the full-overwrite
       // rebuild used to strip these, breaking source badges after a VOD edit.
       ...(current.source !== undefined ? { source: current.source } : {}),

--- a/apps/api/src/test-support/fakeDatabase.ts
+++ b/apps/api/src/test-support/fakeDatabase.ts
@@ -14,6 +14,9 @@
  *   first try) and mirrors the real SDK's `{ committed, snapshot }` result —
  *   `updateFn` returning `undefined` aborts the transaction without writing,
  *   matching real RTDB semantics.
+ * - `.set()` drops any key (at any depth) whose value is an empty array,
+ *   matching real RTDB's documented empty-array-drop-on-write behavior
+ *   (see RtdbService's `getStageFavorites`/tags comments).
  */
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
@@ -49,6 +52,29 @@ let pushCounter = 0;
 function generateKey(): string {
   pushCounter += 1;
   return `-fakeKey${pushCounter.toString().padStart(6, '0')}`;
+}
+
+/**
+ * Recursively drops any object key whose value is an empty array, mirroring
+ * real RTDB's behavior of never persisting empty-array values on write.
+ * Arrays themselves are left intact (RTDB arrays hold sparse/dense element
+ * lists, not keys to strip); only nested object keys are inspected.
+ */
+function stripEmptyArrays(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripEmptyArrays);
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (Array.isArray(val) && val.length === 0) {
+        continue;
+      }
+      result[key] = stripEmptyArrays(val);
+    }
+    return result;
+  }
+  return value;
 }
 
 export class FakeDatabase {
@@ -98,7 +124,7 @@ export class FakeDatabase {
 
   private setAtPath(segments: string[], value: unknown): void {
     if (segments.length === 0) {
-      this.root = (value ?? {}) as Record<string, JsonValue>;
+      this.root = stripEmptyArrays(value ?? {}) as Record<string, JsonValue>;
       return;
     }
 
@@ -116,7 +142,7 @@ export class FakeDatabase {
       }
       node = node[segment] as Record<string, unknown>;
     }
-    node[segments[segments.length - 1]!] = value as JsonValue;
+    node[segments[segments.length - 1]!] = stripEmptyArrays(value) as JsonValue;
   }
 
   private deleteAtPath(segments: string[]): void {

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -33,6 +33,21 @@ export const vodTimestampSchema = z.object({
   seconds: z.number().int().min(0),
   /** Free-text callout for this moment, e.g. "missed punish on shield". */
   note: z.string().trim().min(1).max(200),
+  /**
+   * Note-level tags (TAG-01..05), e.g. preset slugs like 'punish' or
+   * freeform custom text. Embedded directly on the timestamp entry rather
+   * than referencing a separate tag registry — there is no tags tree,
+   * matching the "embedded arrays, no registry" model used for match-level
+   * `tags` below. Capped at 5 per note to keep a single moment's tags
+   * skimmable. Optional (not `.default([])`): absence means "no tags on
+   * this note" for both legacy notes and freshly-created ones, a
+   * meaningful, valid state like every other optional field on this
+   * schema. Because RTDB silently drops keys holding an empty array on
+   * write, sending `tags: []` and omitting `tags` are equivalent on
+   * read-back — see `RtdbService.updateMatch`'s clearing-semantics
+   * comment.
+   */
+  tags: z.array(z.string().trim().min(1).max(24)).max(5).optional(),
 });
 export type VodTimestamp = z.infer<typeof vodTimestampSchema>;
 
@@ -167,6 +182,23 @@ export const matchRecordSchema = z.object({
    * `stocksLeft`.
    */
   gsp: z.number().int().min(0).optional(),
+  /**
+   * Match-level tags (TAG-01..05), e.g. preset slugs like
+   * 'practice-friendlies' or freeform custom text the player types. Stored
+   * as a plain embedded array on the match record — there is no separate
+   * tags tree/registry to keep in sync, so deleting a match cascades tag
+   * removal for free. Capped at 10 per match. User-editable, same
+   * optional/conditional-spread convention as `vodTimestamps`/
+   * `vodStartSeconds`/`gsp` (see `createMatchInputSchema` /
+   * `RtdbService.createMatch`/`updateMatch`). Deliberately `.optional()`,
+   * NOT `.default([])`: this is a read schema over records that predate
+   * the field, and absence (legacy/untagged matches) is a meaningful,
+   * valid state — unlike `stageFavoritesSchema`'s single always-present
+   * document, where `.default([])` is correct. RTDB silently drops keys
+   * holding an empty array on write, so `tags: []` and an omitted `tags`
+   * key are equivalent on read-back.
+   */
+  tags: z.array(z.string().trim().min(1).max(24)).max(10).optional(),
 });
 export type MatchRecord = z.infer<typeof matchRecordSchema>;
 
@@ -252,6 +284,12 @@ const optionalNameInputSchema = z
  * `stocksLeft`/`eventName`/`tournamentName` (see `RtdbService.updateMatch`).
  *
  * `gsp` (V10) follows the same convention — omit to leave/clear it.
+ *
+ * `tags` (TAG-01..05) follows the same convention too — omit (or send an
+ * empty array) to leave/clear match-level tags. Note-level tags ride
+ * inside each `vodTimestamps` entry (see `vodTimestampSchema.tags`) and
+ * need no separate handling here since `vodTimestamps` is already passed
+ * through wholesale.
  */
 export const createMatchInputSchema = z.object({
   fighter_id: z.number().int().positive(),
@@ -268,6 +306,7 @@ export const createMatchInputSchema = z.object({
   vodTimestamps: z.array(vodTimestampSchema).max(20).optional(),
   vodStartSeconds: z.number().int().nonnegative().optional(),
   gsp: z.number().int().min(0).optional(),
+  tags: z.array(z.string().trim().min(1).max(24)).max(10).optional(),
 });
 export type CreateMatchInput = z.infer<typeof createMatchInputSchema>;
 


### PR DESCRIPTION
## Summary

Phase 3 (Tags) data model, deploy-first: optional `tags: string[]` on `matchRecordSchema` (≤10 tags) and `vodTimestampSchema` (≤5 tags), per-tag ≤24 chars trimmed; accepted by create/update input schemas with conditional-spread passthrough in `RtdbService.createMatch`/`updateMatch`.

Shipped ahead of the phase's web UI so the production API accepts the field before preview-channel verification (zod strips unknown keys silently — the vodStartSeconds lesson).

Also: `FakeDatabase.set()` now mirrors real RTDB's empty-array-drop-on-write behavior (`stripEmptyArrays`), enabling the clear-tags-by-omission tests; coexists with the `ref('')` hardening from #162.

Additive + backward compatible; current prod web neither sends nor reads `tags`.

## Tests

New route tests: tags stored on create, omitted when absent, cleared by omission on update, empty-array drop, note-level tags ride vodTimestamps. Suites on this branch: shared 189, api 465, typecheck clean.

## Deploy

Needs API deploy after merge (rev 00034).

🤖 Generated with [Claude Code](https://claude.com/claude-code)