### PR TITLE
feat(api): playlists — schema + RTDB CRUD + /api/playlists routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -27,6 +27,7 @@ import reportsRoutes from './routes/reports.js';
 import billingRoutes, { type StripeLikeClient } from './routes/billing.js';
 import tournamentsRoutes from './routes/tournaments.js';
 import groupsRoutes from './routes/groups.js';
+import playlistsRoutes from './routes/playlists.js';
 import { ConflictError, NotFoundError } from './services/rtdb.js';
 import type { FirebaseServices } from './firebase/admin.js';
 import type { ParryggConfig, ReportsConfig, StartggConfig, StripeConfig } from './config/env.js';
@@ -159,6 +160,7 @@ export function buildApp(options: BuildAppOptions) {
       await api.register(stageFavoritesRoutes);
       await api.register(tournamentsRoutes);
       await api.register(groupsRoutes);
+      await api.register(playlistsRoutes);
       await api.register(startggRoutes, {
         config: options.startgg ?? null,
         fetchImpl: options.startggFetch,

--- a/apps/api/src/routes/playlists.test.ts
+++ b/apps/api/src/routes/playlists.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, TEST_UID } from '../test-support/testApp.js';
+
+describe('GET /api/playlists', () => {
+  it('returns an empty list when the user has no playlists', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/playlists',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([]);
+  });
+
+  it('returns stored playlists with their push keys', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Combo reel', createdAt: 100, matchIds: ['m1'] },
+      p2: { name: 'Counterpicks', createdAt: 200, matchIds: [] },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/playlists',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(
+      expect.arrayContaining([
+        { id: 'p1', name: 'Combo reel', createdAt: 100, matchIds: ['m1'] },
+        { id: 'p2', name: 'Counterpicks', createdAt: 200, matchIds: [] },
+      ]),
+    );
+  });
+
+  it('reads back a playlist with no matchIds key as matchIds: []', async () => {
+    const { app, database } = buildTestApp();
+    // RTDB drops empty arrays on write, so an emptied playlist leaves no
+    // `matchIds` key at all (same lesson as stageFavorites).
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Emptied', createdAt: 100 },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/playlists',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([{ id: 'p1', name: 'Emptied', createdAt: 100, matchIds: [] }]);
+  });
+
+  it('skips a corrupt record instead of failing the whole list', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      good: { name: 'Good', createdAt: 100, matchIds: [] },
+      corrupt: { createdAt: 'not-a-number' },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/playlists',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([{ id: 'good', name: 'Good', createdAt: 100, matchIds: [] }]);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'GET', url: '/api/playlists' });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('POST /api/playlists', () => {
+  it('creates a playlist with a server-stamped createdAt and empty matchIds', async () => {
+    const { app, database } = buildTestApp();
+    const before = Date.now();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/playlists',
+      headers: authHeader(),
+      payload: { name: 'Combo reel' },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = response.json();
+    expect(body.name).toBe('Combo reel');
+    expect(body.matchIds).toEqual([]);
+    expect(body.createdAt).toBeGreaterThanOrEqual(before);
+    expect(body.id).toEqual(expect.any(String));
+    expect(database.dump()).toMatchObject({
+      playlists: { [TEST_UID]: { [body.id]: { name: 'Combo reel' } } },
+    });
+  });
+
+  it('rejects a blank name', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/playlists',
+      headers: authHeader(),
+      payload: { name: '   ' },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects a name over 40 characters', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/playlists',
+      headers: authHeader(),
+      payload: { name: 'a'.repeat(41) },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('rejects the 51st playlist with 403', async () => {
+    const { app, database } = buildTestApp();
+    const seeded: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i += 1) {
+      seeded[`p${i}`] = { name: `Playlist ${i}`, createdAt: i, matchIds: [] };
+    }
+    database.seed(`playlists/${TEST_UID}`, seeded);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/playlists',
+      headers: authHeader(),
+      payload: { name: 'One too many' },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/playlists',
+      payload: { name: 'Combo reel' },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('PATCH /api/playlists/:id', () => {
+  it('reorders matchIds while preserving name', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Combo reel', createdAt: 100, matchIds: ['m1', 'm2'] },
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/playlists/p1',
+      headers: authHeader(),
+      payload: { matchIds: ['m2', 'm1'] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      id: 'p1',
+      name: 'Combo reel',
+      createdAt: 100,
+      matchIds: ['m2', 'm1'],
+    });
+  });
+
+  it('renames while preserving matchIds', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Combo reel', createdAt: 100, matchIds: ['m1', 'm2'] },
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/playlists/p1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      id: 'p1',
+      name: 'Renamed',
+      createdAt: 100,
+      matchIds: ['m1', 'm2'],
+    });
+  });
+
+  it('emptying matchIds reads back as []', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Combo reel', createdAt: 100, matchIds: ['m1'] },
+    });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/playlists/p1',
+      headers: authHeader(),
+      payload: { matchIds: [] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().matchIds).toEqual([]);
+  });
+
+  it('404s for an unknown playlist', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/playlists/nope',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/playlists/p1',
+      payload: { name: 'Renamed' },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});
+
+describe('DELETE /api/playlists/:id', () => {
+  it('removes the playlist', async () => {
+    const { app, database } = buildTestApp();
+    database.seed(`playlists/${TEST_UID}`, {
+      p1: { name: 'Combo reel', createdAt: 100, matchIds: [] },
+    });
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/playlists/p1',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(database.dump()).not.toMatchObject({
+      playlists: { [TEST_UID]: { p1: expect.anything() } },
+    });
+  });
+
+  it('404s for an unknown playlist', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/api/playlists/nope',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { app } = buildTestApp();
+
+    const response = await app.inject({ method: 'DELETE', url: '/api/playlists/p1' });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/apps/api/src/routes/playlists.ts
+++ b/apps/api/src/routes/playlists.ts
@@ -1,0 +1,110 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import {
+  createPlaylistInputSchema,
+  errorResponseSchema,
+  playlistSchema,
+  updatePlaylistInputSchema,
+} from '@smash-tracker/shared';
+import { z } from 'zod';
+import { ForbiddenError, RtdbService } from '../services/rtdb.js';
+
+const playlistIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+/**
+ * VOD Manager overhaul: `playlists/{uid}` — user-curated ordered collections
+ * of match ids (see packages/shared/src/playlist.ts for the data-model
+ * rationale). CRUD mirrors the gsp-readings routes: push-keyed records,
+ * server-stamped `createdAt`, NotFoundError from the service bubbling to the
+ * global 404 handler. POST additionally maps `ForbiddenError` (the
+ * 50-playlist cap) to 403 locally — the global handler doesn't know about it
+ * (mirrors `routes/groups.ts`'s ForbiddenError mapping).
+ *
+ * Every read/write is scoped to `request.uid` from the authenticate
+ * preHandler — never a uid from body/params/query (see the plan's threat
+ * model T-04-01).
+ */
+const playlistsRoutes: FastifyPluginAsyncZod = async (app) => {
+  const rtdb = new RtdbService(app.firebase.database);
+
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/playlists
+  app.get(
+    '/playlists',
+    {
+      schema: {
+        response: {
+          200: z.array(playlistSchema),
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.listPlaylists(request.uid);
+    },
+  );
+
+  // POST /api/playlists
+  app.post(
+    '/playlists',
+    {
+      schema: {
+        body: createPlaylistInputSchema,
+        response: {
+          201: playlistSchema,
+          403: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const playlist = await rtdb.createPlaylist(request.uid, request.body);
+        return reply.code(201).send(playlist);
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          return reply
+            .code(403)
+            .send({ error: 'Forbidden', message: err.message, statusCode: 403 });
+        }
+        throw err;
+      }
+    },
+  );
+
+  // PATCH /api/playlists/:id
+  app.patch(
+    '/playlists/:id',
+    {
+      schema: {
+        params: playlistIdParamsSchema,
+        body: updatePlaylistInputSchema,
+        response: {
+          200: playlistSchema,
+        },
+      },
+    },
+    async (request) => {
+      return rtdb.updatePlaylist(request.uid, request.params.id, request.body);
+    },
+  );
+
+  // DELETE /api/playlists/:id
+  app.delete(
+    '/playlists/:id',
+    {
+      schema: {
+        params: playlistIdParamsSchema,
+        response: {
+          204: z.undefined(),
+        },
+      },
+    },
+    async (request, reply) => {
+      await rtdb.deletePlaylist(request.uid, request.params.id);
+      return reply.code(204).send();
+    },
+  );
+};
+
+export default playlistsRoutes;

--- a/apps/api/src/services/rtdb.ts
+++ b/apps/api/src/services/rtdb.ts
@@ -4,14 +4,17 @@ import {
   gspReadingRecordSchema,
   gspSettingsSchema,
   matchRecordSchema,
+  MAX_PLAYLISTS_PER_USER,
   opponentAliasMapSchema,
   opponentMapSchema,
   opponentNoteMapSchema,
   opponentNoteSchema,
+  playlistRecordSchema,
   stageFavoritesSchema,
   userSchema,
   type CreateGspReadingInput,
   type CreateMatchInput,
+  type CreatePlaylistInput,
   type FighterSelectionInput,
   type GspReading,
   type GspReadingRecord,
@@ -22,8 +25,11 @@ import {
   type OpponentAliasMap,
   type OpponentNote,
   type OpponentNoteMap,
+  type Playlist,
+  type PlaylistRecord,
   type UpdateGspReadingInput,
   type UpdateMatchInput,
+  type UpdatePlaylistInput,
   type UpsertGspSettingsInput,
   type UpsertOpponentNoteInput,
   type UpsertStageFavoritesInput,
@@ -50,6 +56,14 @@ export class ConflictError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'ConflictError';
+  }
+}
+
+/** Thrown for a 403-worthy write: the caller is at/over a per-user cap (e.g. the 50-playlist limit). */
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
   }
 }
 
@@ -530,5 +544,92 @@ export class RtdbService {
     };
     await this.database.ref(`stageFavorites/${uid}`).set(stageFavoritesSchema.parse(favorites));
     return favorites;
+  }
+
+  // ---- playlists/{uid}/{pushKey} -------------------------------------------
+
+  /**
+   * VOD Manager overhaul: user-curated ordered collections of match ids (see
+   * packages/shared/src/playlist.ts for the data-model rationale). List
+   * follows the safeParse-and-skip rule from the production-gap checklist —
+   * one corrupt record must never 500 the whole list (mirrors
+   * `listGspReadings`).
+   */
+  async listPlaylists(uid: string): Promise<Playlist[]> {
+    const snapshot = await this.database.ref(`playlists/${uid}`).get();
+    if (!snapshot.exists()) {
+      return [];
+    }
+
+    const raw = snapshot.val() as Record<string, unknown>;
+    return Object.entries(raw).flatMap(([id, value]) => {
+      const parsed = playlistRecordSchema.safeParse(value);
+      return parsed.success ? [{ id, ...parsed.data }] : [];
+    });
+  }
+
+  /**
+   * Creates a playlist, stamping `createdAt` server-side and starting with
+   * no matches. Enforces `MAX_PLAYLISTS_PER_USER` (unbounded per-user growth
+   * is a DoS vector — see the plan's threat model T-04-04).
+   */
+  async createPlaylist(uid: string, input: CreatePlaylistInput): Promise<Playlist> {
+    const existingSnapshot = await this.database.ref(`playlists/${uid}`).get();
+    const existingCount = existingSnapshot.exists()
+      ? Object.keys(existingSnapshot.val() as Record<string, unknown>).length
+      : 0;
+    if (existingCount >= MAX_PLAYLISTS_PER_USER) {
+      throw new ForbiddenError(`You can create at most ${MAX_PLAYLISTS_PER_USER} playlists`);
+    }
+
+    const record: PlaylistRecord = {
+      name: input.name,
+      createdAt: Date.now(),
+      matchIds: [],
+    };
+
+    const ref = this.database.ref(`playlists/${uid}`).push();
+    await ref.set(record);
+
+    const id = ref.key;
+    if (!id) {
+      throw new Error('Failed to generate a push key for the new playlist');
+    }
+
+    return { id, ...record };
+  }
+
+  /**
+   * Updates a playlist's name and/or matchIds. Merges against the current
+   * record first (conditional-spread) so a rename-only or reorder-only call
+   * never wipes the field the caller omitted — RTDB's `.set()` is a full
+   * overwrite, and `undefined` values are rejected outright, so a naive
+   * `{ ...input }` write would drop whichever field wasn't sent.
+   */
+  async updatePlaylist(uid: string, id: string, input: UpdatePlaylistInput): Promise<Playlist> {
+    const ref = this.database.ref(`playlists/${uid}/${id}`);
+    const existing = await ref.get();
+    if (!existing.exists()) {
+      throw new NotFoundError(`Playlist ${id} not found`);
+    }
+    const current = playlistRecordSchema.parse(existing.val());
+
+    const record: PlaylistRecord = {
+      ...current,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.matchIds !== undefined ? { matchIds: input.matchIds } : {}),
+    };
+
+    await ref.set(playlistRecordSchema.parse(record));
+    return { id, ...record };
+  }
+
+  async deletePlaylist(uid: string, id: string): Promise<void> {
+    const ref = this.database.ref(`playlists/${uid}/${id}`);
+    const existing = await ref.get();
+    if (!existing.exists()) {
+      throw new NotFoundError(`Playlist ${id} not found`);
+    }
+    await ref.remove();
   }
 }

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   createMatchInputSchema,
+  createPlaylistInputSchema,
   fighterIdListSchema,
   fighterSchema,
   fighterSelectionSchema,
