### PR TITLE
test(gsp): de-race the live-calibration assertion against anchor drift

### DIFF
--- a/apps/web/src/pages/Gsp/GspPage.test.tsx
+++ b/apps/web/src/pages/Gsp/GspPage.test.tsx
@@ -543,10 +543,15 @@ describe('GspPage', () => {
 
       renderGspPage();
 
-      // The computed threshold now derives from the live calibration: at
-      // ~1 minute of drift it stays within a whisker of the live value.
-      expect(await screen.findByText(nearNumberMatcher(14_813_136))).toBeInTheDocument();
-      expect(screen.getByText(/auto-updated .+ from gsptiers\.com/)).toBeInTheDocument();
+      // Await the caption, not the number: the caption appears only once
+      // /api/gsp-live resolves, while the anchor-calibrated first render
+      // drifts with the wall clock and sweeps through any fixed constant's
+      // tolerance window on some calendar day (hit 14,813,136 +/- 500 on
+      // 2026-07-25), satisfying the number matcher before live is applied.
+      expect(await screen.findByText(/auto-updated .+ from gsptiers\.com/)).toBeInTheDocument();
+      // With the live calibration applied, ~1 minute of drift keeps the
+      // computed threshold within a whisker of the live value.
+      expect(screen.getByText(nearNumberMatcher(14_813_136))).toBeInTheDocument();
     });
 
     it('uses the live max for the tier ladder boundaries', async () => {


### PR DESCRIPTION
## Summary
Fixes the deterministic-today, date-driven failure of `GspPage.test.tsx > live thresholds > calibrates the threshold card from the live reading and says so` — the failure in master's latest CI run ([30168828089](https://github.com/bsmerbeck/smash-tracker/actions/runs/30168828089)).

## Root cause
The GSP model's built-in 2026-06-11 anchor drifts the computed Elite threshold up ~88 GSP/hour. On 2026-07-25 the anchor-computed value (CI log shows `14,813,442`) swept inside the test's ±500 `nearNumberMatcher` window around the mocked live constant `14,813,136`. That let `await findByText(nearNumberMatcher(...))` resolve against the **first render** (live query still pending, anchor calibration active), so the synchronous caption assertion ran before the live calibration applied and failed. On 07-24 the anchor value was 1,777 below the window — which is why the suite was green through v2.3.

## Fix
Test-side only (the component is correct): await the `auto-updated … from gsptiers.com` caption first — it appears only once `/api/gsp-live` resolves — then assert the number synchronously. Deterministic on any date. Sibling live-threshold tests were checked for the same pattern; both are structurally immune.

Note: without the fix, master self-heals ~tomorrow (the drift exits the window permanently), but the await-the-wrong-signal race would stay latent and any master re-run today still fails.

## Verification
- `pnpm --filter @smash-tracker/web exec vitest run src/pages/Gsp/GspPage.test.tsx` → 28/28
- `pnpm --filter @smash-tracker/web test` → 174 files, 1627/1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)