### PR TITLE
fix(shared): allow empty note text on vod timestamps — tag-only quick captures

### DIFF
--- a/apps/api/src/routes/matches.test.ts
+++ b/apps/api/src/routes/matches.test.ts
@@ -392,6 +392,31 @@ describe('POST /api/matches', () => {
     expect(stored).toMatchObject({ vodTimestamps });
   });
 
+  it('accepts and stores a tag-only vodTimestamp entry with an empty note', async () => {
+    const { app, database } = buildTestApp();
+
+    const vodTimestamps = [{ seconds: 42, note: '', tags: ['punish'] }];
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/matches',
+      headers: authHeader(),
+      payload: {
+        ...validCreateInput,
+        vodUrl: 'https://youtube.com/watch?v=abc123',
+        vodTimestamps,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({ vodTimestamps });
+
+    const dump = database.dump() as Record<string, unknown>;
+    const matches = dump.matches as Record<string, Record<string, unknown>>;
+    const stored = Object.values(matches[TEST_UID]!)[0]!;
+    expect(stored).toMatchObject({ vodTimestamps });
+  });
+
   it('omits tags from the stored record when not provided', async () => {
     const { app, database } = buildTestApp();
 
@@ -900,7 +925,7 @@ describe('PATCH /api/matches/:id', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  it('returns 400 when a vodTimestamps note is empty', async () => {
+  it('accepts a vodTimestamps entry with a blank note (tag-only quick capture)', async () => {
     const { app, database } = buildTestApp();
     database.seed(`matches/${TEST_UID}/existingKey`, {
       fighter_id: 1,
@@ -920,7 +945,10 @@ describe('PATCH /api/matches/:id', () => {
       },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      vodTimestamps: [{ seconds: 10, note: '' }],
+    });
   });
 
   it('returns 400 when a vodTimestamps seconds value is negative', async () => {

--- a/packages/shared/src/match.ts
+++ b/packages/shared/src/match.ts
@@ -31,8 +31,13 @@ export type MatchType = z.infer<typeof matchTypeSchema>;
 export const vodTimestampSchema = z.object({
   /** Offset in whole seconds into the VOD this note refers to. */
   seconds: z.number().int().min(0),
-  /** Free-text callout for this moment, e.g. "missed punish on shield". */
-  note: z.string().trim().min(1).max(200),
+  /**
+   * Free-text callout for this moment, e.g. "missed punish on shield".
+   * Deliberately allows an empty string: the VOD Manager's quick-tag flow
+   * (QuickTagPanel) captures a timestamp + tags instantly with no note text
+   * — a tag-only moment is a legitimate, valid entry, not an error.
+   */
+  note: z.string().trim().max(200),
   /**
    * Note-level tags (TAG-01..05), e.g. preset slugs like 'punish' or
    * freeform custom text. Embedded directly on the timestamp entry rather


### PR DESCRIPTION
## Summary

Phase 4's Quick Tags panel captures a moment with one click: a timestamp note carrying a tag and empty text. `vodTimestampSchema.note` required `min(1)`, so every quick capture 400'd in live testing ("Failed to save VOD notes"). Relaxed to allow empty strings (max 200 kept) — a tag-only moment is a legitimate note.

Cherry-picked from the phase branch (deploy-first pattern) so the prod API accepts it before preview re-verification.

## Tests

Route test asserts a vodTimestamps entry with `note: ''` + tags is accepted and stored. This branch: shared 199 / api 472? (suite green), typecheck clean.

## Deploy

Needs API deploy after merge (rev 00036).

🤖 Generated with [Claude Code](https://claude.com/claude-code)