@@ -12,9 +13,12 @@ import {
   opponentListSchema,
   opponentMapSchema,
   opponentNameInputSchema,
+  playlistRecordSchema,
+  playlistSchema,
   stageSchema,
   tournamentEntrySchema,
   updateMatchInputSchema,
+  updatePlaylistInputSchema,
   upsertOpponentAliasInputSchema,
   userProfileSchema,
   userSchema,
@@ -463,6 +467,75 @@ describe('upsertOpponentAliasInputSchema', () => {
 
   it('rejects a blank canonical name', () => {
     expect(() => upsertOpponentAliasInputSchema.parse({ canonical: '' })).toThrow();
+  });
+});
+
+describe('playlistRecordSchema', () => {
+  it('parses a record with matchIds and defaults matchIds to [] when the key is absent', () => {
+    expect(
+      playlistRecordSchema.parse({ name: 'Combo reel', createdAt: 1_700_000_000_000 }),
+    ).toEqual({ name: 'Combo reel', createdAt: 1_700_000_000_000, matchIds: [] });
+  });
+
+  it('parses a record with matchIds present', () => {
+    const record = { name: 'Counterpicks', createdAt: 1_700_000_000_000, matchIds: ['m1', 'm2'] };
+    expect(playlistRecordSchema.parse(record)).toEqual(record);
+  });
+
+  it('rejects a blank/whitespace-only name', () => {
+    expect(() =>
+      playlistRecordSchema.parse({ name: '   ', createdAt: 1_700_000_000_000 }),
+    ).toThrow();
+  });
+
+  it('rejects a name longer than 40 chars after trim', () => {
+    expect(() =>
+      playlistRecordSchema.parse({ name: 'a'.repeat(41), createdAt: 1_700_000_000_000 }),
+    ).toThrow();
+  });
+
+  it('rejects a matchIds array longer than 100 entries', () => {
+    const matchIds = Array.from({ length: 101 }, (_, i) => `m${i}`);
+    expect(() =>
+      playlistRecordSchema.parse({ name: 'Too many', createdAt: 1_700_000_000_000, matchIds }),
+    ).toThrow();
+  });
+});
+
+describe('playlistSchema', () => {
+  it('extends playlistRecordSchema with an id', () => {
+    const playlist = {
+      id: '-Nabc123',
+      name: 'Combo reel',
+      createdAt: 1_700_000_000_000,
+      matchIds: [],
+    };
+    expect(playlistSchema.parse(playlist)).toEqual(playlist);
+  });
+});
+
+describe('createPlaylistInputSchema', () => {
+  it('accepts a name only', () => {
+    expect(createPlaylistInputSchema.parse({ name: 'Combo reel' })).toEqual({
+      name: 'Combo reel',
+    });
+  });
+
+  it('rejects a blank name', () => {
+    expect(() => createPlaylistInputSchema.parse({ name: '   ' })).toThrow();
+  });
+});
+
+describe('updatePlaylistInputSchema', () => {
+  it('accepts an optional name and/or matchIds', () => {
+    expect(updatePlaylistInputSchema.parse({})).toEqual({});
+    expect(updatePlaylistInputSchema.parse({ name: 'Renamed' })).toEqual({ name: 'Renamed' });
+    expect(updatePlaylistInputSchema.parse({ matchIds: ['m1'] })).toEqual({ matchIds: ['m1'] });
+  });
+
+  it('rejects a matchIds array longer than 100 entries', () => {
+    const matchIds = Array.from({ length: 101 }, (_, i) => `m${i}`);
+    expect(() => updatePlaylistInputSchema.parse({ matchIds })).toThrow();
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -43,3 +43,4 @@ export * from './gspReading.js';
 export * from './gspMmr.js';
 export * from './gspTiers.js';
 export * from './gspLive.js';
+export * from './playlist.js';

--- a/packages/shared/src/playlist.ts
+++ b/packages/shared/src/playlist.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+/**
+ * VOD Manager overhaul: `playlists/{uid}/{pushKey}` — user-curated ordered
+ * collections of match ids, letting a player group footage the way they
+ * actually think about their own play (e.g. "combo reel", "counterpick
+ * reviews") rather than only by opponent/date/tag.
+ *
+ * `matchIds` preserves insertion/reorder order chosen by the user — same
+ * "array doubles as priority order" convention as `stageFavoritesSchema`.
+ * `.default([])` on the READ schema matters: RTDB silently drops empty
+ * arrays on write, so a playlist emptied to zero matches reads back as
+ * `{ name, createdAt }` with no `matchIds` key at all (same lesson as
+ * `stageFavorites.ts`).
+ */
+
+/** Max playlists a single user may create. */
+export const MAX_PLAYLISTS_PER_USER = 50;
+/** Max matches a single playlist may hold. */
+export const MAX_PLAYLIST_MATCHES = 100;
+
+/** `playlists/{uid}/{pushKey}` — a playlist record as stored in RTDB. */
+export const playlistRecordSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+  /** Epoch ms the playlist was created — server-stamped on create. */
+  createdAt: z.number().int().nonnegative(),
+  /** Match ids in user-chosen (insertion/reorder) order. */
+  matchIds: z.array(z.string().min(1)).max(MAX_PLAYLIST_MATCHES).default([]),
+});
+export type PlaylistRecord = z.infer<typeof playlistRecordSchema>;
+
+/** A playlist with its RTDB push key, as returned by the API. */
+export const playlistSchema = playlistRecordSchema.extend({
+  id: z.string(),
+});
+export type Playlist = z.infer<typeof playlistSchema>;
+
+/** POST /api/playlists body — `createdAt` is server-stamped, `matchIds` starts empty. */
+export const createPlaylistInputSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+});
+export type CreatePlaylistInput = z.infer<typeof createPlaylistInputSchema>;
+
+/**
+ * PATCH /api/playlists/:id body — name and/or matchIds, both optional so a
+ * rename-only or reorder-only call doesn't have to resend the other field
+ * (the service merges against the current record; see RtdbService.updatePlaylist).
+ */
+export const updatePlaylistInputSchema = z.object({
+  name: z.string().trim().min(1).max(40).optional(),
+  matchIds: z.array(z.string().min(1)).max(MAX_PLAYLIST_MATCHES).optional(),
+});
+export type UpdatePlaylistInput = z.infer<typeof updatePlaylistInputSchema>;


### PR DESCRIPTION
## Summary

Phase 4 (Playlists) backend, deploy-first: `playlists/{uid}/{playlistId}` = `{name (1-40), createdAt (server-stamped), matchIds[] (order = playlist order, ≤100)}`, ≤50 playlists per user (403 via new shared ForbiddenError mapping), REST CRUD at `/api/playlists` following the gsp-readings conventions (safeParse-and-skip list, conditional-spread writes, `.default([])` empty-array read side). Soft-orphan by design: match deletion never fans out into playlists; clients filter unresolvable ids.

Registered in app.ts (production-gap #1 closed with a grep-asserted test task). Cherry-picked from the phase branch so the prod API accepts playlists before the phase's preview verification.

## Tests

New route suite (CRUD, 403 cap, field-preserving PATCH, empty-matchIds read-back) + shared schema edge tests. This branch: shared 199 / api 471, typecheck clean.

## Deploy

Needs API deploy after merge (rev 00035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)